### PR TITLE
feat: fromJsonとtoJsonの追加実装

### DIFF
--- a/lib/src/models/admin/mastodon_admin_account.dart
+++ b/lib/src/models/admin/mastodon_admin_account.dart
@@ -8,7 +8,7 @@ part 'mastodon_admin_account.g.dart';
 ///
 /// Admin API のレスポンスで返されるアカウント情報。
 /// 通常の [MastodonAccount] に加え、管理者向けの詳細情報を含む。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAdminAccount {
   const MastodonAdminAccount({
     required this.id,
@@ -34,6 +34,9 @@ class MastodonAdminAccount {
 
   factory MastodonAdminAccount.fromJson(Map<String, dynamic> json) =>
       _$MastodonAdminAccountFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAdminAccountToJson(this);
 
   /// アカウントのデータベース内 ID
   final String id;
@@ -103,7 +106,7 @@ class MastodonAdminAccount {
 }
 
 /// 管理者向け IP アドレス情報
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAdminIp {
   const MastodonAdminIp({
     required this.ip,
@@ -112,6 +115,9 @@ class MastodonAdminIp {
 
   factory MastodonAdminIp.fromJson(Map<String, dynamic> json) =>
       _$MastodonAdminIpFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAdminIpToJson(this);
 
   /// IP アドレス
   final String ip;
@@ -122,7 +128,7 @@ class MastodonAdminIp {
 }
 
 /// 管理者向けロール情報
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAdminRole {
   const MastodonAdminRole({
     required this.id,
@@ -137,6 +143,9 @@ class MastodonAdminRole {
 
   factory MastodonAdminRole.fromJson(Map<String, dynamic> json) =>
       _$MastodonAdminRoleFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAdminRoleToJson(this);
 
   /// ロールの ID
   final int id;

--- a/lib/src/models/admin/mastodon_admin_account.g.dart
+++ b/lib/src/models/admin/mastodon_admin_account.g.dart
@@ -40,6 +40,30 @@ MastodonAdminAccount _$MastodonAdminAccountFromJson(
   invitedByAccountId: json['invited_by_account_id'] as String?,
 );
 
+Map<String, dynamic> _$MastodonAdminAccountToJson(
+  MastodonAdminAccount instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'username': instance.username,
+  'domain': instance.domain,
+  'created_at': const SafeDateTimeConverter().toJson(instance.createdAt),
+  'email': instance.email,
+  'ip': instance.ip,
+  'ips': instance.ips,
+  'locale': instance.locale,
+  'invite_request': instance.inviteRequest,
+  'role': instance.role,
+  'confirmed': instance.confirmed,
+  'approved': instance.approved,
+  'disabled': instance.disabled,
+  'sensitized': instance.sensitized,
+  'silenced': instance.silenced,
+  'suspended': instance.suspended,
+  'account': instance.account,
+  'created_by_application_id': instance.createdByApplicationId,
+  'invited_by_account_id': instance.invitedByAccountId,
+};
+
 MastodonAdminIp _$MastodonAdminIpFromJson(Map<String, dynamic> json) =>
     MastodonAdminIp(
       ip: json['ip'] as String,
@@ -47,6 +71,12 @@ MastodonAdminIp _$MastodonAdminIpFromJson(Map<String, dynamic> json) =>
         json['used_at'] as String?,
       ),
     );
+
+Map<String, dynamic> _$MastodonAdminIpToJson(MastodonAdminIp instance) =>
+    <String, dynamic>{
+      'ip': instance.ip,
+      'used_at': const SafeDateTimeConverter().toJson(instance.usedAt),
+    };
 
 MastodonAdminRole _$MastodonAdminRoleFromJson(Map<String, dynamic> json) =>
     MastodonAdminRole(
@@ -63,3 +93,15 @@ MastodonAdminRole _$MastodonAdminRoleFromJson(Map<String, dynamic> json) =>
         json['updated_at'] as String?,
       ),
     );
+
+Map<String, dynamic> _$MastodonAdminRoleToJson(MastodonAdminRole instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'color': instance.color,
+      'position': instance.position,
+      'permissions': instance.permissions,
+      'highlighted': instance.highlighted,
+      'created_at': const SafeDateTimeConverter().toJson(instance.createdAt),
+      'updated_at': const SafeDateTimeConverter().toJson(instance.updatedAt),
+    };

--- a/lib/src/models/admin/mastodon_admin_canonical_email_block.dart
+++ b/lib/src/models/admin/mastodon_admin_canonical_email_block.dart
@@ -5,7 +5,7 @@ part 'mastodon_admin_canonical_email_block.g.dart';
 /// 管理者向け正規化メールブロック情報
 ///
 /// 正規化されたメールアドレスのハッシュによるブロック情報。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAdminCanonicalEmailBlock {
   const MastodonAdminCanonicalEmailBlock({
     required this.id,
@@ -15,6 +15,10 @@ class MastodonAdminCanonicalEmailBlock {
   factory MastodonAdminCanonicalEmailBlock.fromJson(
     Map<String, dynamic> json,
   ) => _$MastodonAdminCanonicalEmailBlockFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() =>
+      _$MastodonAdminCanonicalEmailBlockToJson(this);
 
   /// ブロックのデータベース内 ID
   final String id;

--- a/lib/src/models/admin/mastodon_admin_canonical_email_block.g.dart
+++ b/lib/src/models/admin/mastodon_admin_canonical_email_block.g.dart
@@ -12,3 +12,10 @@ MastodonAdminCanonicalEmailBlock _$MastodonAdminCanonicalEmailBlockFromJson(
   id: json['id'] as String,
   canonicalEmailHash: json['canonical_email_hash'] as String,
 );
+
+Map<String, dynamic> _$MastodonAdminCanonicalEmailBlockToJson(
+  MastodonAdminCanonicalEmailBlock instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'canonical_email_hash': instance.canonicalEmailHash,
+};

--- a/lib/src/models/admin/mastodon_admin_cohort.dart
+++ b/lib/src/models/admin/mastodon_admin_cohort.dart
@@ -6,7 +6,7 @@ part 'mastodon_admin_cohort.g.dart';
 /// 管理者向けリテンションコホートデータ
 ///
 /// 特定の期間に登録したユーザーのリテンション率を表す。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAdminCohort {
   const MastodonAdminCohort({
     this.period,
@@ -16,6 +16,9 @@ class MastodonAdminCohort {
 
   factory MastodonAdminCohort.fromJson(Map<String, dynamic> json) =>
       _$MastodonAdminCohortFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAdminCohortToJson(this);
 
   /// コホート期間の開始日時（深夜0時）
   @SafeDateTimeConverter()
@@ -30,7 +33,7 @@ class MastodonAdminCohort {
 }
 
 /// コホートの個別リテンションデータ
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAdminCohortData {
   const MastodonAdminCohortData({
     this.date,
@@ -40,6 +43,9 @@ class MastodonAdminCohortData {
 
   factory MastodonAdminCohortData.fromJson(Map<String, dynamic> json) =>
       _$MastodonAdminCohortDataFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAdminCohortDataToJson(this);
 
   /// バケット開始日時（深夜0時）
   @SafeDateTimeConverter()

--- a/lib/src/models/admin/mastodon_admin_cohort.g.dart
+++ b/lib/src/models/admin/mastodon_admin_cohort.g.dart
@@ -20,6 +20,14 @@ MastodonAdminCohort _$MastodonAdminCohortFromJson(Map<String, dynamic> json) =>
           [],
     );
 
+Map<String, dynamic> _$MastodonAdminCohortToJson(
+  MastodonAdminCohort instance,
+) => <String, dynamic>{
+  'period': const SafeDateTimeConverter().toJson(instance.period),
+  'frequency': instance.frequency,
+  'data': instance.data,
+};
+
 MastodonAdminCohortData _$MastodonAdminCohortDataFromJson(
   Map<String, dynamic> json,
 ) => MastodonAdminCohortData(
@@ -27,3 +35,11 @@ MastodonAdminCohortData _$MastodonAdminCohortDataFromJson(
   rate: (json['rate'] as num).toDouble(),
   value: json['value'] as String,
 );
+
+Map<String, dynamic> _$MastodonAdminCohortDataToJson(
+  MastodonAdminCohortData instance,
+) => <String, dynamic>{
+  'date': const SafeDateTimeConverter().toJson(instance.date),
+  'rate': instance.rate,
+  'value': instance.value,
+};

--- a/lib/src/models/admin/mastodon_admin_dimension.dart
+++ b/lib/src/models/admin/mastodon_admin_dimension.dart
@@ -5,7 +5,7 @@ part 'mastodon_admin_dimension.g.dart';
 /// 管理者向けディメンション（次元）データ
 ///
 /// サーバーの定性的な統計情報を表す。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAdminDimension {
   const MastodonAdminDimension({
     required this.key,
@@ -14,6 +14,9 @@ class MastodonAdminDimension {
 
   factory MastodonAdminDimension.fromJson(Map<String, dynamic> json) =>
       _$MastodonAdminDimensionFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAdminDimensionToJson(this);
 
   /// ディメンションの識別キー
   final String key;
@@ -24,7 +27,7 @@ class MastodonAdminDimension {
 }
 
 /// ディメンションの個別データ項目
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAdminDimensionData {
   const MastodonAdminDimensionData({
     required this.key,
@@ -36,6 +39,9 @@ class MastodonAdminDimensionData {
 
   factory MastodonAdminDimensionData.fromJson(Map<String, dynamic> json) =>
       _$MastodonAdminDimensionDataFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAdminDimensionDataToJson(this);
 
   /// データ項目の識別キー
   final String key;

--- a/lib/src/models/admin/mastodon_admin_dimension.g.dart
+++ b/lib/src/models/admin/mastodon_admin_dimension.g.dart
@@ -20,6 +20,10 @@ MastodonAdminDimension _$MastodonAdminDimensionFromJson(
       [],
 );
 
+Map<String, dynamic> _$MastodonAdminDimensionToJson(
+  MastodonAdminDimension instance,
+) => <String, dynamic>{'key': instance.key, 'data': instance.data};
+
 MastodonAdminDimensionData _$MastodonAdminDimensionDataFromJson(
   Map<String, dynamic> json,
 ) => MastodonAdminDimensionData(
@@ -29,3 +33,13 @@ MastodonAdminDimensionData _$MastodonAdminDimensionDataFromJson(
   unit: json['unit'] as String?,
   humanValue: json['human_value'] as String?,
 );
+
+Map<String, dynamic> _$MastodonAdminDimensionDataToJson(
+  MastodonAdminDimensionData instance,
+) => <String, dynamic>{
+  'key': instance.key,
+  'human_key': instance.humanKey,
+  'value': instance.value,
+  'unit': instance.unit,
+  'human_value': instance.humanValue,
+};

--- a/lib/src/models/admin/mastodon_admin_domain_allow.dart
+++ b/lib/src/models/admin/mastodon_admin_domain_allow.dart
@@ -6,7 +6,7 @@ part 'mastodon_admin_domain_allow.g.dart';
 /// 管理者向けドメイン許可情報
 ///
 /// フェデレーションが許可されているドメインを表す。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAdminDomainAllow {
   const MastodonAdminDomainAllow({
     required this.id,
@@ -16,6 +16,9 @@ class MastodonAdminDomainAllow {
 
   factory MastodonAdminDomainAllow.fromJson(Map<String, dynamic> json) =>
       _$MastodonAdminDomainAllowFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAdminDomainAllowToJson(this);
 
   /// ドメイン許可のデータベース内 ID
   final String id;

--- a/lib/src/models/admin/mastodon_admin_domain_allow.g.dart
+++ b/lib/src/models/admin/mastodon_admin_domain_allow.g.dart
@@ -15,3 +15,11 @@ MastodonAdminDomainAllow _$MastodonAdminDomainAllowFromJson(
     json['created_at'] as String?,
   ),
 );
+
+Map<String, dynamic> _$MastodonAdminDomainAllowToJson(
+  MastodonAdminDomainAllow instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'domain': instance.domain,
+  'created_at': const SafeDateTimeConverter().toJson(instance.createdAt),
+};

--- a/lib/src/models/admin/mastodon_admin_domain_block.dart
+++ b/lib/src/models/admin/mastodon_admin_domain_block.dart
@@ -19,7 +19,7 @@ enum MastodonAdminDomainBlockSeverity {
 /// 管理者向けドメインブロック情報
 ///
 /// フェデレーションがブロックされているドメインの詳細情報。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAdminDomainBlock {
   const MastodonAdminDomainBlock({
     required this.id,
@@ -36,6 +36,9 @@ class MastodonAdminDomainBlock {
 
   factory MastodonAdminDomainBlock.fromJson(Map<String, dynamic> json) =>
       _$MastodonAdminDomainBlockFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAdminDomainBlockToJson(this);
 
   /// ドメインブロックのデータベース内 ID
   final String id;

--- a/lib/src/models/admin/mastodon_admin_domain_block.g.dart
+++ b/lib/src/models/admin/mastodon_admin_domain_block.g.dart
@@ -27,6 +27,21 @@ MastodonAdminDomainBlock _$MastodonAdminDomainBlockFromJson(
   ),
 );
 
+Map<String, dynamic> _$MastodonAdminDomainBlockToJson(
+  MastodonAdminDomainBlock instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'domain': instance.domain,
+  'digest': instance.digest,
+  'severity': _$MastodonAdminDomainBlockSeverityEnumMap[instance.severity]!,
+  'reject_media': instance.rejectMedia,
+  'reject_reports': instance.rejectReports,
+  'private_comment': instance.privateComment,
+  'public_comment': instance.publicComment,
+  'obfuscate': instance.obfuscate,
+  'created_at': const SafeDateTimeConverter().toJson(instance.createdAt),
+};
+
 const _$MastodonAdminDomainBlockSeverityEnumMap = {
   MastodonAdminDomainBlockSeverity.silence: 'silence',
   MastodonAdminDomainBlockSeverity.suspend: 'suspend',

--- a/lib/src/models/admin/mastodon_admin_email_domain_block.dart
+++ b/lib/src/models/admin/mastodon_admin_email_domain_block.dart
@@ -6,7 +6,7 @@ part 'mastodon_admin_email_domain_block.g.dart';
 /// 管理者向けメールドメインブロック情報
 ///
 /// サインアップが禁止されているメールドメインの情報。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAdminEmailDomainBlock {
   const MastodonAdminEmailDomainBlock({
     required this.id,
@@ -17,6 +17,9 @@ class MastodonAdminEmailDomainBlock {
 
   factory MastodonAdminEmailDomainBlock.fromJson(Map<String, dynamic> json) =>
       _$MastodonAdminEmailDomainBlockFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAdminEmailDomainBlockToJson(this);
 
   /// ブロックのデータベース内 ID
   final String id;
@@ -34,7 +37,7 @@ class MastodonAdminEmailDomainBlock {
 }
 
 /// メールドメインブロックの日別利用統計
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAdminEmailDomainBlockHistory {
   const MastodonAdminEmailDomainBlockHistory({
     required this.day,
@@ -45,6 +48,10 @@ class MastodonAdminEmailDomainBlockHistory {
   factory MastodonAdminEmailDomainBlockHistory.fromJson(
     Map<String, dynamic> json,
   ) => _$MastodonAdminEmailDomainBlockHistoryFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() =>
+      _$MastodonAdminEmailDomainBlockHistoryToJson(this);
 
   /// 該当日の深夜0時の UNIX タイムスタンプ（文字列）
   final String day;

--- a/lib/src/models/admin/mastodon_admin_email_domain_block.g.dart
+++ b/lib/src/models/admin/mastodon_admin_email_domain_block.g.dart
@@ -25,6 +25,15 @@ MastodonAdminEmailDomainBlock _$MastodonAdminEmailDomainBlockFromJson(
       [],
 );
 
+Map<String, dynamic> _$MastodonAdminEmailDomainBlockToJson(
+  MastodonAdminEmailDomainBlock instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'domain': instance.domain,
+  'created_at': const SafeDateTimeConverter().toJson(instance.createdAt),
+  'history': instance.history,
+};
+
 MastodonAdminEmailDomainBlockHistory
 _$MastodonAdminEmailDomainBlockHistoryFromJson(Map<String, dynamic> json) =>
     MastodonAdminEmailDomainBlockHistory(
@@ -32,3 +41,11 @@ _$MastodonAdminEmailDomainBlockHistoryFromJson(Map<String, dynamic> json) =>
       accounts: json['accounts'] as String,
       uses: json['uses'] as String,
     );
+
+Map<String, dynamic> _$MastodonAdminEmailDomainBlockHistoryToJson(
+  MastodonAdminEmailDomainBlockHistory instance,
+) => <String, dynamic>{
+  'day': instance.day,
+  'accounts': instance.accounts,
+  'uses': instance.uses,
+};

--- a/lib/src/models/admin/mastodon_admin_ip_block.dart
+++ b/lib/src/models/admin/mastodon_admin_ip_block.dart
@@ -19,7 +19,7 @@ enum MastodonAdminIpBlockSeverity {
 /// 管理者向け IP ブロック情報
 ///
 /// ブロックされている IP アドレス範囲の情報。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAdminIpBlock {
   const MastodonAdminIpBlock({
     required this.id,
@@ -32,6 +32,9 @@ class MastodonAdminIpBlock {
 
   factory MastodonAdminIpBlock.fromJson(Map<String, dynamic> json) =>
       _$MastodonAdminIpBlockFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAdminIpBlockToJson(this);
 
   /// IP ブロックのデータベース内 ID
   final String id;

--- a/lib/src/models/admin/mastodon_admin_ip_block.g.dart
+++ b/lib/src/models/admin/mastodon_admin_ip_block.g.dart
@@ -25,6 +25,17 @@ MastodonAdminIpBlock _$MastodonAdminIpBlockFromJson(
   ),
 );
 
+Map<String, dynamic> _$MastodonAdminIpBlockToJson(
+  MastodonAdminIpBlock instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'ip': instance.ip,
+  'severity': _$MastodonAdminIpBlockSeverityEnumMap[instance.severity]!,
+  'comment': instance.comment,
+  'created_at': const SafeDateTimeConverter().toJson(instance.createdAt),
+  'expires_at': const SafeDateTimeConverter().toJson(instance.expiresAt),
+};
+
 const _$MastodonAdminIpBlockSeverityEnumMap = {
   MastodonAdminIpBlockSeverity.signUpRequiresApproval:
       'sign_up_requires_approval',

--- a/lib/src/models/admin/mastodon_admin_measure.dart
+++ b/lib/src/models/admin/mastodon_admin_measure.dart
@@ -5,7 +5,7 @@ part 'mastodon_admin_measure.g.dart';
 /// 管理者向けメジャー（定量）データ
 ///
 /// サーバーの定量的な統計情報を表す。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAdminMeasure {
   const MastodonAdminMeasure({
     required this.key,
@@ -18,6 +18,9 @@ class MastodonAdminMeasure {
 
   factory MastodonAdminMeasure.fromJson(Map<String, dynamic> json) =>
       _$MastodonAdminMeasureFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAdminMeasureToJson(this);
 
   /// メジャーの識別キー
   final String key;
@@ -40,7 +43,7 @@ class MastodonAdminMeasure {
 }
 
 /// メジャーの日別データ
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAdminMeasureData {
   const MastodonAdminMeasureData({
     required this.date,
@@ -49,6 +52,9 @@ class MastodonAdminMeasureData {
 
   factory MastodonAdminMeasureData.fromJson(Map<String, dynamic> json) =>
       _$MastodonAdminMeasureDataFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAdminMeasureDataToJson(this);
 
   /// 日付（深夜0時のタイムスタンプ）
   final String date;

--- a/lib/src/models/admin/mastodon_admin_measure.g.dart
+++ b/lib/src/models/admin/mastodon_admin_measure.g.dart
@@ -23,9 +23,24 @@ MastodonAdminMeasure _$MastodonAdminMeasureFromJson(
       [],
 );
 
+Map<String, dynamic> _$MastodonAdminMeasureToJson(
+  MastodonAdminMeasure instance,
+) => <String, dynamic>{
+  'key': instance.key,
+  'unit': instance.unit,
+  'total': instance.total,
+  'human_value': instance.humanValue,
+  'previous_total': instance.previousTotal,
+  'data': instance.data,
+};
+
 MastodonAdminMeasureData _$MastodonAdminMeasureDataFromJson(
   Map<String, dynamic> json,
 ) => MastodonAdminMeasureData(
   date: json['date'] as String,
   value: json['value'] as String,
 );
+
+Map<String, dynamic> _$MastodonAdminMeasureDataToJson(
+  MastodonAdminMeasureData instance,
+) => <String, dynamic>{'date': instance.date, 'value': instance.value};

--- a/lib/src/models/admin/mastodon_admin_preview_card_provider.dart
+++ b/lib/src/models/admin/mastodon_admin_preview_card_provider.dart
@@ -7,7 +7,7 @@ part 'mastodon_admin_preview_card_provider.g.dart';
 /// 管理者向けプレビューカード発行元
 ///
 /// トレンドリンクの発行元ドメインの管理情報を表す。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAdminPreviewCardProvider {
   const MastodonAdminPreviewCardProvider({
     required this.id,
@@ -21,6 +21,10 @@ class MastodonAdminPreviewCardProvider {
   factory MastodonAdminPreviewCardProvider.fromJson(
     Map<String, dynamic> json,
   ) => _$MastodonAdminPreviewCardProviderFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() =>
+      _$MastodonAdminPreviewCardProviderToJson(this);
 
   /// 発行元のデータベース ID
   final String id;

--- a/lib/src/models/admin/mastodon_admin_preview_card_provider.g.dart
+++ b/lib/src/models/admin/mastodon_admin_preview_card_provider.g.dart
@@ -20,3 +20,16 @@ MastodonAdminPreviewCardProvider _$MastodonAdminPreviewCardProviderFromJson(
   ),
   requiresReview: json['requires_review'] as bool?,
 );
+
+Map<String, dynamic> _$MastodonAdminPreviewCardProviderToJson(
+  MastodonAdminPreviewCardProvider instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'domain': instance.domain,
+  'trendable': instance.trendable,
+  'reviewed_at': const SafeDateTimeConverter().toJson(instance.reviewedAt),
+  'requested_review_at': const SafeDateTimeConverter().toJson(
+    instance.requestedReviewAt,
+  ),
+  'requires_review': instance.requiresReview,
+};

--- a/lib/src/models/admin/mastodon_admin_report.dart
+++ b/lib/src/models/admin/mastodon_admin_report.dart
@@ -11,7 +11,7 @@ part 'mastodon_admin_report.g.dart';
 ///
 /// Admin API で返される通報の詳細情報。
 /// 通常の通報情報に加え、担当モデレーターや対応状況などの管理情報を含む。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAdminReport {
   const MastodonAdminReport({
     required this.id,
@@ -32,6 +32,9 @@ class MastodonAdminReport {
 
   factory MastodonAdminReport.fromJson(Map<String, dynamic> json) =>
       _$MastodonAdminReportFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAdminReportToJson(this);
 
   /// 通報のデータベース内 ID
   final String id;

--- a/lib/src/models/admin/mastodon_admin_report.g.dart
+++ b/lib/src/models/admin/mastodon_admin_report.g.dart
@@ -52,3 +52,24 @@ MastodonAdminReport _$MastodonAdminReportFromJson(
           .toList() ??
       [],
 );
+
+Map<String, dynamic> _$MastodonAdminReportToJson(
+  MastodonAdminReport instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'action_taken': instance.actionTaken,
+  'action_taken_at': const SafeDateTimeConverter().toJson(
+    instance.actionTakenAt,
+  ),
+  'category': instance.category,
+  'comment': instance.comment,
+  'forwarded': instance.forwarded,
+  'created_at': const SafeDateTimeConverter().toJson(instance.createdAt),
+  'updated_at': const SafeDateTimeConverter().toJson(instance.updatedAt),
+  'account': instance.account,
+  'target_account': instance.targetAccount,
+  'assigned_account': instance.assignedAccount,
+  'action_taken_by_account': instance.actionTakenByAccount,
+  'statuses': instance.statuses,
+  'rules': instance.rules,
+};

--- a/lib/src/models/admin/mastodon_admin_tag.dart
+++ b/lib/src/models/admin/mastodon_admin_tag.dart
@@ -6,7 +6,7 @@ part 'mastodon_admin_tag.g.dart';
 /// 管理者向けハッシュタグ情報
 ///
 /// 通常の [MastodonTag] に管理者向けのトレンド管理フィールドを追加したもの。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAdminTag {
   const MastodonAdminTag({
     required this.id,
@@ -21,6 +21,9 @@ class MastodonAdminTag {
 
   factory MastodonAdminTag.fromJson(Map<String, dynamic> json) =>
       _$MastodonAdminTagFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAdminTagToJson(this);
 
   /// タグのデータベース ID
   @JsonKey(defaultValue: '')

--- a/lib/src/models/admin/mastodon_admin_tag.g.dart
+++ b/lib/src/models/admin/mastodon_admin_tag.g.dart
@@ -23,3 +23,15 @@ MastodonAdminTag _$MastodonAdminTagFromJson(Map<String, dynamic> json) =>
       requiresReview: json['requires_review'] as bool?,
       listable: json['listable'] as bool?,
     );
+
+Map<String, dynamic> _$MastodonAdminTagToJson(MastodonAdminTag instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'url': instance.url,
+      'history': instance.history,
+      'trendable': instance.trendable,
+      'usable': instance.usable,
+      'requires_review': instance.requiresReview,
+      'listable': instance.listable,
+    };

--- a/lib/src/models/admin/mastodon_admin_trends_link.dart
+++ b/lib/src/models/admin/mastodon_admin_trends_link.dart
@@ -9,7 +9,7 @@ part 'mastodon_admin_trends_link.g.dart';
 ///
 /// 通常の [MastodonTrendsLink] のフィールドに加え、
 /// 管理者向けの [id] と [requiresReview] を持つ。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAdminTrendsLink {
   const MastodonAdminTrendsLink({
     required this.id,
@@ -34,6 +34,9 @@ class MastodonAdminTrendsLink {
 
   factory MastodonAdminTrendsLink.fromJson(Map<String, dynamic> json) =>
       _$MastodonAdminTrendsLinkFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAdminTrendsLinkToJson(this);
 
   static Object? _readType(Map<dynamic, dynamic> json, String key) =>
       json['type'] ?? 'link';

--- a/lib/src/models/admin/mastodon_admin_trends_link.g.dart
+++ b/lib/src/models/admin/mastodon_admin_trends_link.g.dart
@@ -47,6 +47,29 @@ MastodonAdminTrendsLink _$MastodonAdminTrendsLinkFromJson(
   requiresReview: json['requires_review'] as bool?,
 );
 
+Map<String, dynamic> _$MastodonAdminTrendsLinkToJson(
+  MastodonAdminTrendsLink instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'url': instance.url,
+  'title': instance.title,
+  'description': instance.description,
+  'type': _$MastodonPreviewCardTypeEnumMap[instance.type]!,
+  'author_name': instance.authorName,
+  'author_url': instance.authorUrl,
+  'provider_name': instance.providerName,
+  'provider_url': instance.providerUrl,
+  'html': instance.html,
+  'width': instance.width,
+  'height': instance.height,
+  'image': instance.image,
+  'embed_url': instance.embedUrl,
+  'blurhash': instance.blurhash,
+  'authors': instance.authors,
+  'history': instance.history,
+  'requires_review': instance.requiresReview,
+};
+
 const _$MastodonPreviewCardTypeEnumMap = {
   MastodonPreviewCardType.link: 'link',
   MastodonPreviewCardType.photo: 'photo',

--- a/lib/src/models/mastodon_account.dart
+++ b/lib/src/models/mastodon_account.dart
@@ -9,7 +9,7 @@ part 'mastodon_account.g.dart';
 ///
 /// `/api/v1/accounts/:id` や `/api/v1/accounts/verify_credentials` などの
 /// レスポンスに対応する
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAccount {
   const MastodonAccount({
     required this.id,
@@ -43,6 +43,9 @@ class MastodonAccount {
 
   factory MastodonAccount.fromJson(Map<String, dynamic> json) =>
       _$MastodonAccountFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAccountToJson(this);
 
   /// アカウントの内部 ID
   final String id;
@@ -146,7 +149,7 @@ class MastodonAccount {
 }
 
 /// Mastodon アカウントのプロフィールフィールド
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonField {
   const MastodonField({
     required this.name,
@@ -156,6 +159,9 @@ class MastodonField {
 
   factory MastodonField.fromJson(Map<String, dynamic> json) =>
       _$MastodonFieldFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonFieldToJson(this);
 
   /// フィールドのラベル名
   final String name;

--- a/lib/src/models/mastodon_account.g.dart
+++ b/lib/src/models/mastodon_account.g.dart
@@ -53,6 +53,38 @@ MastodonAccount _$MastodonAccountFromJson(Map<String, dynamic> json) =>
       headerBlurhash: json['header_blurhash'] as String?,
     );
 
+Map<String, dynamic> _$MastodonAccountToJson(
+  MastodonAccount instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'username': instance.username,
+  'acct': instance.acct,
+  'display_name': instance.displayName,
+  'note': instance.note,
+  'url': instance.url,
+  'avatar': instance.avatarUrl,
+  'avatar_static': instance.avatarStaticUrl,
+  'header': instance.headerUrl,
+  'header_static': instance.headerStaticUrl,
+  'locked': instance.locked,
+  'bot': instance.bot,
+  'discoverable': instance.discoverable,
+  'noindex': instance.noindex,
+  'followers_count': instance.followersCount,
+  'following_count': instance.followingCount,
+  'statuses_count': instance.statusesCount,
+  'created_at': const SafeDateTimeConverter().toJson(instance.createdAt),
+  'last_status_at': const SafeDateTimeConverter().toJson(instance.lastStatusAt),
+  'fields': instance.fields,
+  'emojis': instance.emojis,
+  'moved': instance.moved,
+  'suspended': instance.suspended,
+  'limited': instance.limited,
+  'hide_collections': instance.hideCollections,
+  'avatar_blurhash': instance.avatarBlurhash,
+  'header_blurhash': instance.headerBlurhash,
+};
+
 MastodonField _$MastodonFieldFromJson(Map<String, dynamic> json) =>
     MastodonField(
       name: json['name'] as String,
@@ -61,3 +93,10 @@ MastodonField _$MastodonFieldFromJson(Map<String, dynamic> json) =>
         json['verified_at'] as String?,
       ),
     );
+
+Map<String, dynamic> _$MastodonFieldToJson(MastodonField instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'value': instance.value,
+      'verified_at': const SafeDateTimeConverter().toJson(instance.verifiedAt),
+    };

--- a/lib/src/models/mastodon_announcement.dart
+++ b/lib/src/models/mastodon_announcement.dart
@@ -7,7 +7,7 @@ import 'mastodon_status.dart';
 part 'mastodon_announcement.g.dart';
 
 /// お知らせに対するリアクション
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAnnouncementReaction {
   const MastodonAnnouncementReaction({
     required this.name,
@@ -19,6 +19,9 @@ class MastodonAnnouncementReaction {
 
   factory MastodonAnnouncementReaction.fromJson(Map<String, dynamic> json) =>
       _$MastodonAnnouncementReactionFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAnnouncementReactionToJson(this);
 
   /// 絵文字名（Unicode絵文字またはカスタム絵文字ショートコード）
   final String name;
@@ -39,7 +42,7 @@ class MastodonAnnouncementReaction {
 }
 
 /// サーバーのお知らせ
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAnnouncement {
   const MastodonAnnouncement({
     required this.id,
@@ -59,6 +62,9 @@ class MastodonAnnouncement {
 
   factory MastodonAnnouncement.fromJson(Map<String, dynamic> json) =>
       _$MastodonAnnouncementFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAnnouncementToJson(this);
 
   /// お知らせの内部ID
   final String id;
@@ -113,7 +119,7 @@ class MastodonAnnouncement {
 }
 
 /// お知らせ本文中で参照されるステータス
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAnnouncementStatus {
   const MastodonAnnouncementStatus({
     required this.id,
@@ -122,6 +128,9 @@ class MastodonAnnouncementStatus {
 
   factory MastodonAnnouncementStatus.fromJson(Map<String, dynamic> json) =>
       _$MastodonAnnouncementStatusFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAnnouncementStatusToJson(this);
 
   /// ステータスID
   final String id;

--- a/lib/src/models/mastodon_announcement.g.dart
+++ b/lib/src/models/mastodon_announcement.g.dart
@@ -16,6 +16,16 @@ MastodonAnnouncementReaction _$MastodonAnnouncementReactionFromJson(
   staticUrl: json['static_url'] as String?,
 );
 
+Map<String, dynamic> _$MastodonAnnouncementReactionToJson(
+  MastodonAnnouncementReaction instance,
+) => <String, dynamic>{
+  'name': instance.name,
+  'count': instance.count,
+  'me': instance.me,
+  'url': instance.url,
+  'static_url': instance.staticUrl,
+};
+
 MastodonAnnouncement _$MastodonAnnouncementFromJson(
   Map<String, dynamic> json,
 ) => MastodonAnnouncement(
@@ -67,9 +77,31 @@ MastodonAnnouncement _$MastodonAnnouncementFromJson(
   ),
 );
 
+Map<String, dynamic> _$MastodonAnnouncementToJson(
+  MastodonAnnouncement instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'content': instance.content,
+  'starts_at': const SafeDateTimeConverter().toJson(instance.startsAt),
+  'ends_at': const SafeDateTimeConverter().toJson(instance.endsAt),
+  'all_day': instance.allDay,
+  'published_at': const SafeDateTimeConverter().toJson(instance.publishedAt),
+  'updated_at': const SafeDateTimeConverter().toJson(instance.updatedAt),
+  'read': instance.read,
+  'emojis': instance.emojis,
+  'reactions': instance.reactions,
+  'tags': instance.tags,
+  'mentions': instance.mentions,
+  'statuses': instance.statuses,
+};
+
 MastodonAnnouncementStatus _$MastodonAnnouncementStatusFromJson(
   Map<String, dynamic> json,
 ) => MastodonAnnouncementStatus(
   id: json['id'] as String,
   url: json['url'] as String? ?? '',
 );
+
+Map<String, dynamic> _$MastodonAnnouncementStatusToJson(
+  MastodonAnnouncementStatus instance,
+) => <String, dynamic>{'id': instance.id, 'url': instance.url};

--- a/lib/src/models/mastodon_application.dart
+++ b/lib/src/models/mastodon_application.dart
@@ -5,7 +5,7 @@ part 'mastodon_application.g.dart';
 /// OAuth アプリケーション情報を表すモデル
 ///
 /// `GET /api/v1/apps/verify_credentials` のレスポンスに対応する
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonApplication {
   /// 各フィールドを指定して [MastodonApplication] を生成する
   const MastodonApplication({
@@ -21,6 +21,9 @@ class MastodonApplication {
   /// JSON マップから [MastodonApplication] を生成する
   factory MastodonApplication.fromJson(Map<String, dynamic> json) =>
       _$MastodonApplicationFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonApplicationToJson(this);
 
   /// アプリケーションのデータベース ID
   final String id;
@@ -50,7 +53,7 @@ class MastodonApplication {
 ///
 /// `POST /api/v1/apps` のレスポンスに対応する。
 /// [MastodonApplication] のフィールドに加え、クライアント認証情報を含む。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonCredentialApplication {
   /// 各フィールドを指定して [MastodonCredentialApplication] を生成する
   const MastodonCredentialApplication({
@@ -68,6 +71,9 @@ class MastodonCredentialApplication {
   /// JSON マップから [MastodonCredentialApplication] を生成する
   factory MastodonCredentialApplication.fromJson(Map<String, dynamic> json) =>
       _$MastodonCredentialApplicationFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonCredentialApplicationToJson(this);
 
   /// アプリケーションのデータベース ID
   final String id;

--- a/lib/src/models/mastodon_application.g.dart
+++ b/lib/src/models/mastodon_application.g.dart
@@ -21,6 +21,18 @@ MastodonApplication _$MastodonApplicationFromJson(Map<String, dynamic> json) =>
       vapidKey: json['vapid_key'] as String?,
     );
 
+Map<String, dynamic> _$MastodonApplicationToJson(
+  MastodonApplication instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'name': instance.name,
+  'website': instance.website,
+  'scopes': instance.scopes,
+  'redirect_uris': instance.redirectUris,
+  'redirect_uri': instance.redirectUri,
+  'vapid_key': instance.vapidKey,
+};
+
 MastodonCredentialApplication _$MastodonCredentialApplicationFromJson(
   Map<String, dynamic> json,
 ) => MastodonCredentialApplication(
@@ -36,3 +48,17 @@ MastodonCredentialApplication _$MastodonCredentialApplicationFromJson(
   clientSecret: json['client_secret'] as String,
   clientSecretExpiresAt: (json['client_secret_expires_at'] as num).toInt(),
 );
+
+Map<String, dynamic> _$MastodonCredentialApplicationToJson(
+  MastodonCredentialApplication instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'name': instance.name,
+  'website': instance.website,
+  'scopes': instance.scopes,
+  'redirect_uris': instance.redirectUris,
+  'redirect_uri': instance.redirectUri,
+  'client_id': instance.clientId,
+  'client_secret': instance.clientSecret,
+  'client_secret_expires_at': instance.clientSecretExpiresAt,
+};

--- a/lib/src/models/mastodon_async_refresh.dart
+++ b/lib/src/models/mastodon_async_refresh.dart
@@ -5,7 +5,7 @@ part 'mastodon_async_refresh.g.dart';
 /// 非同期リフレッシュ操作のステータス（実験的）
 ///
 /// `GET /api/v1_alpha/async_refreshes/:id` のレスポンスに対応する
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAsyncRefresh {
   const MastodonAsyncRefresh({
     required this.id,
@@ -15,6 +15,9 @@ class MastodonAsyncRefresh {
 
   factory MastodonAsyncRefresh.fromJson(Map<String, dynamic> json) =>
       _$MastodonAsyncRefreshFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAsyncRefreshToJson(this);
 
   /// 非同期リフレッシュの識別子
   final String id;

--- a/lib/src/models/mastodon_async_refresh.g.dart
+++ b/lib/src/models/mastodon_async_refresh.g.dart
@@ -13,3 +13,11 @@ MastodonAsyncRefresh _$MastodonAsyncRefreshFromJson(
   status: json['status'] as String,
   resultCount: (json['result_count'] as num?)?.toInt(),
 );
+
+Map<String, dynamic> _$MastodonAsyncRefreshToJson(
+  MastodonAsyncRefresh instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'status': instance.status,
+  'result_count': instance.resultCount,
+};

--- a/lib/src/models/mastodon_conversation.dart
+++ b/lib/src/models/mastodon_conversation.dart
@@ -8,7 +8,7 @@ part 'mastodon_conversation.g.dart';
 /// ダイレクトメッセージの会話
 ///
 /// `/api/v1/conversations` のレスポンスに対応する
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonConversation {
   const MastodonConversation({
     required this.id,
@@ -19,6 +19,9 @@ class MastodonConversation {
 
   factory MastodonConversation.fromJson(Map<String, dynamic> json) =>
       _$MastodonConversationFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonConversationToJson(this);
 
   /// 会話の内部 ID
   final String id;

--- a/lib/src/models/mastodon_conversation.g.dart
+++ b/lib/src/models/mastodon_conversation.g.dart
@@ -20,3 +20,12 @@ MastodonConversation _$MastodonConversationFromJson(
       ? null
       : MastodonStatus.fromJson(json['last_status'] as Map<String, dynamic>),
 );
+
+Map<String, dynamic> _$MastodonConversationToJson(
+  MastodonConversation instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'unread': instance.unread,
+  'accounts': instance.accounts,
+  'last_status': instance.lastStatus,
+};

--- a/lib/src/models/mastodon_credential_account.dart
+++ b/lib/src/models/mastodon_credential_account.dart
@@ -13,7 +13,7 @@ part 'mastodon_credential_account.g.dart';
 ///
 /// `/api/v1/accounts/verify_credentials` や `/api/v1/accounts/update_credentials`、
 /// `DELETE /api/v1/profile/avatar|header` などのレスポンスに対応する。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonCredentialAccount {
   const MastodonCredentialAccount({
     required this.id,
@@ -49,6 +49,9 @@ class MastodonCredentialAccount {
 
   factory MastodonCredentialAccount.fromJson(Map<String, dynamic> json) =>
       _$MastodonCredentialAccountFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonCredentialAccountToJson(this);
 
   /// アカウントの内部 ID
   final String id;
@@ -155,7 +158,7 @@ class MastodonCredentialAccount {
 }
 
 /// 認証済みユーザーの投稿デフォルト設定・非公開情報
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAccountSource {
   const MastodonAccountSource({
     this.privacy,
@@ -169,6 +172,9 @@ class MastodonAccountSource {
 
   factory MastodonAccountSource.fromJson(Map<String, dynamic> json) =>
       _$MastodonAccountSourceFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAccountSourceToJson(this);
 
   /// デフォルトの投稿公開範囲
   final String? privacy;
@@ -195,7 +201,7 @@ class MastodonAccountSource {
 }
 
 /// ユーザーロール情報
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonRole {
   const MastodonRole({
     required this.id,
@@ -209,6 +215,9 @@ class MastodonRole {
 
   factory MastodonRole.fromJson(Map<String, dynamic> json) =>
       _$MastodonRoleFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonRoleToJson(this);
 
   /// ロール ID
   final int id;

--- a/lib/src/models/mastodon_credential_account.g.dart
+++ b/lib/src/models/mastodon_credential_account.g.dart
@@ -58,6 +58,40 @@ MastodonCredentialAccount _$MastodonCredentialAccountFromJson(
       : MastodonRole.fromJson(json['role'] as Map<String, dynamic>),
 );
 
+Map<String, dynamic> _$MastodonCredentialAccountToJson(
+  MastodonCredentialAccount instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'username': instance.username,
+  'acct': instance.acct,
+  'display_name': instance.displayName,
+  'note': instance.note,
+  'url': instance.url,
+  'avatar': instance.avatarUrl,
+  'avatar_static': instance.avatarStaticUrl,
+  'header': instance.headerUrl,
+  'header_static': instance.headerStaticUrl,
+  'locked': instance.locked,
+  'bot': instance.bot,
+  'discoverable': instance.discoverable,
+  'noindex': instance.noindex,
+  'followers_count': instance.followersCount,
+  'following_count': instance.followingCount,
+  'statuses_count': instance.statusesCount,
+  'created_at': const SafeDateTimeConverter().toJson(instance.createdAt),
+  'last_status_at': const SafeDateTimeConverter().toJson(instance.lastStatusAt),
+  'fields': instance.fields,
+  'emojis': instance.emojis,
+  'moved': instance.moved,
+  'suspended': instance.suspended,
+  'limited': instance.limited,
+  'hide_collections': instance.hideCollections,
+  'avatar_blurhash': instance.avatarBlurhash,
+  'header_blurhash': instance.headerBlurhash,
+  'source': instance.source,
+  'role': instance.role,
+};
+
 MastodonAccountSource _$MastodonAccountSourceFromJson(
   Map<String, dynamic> json,
 ) => MastodonAccountSource(
@@ -74,6 +108,18 @@ MastodonAccountSource _$MastodonAccountSourceFromJson(
   quotePolicy: json['quote_policy'] as String?,
 );
 
+Map<String, dynamic> _$MastodonAccountSourceToJson(
+  MastodonAccountSource instance,
+) => <String, dynamic>{
+  'privacy': instance.privacy,
+  'sensitive': instance.sensitive,
+  'language': instance.language,
+  'note': instance.note,
+  'fields': instance.fields,
+  'follow_requests_count': instance.followRequestsCount,
+  'quote_policy': instance.quotePolicy,
+};
+
 MastodonRole _$MastodonRoleFromJson(Map<String, dynamic> json) => MastodonRole(
   id: (json['id'] as num).toInt(),
   name: json['name'] as String,
@@ -87,3 +133,14 @@ MastodonRole _$MastodonRoleFromJson(Map<String, dynamic> json) => MastodonRole(
     json['updated_at'] as String?,
   ),
 );
+
+Map<String, dynamic> _$MastodonRoleToJson(MastodonRole instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'permissions': instance.permissions,
+      'color': instance.color,
+      'highlighted': instance.highlighted,
+      'created_at': const SafeDateTimeConverter().toJson(instance.createdAt),
+      'updated_at': const SafeDateTimeConverter().toJson(instance.updatedAt),
+    };

--- a/lib/src/models/mastodon_custom_emoji.dart
+++ b/lib/src/models/mastodon_custom_emoji.dart
@@ -5,7 +5,7 @@ part 'mastodon_custom_emoji.g.dart';
 /// Mastodon のカスタム絵文字
 ///
 /// アカウントのプロフィールや投稿テキストに含まれる `:shortcode:` 形式の絵文字を表す
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonCustomEmoji {
   const MastodonCustomEmoji({
     required this.shortcode,
@@ -17,6 +17,9 @@ class MastodonCustomEmoji {
 
   factory MastodonCustomEmoji.fromJson(Map<String, dynamic> json) =>
       _$MastodonCustomEmojiFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonCustomEmojiToJson(this);
 
   /// `:shortcode:` 形式のショートコード（コロンを除いた部分）
   final String shortcode;

--- a/lib/src/models/mastodon_custom_emoji.g.dart
+++ b/lib/src/models/mastodon_custom_emoji.g.dart
@@ -14,3 +14,13 @@ MastodonCustomEmoji _$MastodonCustomEmojiFromJson(Map<String, dynamic> json) =>
       visibleInPicker: json['visible_in_picker'] as bool? ?? true,
       category: json['category'] as String?,
     );
+
+Map<String, dynamic> _$MastodonCustomEmojiToJson(
+  MastodonCustomEmoji instance,
+) => <String, dynamic>{
+  'shortcode': instance.shortcode,
+  'url': instance.url,
+  'static_url': instance.staticUrl,
+  'visible_in_picker': instance.visibleInPicker,
+  'category': instance.category,
+};

--- a/lib/src/models/mastodon_domain_block.dart
+++ b/lib/src/models/mastodon_domain_block.dart
@@ -18,7 +18,7 @@ enum MastodonDomainBlockSeverity {
 /// インスタンスがブロックしているドメインの情報
 ///
 /// `GET /api/v1/instance/domain_blocks`
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonDomainBlock {
   const MastodonDomainBlock({
     required this.domain,
@@ -29,6 +29,9 @@ class MastodonDomainBlock {
 
   factory MastodonDomainBlock.fromJson(Map<String, dynamic> json) =>
       _$MastodonDomainBlockFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonDomainBlockToJson(this);
 
   /// ブロック対象のドメイン名
   final String domain;

--- a/lib/src/models/mastodon_domain_block.g.dart
+++ b/lib/src/models/mastodon_domain_block.g.dart
@@ -18,6 +18,15 @@ MastodonDomainBlock _$MastodonDomainBlockFromJson(Map<String, dynamic> json) =>
       comment: json['comment'] as String?,
     );
 
+Map<String, dynamic> _$MastodonDomainBlockToJson(
+  MastodonDomainBlock instance,
+) => <String, dynamic>{
+  'domain': instance.domain,
+  'digest': instance.digest,
+  'severity': _$MastodonDomainBlockSeverityEnumMap[instance.severity]!,
+  'comment': instance.comment,
+};
+
 const _$MastodonDomainBlockSeverityEnumMap = {
   MastodonDomainBlockSeverity.silence: 'silence',
   MastodonDomainBlockSeverity.suspend: 'suspend',

--- a/lib/src/models/mastodon_extended_description.dart
+++ b/lib/src/models/mastodon_extended_description.dart
@@ -7,7 +7,7 @@ part 'mastodon_extended_description.g.dart';
 /// インスタンスの詳細な説明文
 ///
 /// `GET /api/v1/instance/extended_description`
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonExtendedDescription {
   const MastodonExtendedDescription({
     this.updatedAt,
@@ -16,6 +16,9 @@ class MastodonExtendedDescription {
 
   factory MastodonExtendedDescription.fromJson(Map<String, dynamic> json) =>
       _$MastodonExtendedDescriptionFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonExtendedDescriptionToJson(this);
 
   /// 詳細説明の最終更新日時
   @SafeDateTimeConverter()

--- a/lib/src/models/mastodon_extended_description.g.dart
+++ b/lib/src/models/mastodon_extended_description.g.dart
@@ -14,3 +14,10 @@ MastodonExtendedDescription _$MastodonExtendedDescriptionFromJson(
   ),
   content: json['content'] as String? ?? '',
 );
+
+Map<String, dynamic> _$MastodonExtendedDescriptionToJson(
+  MastodonExtendedDescription instance,
+) => <String, dynamic>{
+  'updated_at': const SafeDateTimeConverter().toJson(instance.updatedAt),
+  'content': instance.content,
+};

--- a/lib/src/models/mastodon_familiar_followers.dart
+++ b/lib/src/models/mastodon_familiar_followers.dart
@@ -5,7 +5,7 @@ import 'mastodon_account.dart';
 part 'mastodon_familiar_followers.g.dart';
 
 /// 指定アカウントをフォローしている、自分がフォロー中のアカウントの一覧
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonFamiliarFollowers {
   /// 各フィールドを指定して [MastodonFamiliarFollowers] を生成する
   const MastodonFamiliarFollowers({
@@ -16,6 +16,9 @@ class MastodonFamiliarFollowers {
   /// JSON マップから [MastodonFamiliarFollowers] を生成する
   factory MastodonFamiliarFollowers.fromJson(Map<String, dynamic> json) =>
       _$MastodonFamiliarFollowersFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonFamiliarFollowersToJson(this);
 
   /// 対象アカウントの ID
   final String id;

--- a/lib/src/models/mastodon_familiar_followers.g.dart
+++ b/lib/src/models/mastodon_familiar_followers.g.dart
@@ -16,3 +16,7 @@ MastodonFamiliarFollowers _$MastodonFamiliarFollowersFromJson(
           .toList() ??
       [],
 );
+
+Map<String, dynamic> _$MastodonFamiliarFollowersToJson(
+  MastodonFamiliarFollowers instance,
+) => <String, dynamic>{'id': instance.id, 'accounts': instance.accounts};

--- a/lib/src/models/mastodon_featured_tag.dart
+++ b/lib/src/models/mastodon_featured_tag.dart
@@ -5,7 +5,7 @@ import 'json_converters.dart';
 part 'mastodon_featured_tag.g.dart';
 
 /// アカウントのプロフィールで紹介されているハッシュタグ
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonFeaturedTag {
   /// 各フィールドを指定して [MastodonFeaturedTag] を生成する
   const MastodonFeaturedTag({
@@ -19,6 +19,9 @@ class MastodonFeaturedTag {
   /// JSON マップから [MastodonFeaturedTag] を生成する
   factory MastodonFeaturedTag.fromJson(Map<String, dynamic> json) =>
       _$MastodonFeaturedTagFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonFeaturedTagToJson(this);
 
   /// 紹介タグの内部 ID
   final String id;

--- a/lib/src/models/mastodon_featured_tag.g.dart
+++ b/lib/src/models/mastodon_featured_tag.g.dart
@@ -16,3 +16,13 @@ MastodonFeaturedTag _$MastodonFeaturedTagFromJson(Map<String, dynamic> json) =>
         json['last_status_at'] as String?,
       ),
     );
+
+Map<String, dynamic> _$MastodonFeaturedTagToJson(
+  MastodonFeaturedTag instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'name': instance.name,
+  'url': instance.url,
+  'statuses_count': instance.statusesCount,
+  'last_status_at': const SafeDateTimeConverter().toJson(instance.lastStatusAt),
+};

--- a/lib/src/models/mastodon_filter.dart
+++ b/lib/src/models/mastodon_filter.dart
@@ -22,7 +22,7 @@ enum MastodonFilterAction {
 /// `/api/v2/filters` のレスポンスに対応する。
 /// サーバーサイドでフィルタリングを行い、1つのフィルターに複数のキーワードや
 /// ステータスを関連付けることができる。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonFilter {
   const MastodonFilter({
     required this.id,
@@ -36,6 +36,9 @@ class MastodonFilter {
 
   factory MastodonFilter.fromJson(Map<String, dynamic> json) =>
       _$MastodonFilterFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonFilterToJson(this);
 
   /// フィルターの内部 ID
   final String id;
@@ -68,7 +71,7 @@ class MastodonFilter {
 /// フィルターキーワード
 ///
 /// `/api/v2/filters/:filter_id/keywords` のレスポンスに対応する
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonFilterKeyword {
   const MastodonFilterKeyword({
     required this.id,
@@ -78,6 +81,9 @@ class MastodonFilterKeyword {
 
   factory MastodonFilterKeyword.fromJson(Map<String, dynamic> json) =>
       _$MastodonFilterKeywordFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonFilterKeywordToJson(this);
 
   /// FilterKeyword の内部 ID
   final String id;
@@ -94,7 +100,7 @@ class MastodonFilterKeyword {
 /// ステータスフィルター
 ///
 /// `/api/v2/filters/:filter_id/statuses` のレスポンスに対応する
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonFilterStatus {
   const MastodonFilterStatus({
     required this.id,
@@ -103,6 +109,9 @@ class MastodonFilterStatus {
 
   factory MastodonFilterStatus.fromJson(Map<String, dynamic> json) =>
       _$MastodonFilterStatusFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonFilterStatusToJson(this);
 
   /// FilterStatus の内部 ID
   final String id;
@@ -117,7 +126,7 @@ class MastodonFilterStatus {
 /// `/api/v1/filters` のレスポンスに対応する。
 /// クライアントサイドフィルタリング用で、1フィルター = 1キーワードの構造。
 @Deprecated('Mastodon 4.0.0 で非推奨。代わりに MastodonFilter (v2) を使用してください')
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonFilterV1 {
   @Deprecated('Mastodon 4.0.0 で非推奨。代わりに MastodonFilter (v2) を使用してください')
   const MastodonFilterV1({
@@ -132,6 +141,9 @@ class MastodonFilterV1 {
   @Deprecated('Mastodon 4.0.0 で非推奨。代わりに MastodonFilter (v2) を使用してください')
   factory MastodonFilterV1.fromJson(Map<String, dynamic> json) =>
       _$MastodonFilterV1FromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonFilterV1ToJson(this);
 
   /// フィルターの内部 ID
   final String id;

--- a/lib/src/models/mastodon_filter.g.dart
+++ b/lib/src/models/mastodon_filter.g.dart
@@ -36,6 +36,17 @@ MastodonFilter _$MastodonFilterFromJson(
   ),
 );
 
+Map<String, dynamic> _$MastodonFilterToJson(MastodonFilter instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'context': instance.context,
+      'expires_at': const SafeDateTimeConverter().toJson(instance.expiresAt),
+      'filter_action': _$MastodonFilterActionEnumMap[instance.filterAction]!,
+      'keywords': instance.keywords,
+      'statuses': instance.statuses,
+    };
+
 const _$MastodonFilterActionEnumMap = {
   MastodonFilterAction.warn: 'warn',
   MastodonFilterAction.hide: 'hide',
@@ -50,12 +61,24 @@ MastodonFilterKeyword _$MastodonFilterKeywordFromJson(
   wholeWord: json['whole_word'] as bool? ?? false,
 );
 
+Map<String, dynamic> _$MastodonFilterKeywordToJson(
+  MastodonFilterKeyword instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'keyword': instance.keyword,
+  'whole_word': instance.wholeWord,
+};
+
 MastodonFilterStatus _$MastodonFilterStatusFromJson(
   Map<String, dynamic> json,
 ) => MastodonFilterStatus(
   id: json['id'] as String,
   statusId: json['status_id'] as String? ?? '',
 );
+
+Map<String, dynamic> _$MastodonFilterStatusToJson(
+  MastodonFilterStatus instance,
+) => <String, dynamic>{'id': instance.id, 'status_id': instance.statusId};
 
 MastodonFilterV1 _$MastodonFilterV1FromJson(Map<String, dynamic> json) =>
     MastodonFilterV1(
@@ -72,3 +95,13 @@ MastodonFilterV1 _$MastodonFilterV1FromJson(Map<String, dynamic> json) =>
         json['expires_at'] as String?,
       ),
     );
+
+Map<String, dynamic> _$MastodonFilterV1ToJson(MastodonFilterV1 instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'phrase': instance.phrase,
+      'context': instance.context,
+      'expires_at': const SafeDateTimeConverter().toJson(instance.expiresAt),
+      'irreversible': instance.irreversible,
+      'whole_word': instance.wholeWord,
+    };

--- a/lib/src/models/mastodon_grouped_notifications_results.dart
+++ b/lib/src/models/mastodon_grouped_notifications_results.dart
@@ -11,7 +11,7 @@ part 'mastodon_grouped_notifications_results.g.dart';
 ///
 /// `/api/v2/notifications` のレスポンスに対応するモデル。
 /// 通知グループ・関連アカウント・関連投稿を一括で返す。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonGroupedNotificationsResults {
   const MastodonGroupedNotificationsResults({
     required this.accounts,
@@ -23,6 +23,10 @@ class MastodonGroupedNotificationsResults {
   factory MastodonGroupedNotificationsResults.fromJson(
     Map<String, dynamic> json,
   ) => _$MastodonGroupedNotificationsResultsFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() =>
+      _$MastodonGroupedNotificationsResultsToJson(this);
 
   /// 通知に関連するアカウントの一覧
   @JsonKey(defaultValue: <MastodonAccount>[])

--- a/lib/src/models/mastodon_grouped_notifications_results.g.dart
+++ b/lib/src/models/mastodon_grouped_notifications_results.g.dart
@@ -37,3 +37,12 @@ _$MastodonGroupedNotificationsResultsFromJson(Map<String, dynamic> json) =>
               .toList() ??
           [],
     );
+
+Map<String, dynamic> _$MastodonGroupedNotificationsResultsToJson(
+  MastodonGroupedNotificationsResults instance,
+) => <String, dynamic>{
+  'accounts': instance.accounts,
+  'partial_accounts': instance.partialAccounts,
+  'statuses': instance.statuses,
+  'notification_groups': instance.notificationGroups,
+};

--- a/lib/src/models/mastodon_identity_proof.dart
+++ b/lib/src/models/mastodon_identity_proof.dart
@@ -5,7 +5,7 @@ part 'mastodon_identity_proof.g.dart';
 /// アカウントの本人確認証明情報
 ///
 /// **非推奨**: Mastodon 3.5.0 以降は常に空配列を返す。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonIdentityProof {
   const MastodonIdentityProof({
     required this.provider,
@@ -17,6 +17,9 @@ class MastodonIdentityProof {
 
   factory MastodonIdentityProof.fromJson(Map<String, dynamic> json) =>
       _$MastodonIdentityProofFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonIdentityProofToJson(this);
 
   /// 証明プロバイダー名（例: Keybase）
   final String provider;

--- a/lib/src/models/mastodon_identity_proof.g.dart
+++ b/lib/src/models/mastodon_identity_proof.g.dart
@@ -15,3 +15,13 @@ MastodonIdentityProof _$MastodonIdentityProofFromJson(
   proofUrl: json['proof_url'] as String,
   profileUrl: json['profile_url'] as String,
 );
+
+Map<String, dynamic> _$MastodonIdentityProofToJson(
+  MastodonIdentityProof instance,
+) => <String, dynamic>{
+  'provider': instance.provider,
+  'provider_username': instance.providerUsername,
+  'updated_at': instance.updatedAt,
+  'proof_url': instance.proofUrl,
+  'profile_url': instance.profileUrl,
+};

--- a/lib/src/models/mastodon_instance.dart
+++ b/lib/src/models/mastodon_instance.dart
@@ -18,7 +18,7 @@ enum MastodonTimelineAccessLevel {
 }
 
 /// ライブフィード（リアルタイムタイムライン）のアクセス設定
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonTimelineLiveFeeds {
   const MastodonTimelineLiveFeeds({
     required this.local,
@@ -27,6 +27,9 @@ class MastodonTimelineLiveFeeds {
 
   factory MastodonTimelineLiveFeeds.fromJson(Map<String, dynamic> json) =>
       _$MastodonTimelineLiveFeedsFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonTimelineLiveFeedsToJson(this);
 
   static Object? _readLocal(Map<dynamic, dynamic> json, String key) =>
       json['local'] ?? 'public';
@@ -50,7 +53,7 @@ class MastodonTimelineLiveFeeds {
 }
 
 /// ハッシュタグフィードのアクセス設定
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonTimelineHashtagFeeds {
   const MastodonTimelineHashtagFeeds({
     required this.local,
@@ -59,6 +62,9 @@ class MastodonTimelineHashtagFeeds {
 
   factory MastodonTimelineHashtagFeeds.fromJson(Map<String, dynamic> json) =>
       _$MastodonTimelineHashtagFeedsFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonTimelineHashtagFeedsToJson(this);
 
   static Object? _readLocal(Map<dynamic, dynamic> json, String key) =>
       json['local'] ?? 'public';
@@ -80,7 +86,7 @@ class MastodonTimelineHashtagFeeds {
 }
 
 /// インスタンスのタイムラインアクセス設定（`configuration.timelines_access`）
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonTimelinesAccess {
   const MastodonTimelinesAccess({
     this.liveFeeds,
@@ -90,6 +96,9 @@ class MastodonTimelinesAccess {
 
   factory MastodonTimelinesAccess.fromJson(Map<String, dynamic> json) =>
       _$MastodonTimelinesAccessFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonTimelinesAccessToJson(this);
 
   /// ライブフィードのアクセス設定nullの場合は両タイムラインともpublicとみなす
   final MastodonTimelineLiveFeeds? liveFeeds;
@@ -102,7 +111,7 @@ class MastodonTimelinesAccess {
 }
 
 /// インスタンスのURL設定（`configuration.urls`）
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonInstanceUrls {
   const MastodonInstanceUrls({
     this.streaming,
@@ -114,6 +123,9 @@ class MastodonInstanceUrls {
 
   factory MastodonInstanceUrls.fromJson(Map<String, dynamic> json) =>
       _$MastodonInstanceUrlsFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonInstanceUrlsToJson(this);
 
   /// WebSocketストリーミングの接続先URL
   final String? streaming;
@@ -132,7 +144,7 @@ class MastodonInstanceUrls {
 }
 
 /// 投稿に関する制限設定（`configuration.statuses`）
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonStatusesConfiguration {
   const MastodonStatusesConfiguration({
     required this.maxCharacters,
@@ -142,6 +154,9 @@ class MastodonStatusesConfiguration {
 
   factory MastodonStatusesConfiguration.fromJson(Map<String, dynamic> json) =>
       _$MastodonStatusesConfigurationFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonStatusesConfigurationToJson(this);
 
   /// 投稿の最大文字数
   @JsonKey(defaultValue: 500)
@@ -157,7 +172,7 @@ class MastodonStatusesConfiguration {
 }
 
 /// メディア添付に関する制限設定（`configuration.media_attachments`）
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonMediaConfiguration {
   const MastodonMediaConfiguration({
     required this.supportedMimeTypes,
@@ -171,6 +186,9 @@ class MastodonMediaConfiguration {
 
   factory MastodonMediaConfiguration.fromJson(Map<String, dynamic> json) =>
       _$MastodonMediaConfigurationFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonMediaConfigurationToJson(this);
 
   /// 受け付けるMIMEタイプのリスト
   @JsonKey(defaultValue: <String>[])
@@ -196,7 +214,7 @@ class MastodonMediaConfiguration {
 }
 
 /// 投票に関する制限設定（`configuration.polls`）
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonPollsConfiguration {
   const MastodonPollsConfiguration({
     required this.maxOptions,
@@ -207,6 +225,9 @@ class MastodonPollsConfiguration {
 
   factory MastodonPollsConfiguration.fromJson(Map<String, dynamic> json) =>
       _$MastodonPollsConfigurationFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonPollsConfigurationToJson(this);
 
   /// 投票の最大選択肢数
   @JsonKey(defaultValue: 4)
@@ -226,7 +247,7 @@ class MastodonPollsConfiguration {
 }
 
 /// アカウントに関する制限設定（`configuration.accounts`）
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAccountsConfiguration {
   const MastodonAccountsConfiguration({
     required this.maxFeaturedTags,
@@ -238,6 +259,9 @@ class MastodonAccountsConfiguration {
 
   factory MastodonAccountsConfiguration.fromJson(Map<String, dynamic> json) =>
       _$MastodonAccountsConfigurationFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAccountsConfigurationToJson(this);
 
   /// フィーチャータグの最大件数
   @JsonKey(defaultValue: 10)
@@ -261,7 +285,7 @@ class MastodonAccountsConfiguration {
 }
 
 /// インスタンスの各種制限・設定（`configuration`）
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonInstanceConfiguration {
   const MastodonInstanceConfiguration({
     required this.urls,
@@ -277,6 +301,9 @@ class MastodonInstanceConfiguration {
 
   factory MastodonInstanceConfiguration.fromJson(Map<String, dynamic> json) =>
       _$MastodonInstanceConfigurationFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonInstanceConfigurationToJson(this);
 
   static Object? _readUrls(Map<dynamic, dynamic> json, String key) =>
       json['urls'] ?? const <String, dynamic>{};
@@ -323,7 +350,7 @@ class MastodonInstanceConfiguration {
 }
 
 /// インスタンスのサムネイル画像情報（`thumbnail`）
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonInstanceThumbnail {
   const MastodonInstanceThumbnail({
     required this.url,
@@ -333,6 +360,9 @@ class MastodonInstanceThumbnail {
 
   factory MastodonInstanceThumbnail.fromJson(Map<String, dynamic> json) =>
       _$MastodonInstanceThumbnailFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonInstanceThumbnailToJson(this);
 
   /// サムネイル画像のURL
   final String url;
@@ -345,13 +375,17 @@ class MastodonInstanceThumbnail {
 }
 
 /// サムネイル画像の解像度別バージョン（`thumbnail.versions`）
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class MastodonInstanceThumbnailVersions {
   const MastodonInstanceThumbnailVersions({this.at1x, this.at2x});
 
   factory MastodonInstanceThumbnailVersions.fromJson(
     Map<String, dynamic> json,
   ) => _$MastodonInstanceThumbnailVersionsFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() =>
+      _$MastodonInstanceThumbnailVersionsToJson(this);
 
   /// 標準解像度（1x）のサムネイルURL
   @JsonKey(name: '@1x')
@@ -363,12 +397,15 @@ class MastodonInstanceThumbnailVersions {
 }
 
 /// インスタンスの利用状況（`usage`）
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonInstanceUsage {
   const MastodonInstanceUsage({required this.activeMonth});
 
   factory MastodonInstanceUsage.fromJson(Map<String, dynamic> json) =>
       _$MastodonInstanceUsageFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonInstanceUsageToJson(this);
 
   static Object? _readActiveMonth(Map<dynamic, dynamic> json, String key) =>
       (json['users'] as Map<String, dynamic>?)?['active_month'];
@@ -379,7 +416,7 @@ class MastodonInstanceUsage {
 }
 
 /// インスタンスの登録設定（`registrations`）
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonInstanceRegistrations {
   const MastodonInstanceRegistrations({
     required this.enabled,
@@ -392,6 +429,9 @@ class MastodonInstanceRegistrations {
 
   factory MastodonInstanceRegistrations.fromJson(Map<String, dynamic> json) =>
       _$MastodonInstanceRegistrationsFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonInstanceRegistrationsToJson(this);
 
   /// 新規登録を受け付けているかどうか
   @JsonKey(defaultValue: false)
@@ -415,12 +455,15 @@ class MastodonInstanceRegistrations {
 }
 
 /// インスタンスの連絡先情報（`contact`）
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonInstanceContact {
   const MastodonInstanceContact({this.email, this.account});
 
   factory MastodonInstanceContact.fromJson(Map<String, dynamic> json) =>
       _$MastodonInstanceContactFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonInstanceContactToJson(this);
 
   /// 管理者の連絡先メールアドレス。
   final String? email;
@@ -430,7 +473,7 @@ class MastodonInstanceContact {
 }
 
 /// インスタンスの利用規約（`rules`）
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonInstanceRule {
   const MastodonInstanceRule({
     required this.id,
@@ -441,6 +484,9 @@ class MastodonInstanceRule {
 
   factory MastodonInstanceRule.fromJson(Map<String, dynamic> json) =>
       _$MastodonInstanceRuleFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonInstanceRuleToJson(this);
 
   /// 規約の ID
   final String id;
@@ -456,7 +502,7 @@ class MastodonInstanceRule {
 }
 
 /// インスタンス規約の翻訳（`rules[].translations`）
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonInstanceRuleTranslation {
   const MastodonInstanceRuleTranslation({
     required this.text,
@@ -466,6 +512,10 @@ class MastodonInstanceRuleTranslation {
   factory MastodonInstanceRuleTranslation.fromJson(
     Map<String, dynamic> json,
   ) => _$MastodonInstanceRuleTranslationFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() =>
+      _$MastodonInstanceRuleTranslationToJson(this);
 
   /// 翻訳された規約の本文
   final String text;
@@ -477,7 +527,7 @@ class MastodonInstanceRuleTranslation {
 /// Mastodonインスタンスの情報
 ///
 /// `/api/v2/instance`のレスポンスに対応
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonInstance {
   const MastodonInstance({
     required this.domain,
@@ -498,6 +548,9 @@ class MastodonInstance {
 
   factory MastodonInstance.fromJson(Map<String, dynamic> json) =>
       _$MastodonInstanceFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonInstanceToJson(this);
 
   static Object? _readConfiguration(Map<dynamic, dynamic> json, String key) =>
       json['configuration'] ?? const <String, dynamic>{};
@@ -556,7 +609,7 @@ class MastodonInstance {
 }
 
 /// インスタンスのアイコン画像（`icon`、Mastodon 4.3+）
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonInstanceIcon {
   const MastodonInstanceIcon({
     required this.src,
@@ -565,6 +618,9 @@ class MastodonInstanceIcon {
 
   factory MastodonInstanceIcon.fromJson(Map<String, dynamic> json) =>
       _$MastodonInstanceIconFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonInstanceIconToJson(this);
 
   /// アイコン画像のURL
   final String src;

--- a/lib/src/models/mastodon_instance.g.dart
+++ b/lib/src/models/mastodon_instance.g.dart
@@ -21,6 +21,13 @@ MastodonTimelineLiveFeeds _$MastodonTimelineLiveFeedsFromJson(
   ),
 );
 
+Map<String, dynamic> _$MastodonTimelineLiveFeedsToJson(
+  MastodonTimelineLiveFeeds instance,
+) => <String, dynamic>{
+  'local': _$MastodonTimelineAccessLevelEnumMap[instance.local]!,
+  'remote': _$MastodonTimelineAccessLevelEnumMap[instance.remote]!,
+};
+
 const _$MastodonTimelineAccessLevelEnumMap = {
   MastodonTimelineAccessLevel.public: 'public',
   MastodonTimelineAccessLevel.authenticated: 'authenticated',
@@ -42,6 +49,13 @@ MastodonTimelineHashtagFeeds _$MastodonTimelineHashtagFeedsFromJson(
   ),
 );
 
+Map<String, dynamic> _$MastodonTimelineHashtagFeedsToJson(
+  MastodonTimelineHashtagFeeds instance,
+) => <String, dynamic>{
+  'local': _$MastodonTimelineAccessLevelEnumMap[instance.local]!,
+  'remote': _$MastodonTimelineAccessLevelEnumMap[instance.remote]!,
+};
+
 MastodonTimelinesAccess _$MastodonTimelinesAccessFromJson(
   Map<String, dynamic> json,
 ) => MastodonTimelinesAccess(
@@ -62,6 +76,14 @@ MastodonTimelinesAccess _$MastodonTimelinesAccessFromJson(
         ),
 );
 
+Map<String, dynamic> _$MastodonTimelinesAccessToJson(
+  MastodonTimelinesAccess instance,
+) => <String, dynamic>{
+  'live_feeds': instance.liveFeeds,
+  'hashtag_feeds': instance.hashtagFeeds,
+  'trending_link_feeds': instance.trendingLinkFeeds,
+};
+
 MastodonInstanceUrls _$MastodonInstanceUrlsFromJson(
   Map<String, dynamic> json,
 ) => MastodonInstanceUrls(
@@ -72,6 +94,16 @@ MastodonInstanceUrls _$MastodonInstanceUrlsFromJson(
   termsOfService: json['terms_of_service'] as String?,
 );
 
+Map<String, dynamic> _$MastodonInstanceUrlsToJson(
+  MastodonInstanceUrls instance,
+) => <String, dynamic>{
+  'streaming': instance.streaming,
+  'status': instance.status,
+  'about': instance.about,
+  'privacy_policy': instance.privacyPolicy,
+  'terms_of_service': instance.termsOfService,
+};
+
 MastodonStatusesConfiguration _$MastodonStatusesConfigurationFromJson(
   Map<String, dynamic> json,
 ) => MastodonStatusesConfiguration(
@@ -80,6 +112,14 @@ MastodonStatusesConfiguration _$MastodonStatusesConfigurationFromJson(
   charactersReservedPerUrl:
       (json['characters_reserved_per_url'] as num?)?.toInt() ?? 23,
 );
+
+Map<String, dynamic> _$MastodonStatusesConfigurationToJson(
+  MastodonStatusesConfiguration instance,
+) => <String, dynamic>{
+  'max_characters': instance.maxCharacters,
+  'max_media_attachments': instance.maxMediaAttachments,
+  'characters_reserved_per_url': instance.charactersReservedPerUrl,
+};
 
 MastodonMediaConfiguration _$MastodonMediaConfigurationFromJson(
   Map<String, dynamic> json,
@@ -97,6 +137,18 @@ MastodonMediaConfiguration _$MastodonMediaConfigurationFromJson(
   videoMatrixLimit: (json['video_matrix_limit'] as num?)?.toInt(),
 );
 
+Map<String, dynamic> _$MastodonMediaConfigurationToJson(
+  MastodonMediaConfiguration instance,
+) => <String, dynamic>{
+  'supported_mime_types': instance.supportedMimeTypes,
+  'description_limit': instance.descriptionLimit,
+  'image_size_limit': instance.imageSizeLimit,
+  'image_matrix_limit': instance.imageMatrixLimit,
+  'video_size_limit': instance.videoSizeLimit,
+  'video_frame_rate_limit': instance.videoFrameRateLimit,
+  'video_matrix_limit': instance.videoMatrixLimit,
+};
+
 MastodonPollsConfiguration _$MastodonPollsConfigurationFromJson(
   Map<String, dynamic> json,
 ) => MastodonPollsConfiguration(
@@ -106,6 +158,15 @@ MastodonPollsConfiguration _$MastodonPollsConfigurationFromJson(
   minExpiration: (json['min_expiration'] as num?)?.toInt() ?? 300,
   maxExpiration: (json['max_expiration'] as num?)?.toInt() ?? 2629746,
 );
+
+Map<String, dynamic> _$MastodonPollsConfigurationToJson(
+  MastodonPollsConfiguration instance,
+) => <String, dynamic>{
+  'max_options': instance.maxOptions,
+  'max_characters_per_option': instance.maxCharactersPerOption,
+  'min_expiration': instance.minExpiration,
+  'max_expiration': instance.maxExpiration,
+};
 
 MastodonAccountsConfiguration _$MastodonAccountsConfigurationFromJson(
   Map<String, dynamic> json,
@@ -118,6 +179,16 @@ MastodonAccountsConfiguration _$MastodonAccountsConfigurationFromJson(
   profileFieldValueLimit:
       (json['profile_field_value_limit'] as num?)?.toInt() ?? 255,
 );
+
+Map<String, dynamic> _$MastodonAccountsConfigurationToJson(
+  MastodonAccountsConfiguration instance,
+) => <String, dynamic>{
+  'max_featured_tags': instance.maxFeaturedTags,
+  'max_pinned_statuses': instance.maxPinnedStatuses,
+  'max_profile_fields': instance.maxProfileFields,
+  'profile_field_name_limit': instance.profileFieldNameLimit,
+  'profile_field_value_limit': instance.profileFieldValueLimit,
+};
 
 MastodonInstanceConfiguration _$MastodonInstanceConfigurationFromJson(
   Map<String, dynamic> json,
@@ -166,6 +237,20 @@ MastodonInstanceConfiguration _$MastodonInstanceConfigurationFromJson(
           as String?,
 );
 
+Map<String, dynamic> _$MastodonInstanceConfigurationToJson(
+  MastodonInstanceConfiguration instance,
+) => <String, dynamic>{
+  'urls': instance.urls,
+  'statuses': instance.statuses,
+  'media_attachments': instance.mediaAttachments,
+  'polls': instance.polls,
+  'accounts': instance.accounts,
+  'timelines_access': instance.timelinesAccess,
+  'translation_enabled': instance.translationEnabled,
+  'limited_federation': instance.limitedFederation,
+  'vapid_public_key': instance.vapidPublicKey,
+};
+
 MastodonInstanceThumbnail _$MastodonInstanceThumbnailFromJson(
   Map<String, dynamic> json,
 ) => MastodonInstanceThumbnail(
@@ -178,12 +263,24 @@ MastodonInstanceThumbnail _$MastodonInstanceThumbnailFromJson(
         ),
 );
 
+Map<String, dynamic> _$MastodonInstanceThumbnailToJson(
+  MastodonInstanceThumbnail instance,
+) => <String, dynamic>{
+  'url': instance.url,
+  'blurhash': instance.blurhash,
+  'versions': instance.versions,
+};
+
 MastodonInstanceThumbnailVersions _$MastodonInstanceThumbnailVersionsFromJson(
   Map<String, dynamic> json,
 ) => MastodonInstanceThumbnailVersions(
   at1x: json['@1x'] as String?,
   at2x: json['@2x'] as String?,
 );
+
+Map<String, dynamic> _$MastodonInstanceThumbnailVersionsToJson(
+  MastodonInstanceThumbnailVersions instance,
+) => <String, dynamic>{'@1x': instance.at1x, '@2x': instance.at2x};
 
 MastodonInstanceUsage _$MastodonInstanceUsageFromJson(
   Map<String, dynamic> json,
@@ -193,6 +290,10 @@ MastodonInstanceUsage _$MastodonInstanceUsageFromJson(
           ?.toInt() ??
       0,
 );
+
+Map<String, dynamic> _$MastodonInstanceUsageToJson(
+  MastodonInstanceUsage instance,
+) => <String, dynamic>{'active_month': instance.activeMonth};
 
 MastodonInstanceRegistrations _$MastodonInstanceRegistrationsFromJson(
   Map<String, dynamic> json,
@@ -205,6 +306,17 @@ MastodonInstanceRegistrations _$MastodonInstanceRegistrationsFromJson(
   reasonRequired: json['reason_required'] as bool?,
 );
 
+Map<String, dynamic> _$MastodonInstanceRegistrationsToJson(
+  MastodonInstanceRegistrations instance,
+) => <String, dynamic>{
+  'enabled': instance.enabled,
+  'approval_required': instance.approvalRequired,
+  'message': instance.message,
+  'url': instance.url,
+  'min_age': instance.minAge,
+  'reason_required': instance.reasonRequired,
+};
+
 MastodonInstanceContact _$MastodonInstanceContactFromJson(
   Map<String, dynamic> json,
 ) => MastodonInstanceContact(
@@ -213,6 +325,10 @@ MastodonInstanceContact _$MastodonInstanceContactFromJson(
       ? null
       : MastodonAccount.fromJson(json['account'] as Map<String, dynamic>),
 );
+
+Map<String, dynamic> _$MastodonInstanceContactToJson(
+  MastodonInstanceContact instance,
+) => <String, dynamic>{'email': instance.email, 'account': instance.account};
 
 MastodonInstanceRule _$MastodonInstanceRuleFromJson(
   Map<String, dynamic> json,
@@ -228,12 +344,25 @@ MastodonInstanceRule _$MastodonInstanceRuleFromJson(
   ),
 );
 
+Map<String, dynamic> _$MastodonInstanceRuleToJson(
+  MastodonInstanceRule instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'text': instance.text,
+  'hint': instance.hint,
+  'translations': instance.translations,
+};
+
 MastodonInstanceRuleTranslation _$MastodonInstanceRuleTranslationFromJson(
   Map<String, dynamic> json,
 ) => MastodonInstanceRuleTranslation(
   text: json['text'] as String,
   hint: json['hint'] as String?,
 );
+
+Map<String, dynamic> _$MastodonInstanceRuleTranslationToJson(
+  MastodonInstanceRuleTranslation instance,
+) => <String, dynamic>{'text': instance.text, 'hint': instance.hint};
 
 MastodonInstance _$MastodonInstanceFromJson(
   Map<String, dynamic> json,
@@ -282,9 +411,31 @@ MastodonInstance _$MastodonInstanceFromJson(
           ?.toInt(),
 );
 
+Map<String, dynamic> _$MastodonInstanceToJson(MastodonInstance instance) =>
+    <String, dynamic>{
+      'domain': instance.domain,
+      'title': instance.title,
+      'version': instance.version,
+      'source_url': instance.sourceUrl,
+      'description': instance.description,
+      'icon': instance.icon,
+      'thumbnail': instance.thumbnail,
+      'usage': instance.usage,
+      'configuration': instance.configuration,
+      'contact': instance.contact,
+      'registrations': instance.registrations,
+      'languages': instance.languages,
+      'rules': instance.rules,
+      'api_version_mastodon': instance.apiVersionMastodon,
+    };
+
 MastodonInstanceIcon _$MastodonInstanceIconFromJson(
   Map<String, dynamic> json,
 ) => MastodonInstanceIcon(
   src: json['src'] as String,
   size: json['size'] as String,
 );
+
+Map<String, dynamic> _$MastodonInstanceIconToJson(
+  MastodonInstanceIcon instance,
+) => <String, dynamic>{'src': instance.src, 'size': instance.size};

--- a/lib/src/models/mastodon_instance_v1.dart
+++ b/lib/src/models/mastodon_instance_v1.dart
@@ -6,19 +6,22 @@ import 'mastodon_instance.dart';
 part 'mastodon_instance_v1.g.dart';
 
 /// v1 インスタンスのURL設定
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonInstanceV1Urls {
   const MastodonInstanceV1Urls({this.streamingApi});
 
   factory MastodonInstanceV1Urls.fromJson(Map<String, dynamic> json) =>
       _$MastodonInstanceV1UrlsFromJson(json);
 
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonInstanceV1UrlsToJson(this);
+
   /// WebSocket ストリーミング API の接続先 URL
   final String? streamingApi;
 }
 
 /// v1 インスタンスの統計情報
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonInstanceV1Stats {
   const MastodonInstanceV1Stats({
     required this.userCount,
@@ -28,6 +31,9 @@ class MastodonInstanceV1Stats {
 
   factory MastodonInstanceV1Stats.fromJson(Map<String, dynamic> json) =>
       _$MastodonInstanceV1StatsFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonInstanceV1StatsToJson(this);
 
   /// 登録ユーザー数
   @JsonKey(defaultValue: 0)
@@ -43,7 +49,7 @@ class MastodonInstanceV1Stats {
 }
 
 /// v1 インスタンスの設定情報
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonInstanceV1Configuration {
   const MastodonInstanceV1Configuration({
     this.statuses,
@@ -54,6 +60,10 @@ class MastodonInstanceV1Configuration {
   factory MastodonInstanceV1Configuration.fromJson(
     Map<String, dynamic> json,
   ) => _$MastodonInstanceV1ConfigurationFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() =>
+      _$MastodonInstanceV1ConfigurationToJson(this);
 
   /// 投稿制限設定
   final MastodonStatusesConfiguration? statuses;
@@ -70,7 +80,7 @@ class MastodonInstanceV1Configuration {
 /// `/api/v1/instance` のレスポンスに対応する。
 ///
 /// **非推奨**: Mastodon 4.0.0 以降は [MastodonInstance]（v2）を使用すること。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonInstanceV1 {
   const MastodonInstanceV1({
     required this.uri,
@@ -93,6 +103,9 @@ class MastodonInstanceV1 {
 
   factory MastodonInstanceV1.fromJson(Map<String, dynamic> json) =>
       _$MastodonInstanceV1FromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonInstanceV1ToJson(this);
 
   /// サーバーのドメイン
   final String uri;

--- a/lib/src/models/mastodon_instance_v1.g.dart
+++ b/lib/src/models/mastodon_instance_v1.g.dart
@@ -10,6 +10,10 @@ MastodonInstanceV1Urls _$MastodonInstanceV1UrlsFromJson(
   Map<String, dynamic> json,
 ) => MastodonInstanceV1Urls(streamingApi: json['streaming_api'] as String?);
 
+Map<String, dynamic> _$MastodonInstanceV1UrlsToJson(
+  MastodonInstanceV1Urls instance,
+) => <String, dynamic>{'streaming_api': instance.streamingApi};
+
 MastodonInstanceV1Stats _$MastodonInstanceV1StatsFromJson(
   Map<String, dynamic> json,
 ) => MastodonInstanceV1Stats(
@@ -17,6 +21,14 @@ MastodonInstanceV1Stats _$MastodonInstanceV1StatsFromJson(
   statusCount: (json['status_count'] as num?)?.toInt() ?? 0,
   domainCount: (json['domain_count'] as num?)?.toInt() ?? 0,
 );
+
+Map<String, dynamic> _$MastodonInstanceV1StatsToJson(
+  MastodonInstanceV1Stats instance,
+) => <String, dynamic>{
+  'user_count': instance.userCount,
+  'status_count': instance.statusCount,
+  'domain_count': instance.domainCount,
+};
 
 MastodonInstanceV1Configuration _$MastodonInstanceV1ConfigurationFromJson(
   Map<String, dynamic> json,
@@ -37,6 +49,14 @@ MastodonInstanceV1Configuration _$MastodonInstanceV1ConfigurationFromJson(
           json['polls'] as Map<String, dynamic>,
         ),
 );
+
+Map<String, dynamic> _$MastodonInstanceV1ConfigurationToJson(
+  MastodonInstanceV1Configuration instance,
+) => <String, dynamic>{
+  'statuses': instance.statuses,
+  'media_attachments': instance.mediaAttachments,
+  'polls': instance.polls,
+};
 
 MastodonInstanceV1 _$MastodonInstanceV1FromJson(
   Map<String, dynamic> json,
@@ -76,3 +96,23 @@ MastodonInstanceV1 _$MastodonInstanceV1FromJson(
           json['contact_account'] as Map<String, dynamic>,
         ),
 );
+
+Map<String, dynamic> _$MastodonInstanceV1ToJson(MastodonInstanceV1 instance) =>
+    <String, dynamic>{
+      'uri': instance.uri,
+      'title': instance.title,
+      'short_description': instance.shortDescription,
+      'description': instance.description,
+      'email': instance.email,
+      'version': instance.version,
+      'urls': instance.urls,
+      'stats': instance.stats,
+      'thumbnail': instance.thumbnail,
+      'languages': instance.languages,
+      'registrations': instance.registrations,
+      'approval_required': instance.approvalRequired,
+      'invites_enabled': instance.invitesEnabled,
+      'configuration': instance.configuration,
+      'contact_account': instance.contactAccount,
+      'rules': instance.rules,
+    };

--- a/lib/src/models/mastodon_list.dart
+++ b/lib/src/models/mastodon_list.dart
@@ -3,7 +3,7 @@ import 'package:json_annotation/json_annotation.dart';
 part 'mastodon_list.g.dart';
 
 /// ユーザー定義のリスト
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonList {
   /// 各フィールドを指定して [MastodonList] を生成する
   const MastodonList({
@@ -16,6 +16,9 @@ class MastodonList {
   /// JSON マップから [MastodonList] を生成する
   factory MastodonList.fromJson(Map<String, dynamic> json) =>
       _$MastodonListFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonListToJson(this);
 
   /// リストの内部 ID
   final String id;

--- a/lib/src/models/mastodon_list.g.dart
+++ b/lib/src/models/mastodon_list.g.dart
@@ -12,3 +12,11 @@ MastodonList _$MastodonListFromJson(Map<String, dynamic> json) => MastodonList(
   repliesPolicy: json['replies_policy'] as String? ?? 'list',
   exclusive: json['exclusive'] as bool? ?? false,
 );
+
+Map<String, dynamic> _$MastodonListToJson(MastodonList instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'replies_policy': instance.repliesPolicy,
+      'exclusive': instance.exclusive,
+    };

--- a/lib/src/models/mastodon_marker.dart
+++ b/lib/src/models/mastodon_marker.dart
@@ -5,7 +5,7 @@ import 'json_converters.dart';
 part 'mastodon_marker.g.dart';
 
 /// タイムラインの既読位置マーカーを表すモデル
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonMarker {
   /// 各フィールドを指定して [MastodonMarker] を生成する
   const MastodonMarker({
@@ -17,6 +17,9 @@ class MastodonMarker {
   /// JSON マップから [MastodonMarker] を生成する
   factory MastodonMarker.fromJson(Map<String, dynamic> json) =>
       _$MastodonMarkerFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonMarkerToJson(this);
 
   /// 最後に閲覧したエンティティ（ステータスまたは通知）の ID
   final String lastReadId;

--- a/lib/src/models/mastodon_marker.g.dart
+++ b/lib/src/models/mastodon_marker.g.dart
@@ -14,3 +14,10 @@ MastodonMarker _$MastodonMarkerFromJson(Map<String, dynamic> json) =>
         json['updated_at'] as String?,
       ),
     );
+
+Map<String, dynamic> _$MastodonMarkerToJson(MastodonMarker instance) =>
+    <String, dynamic>{
+      'last_read_id': instance.lastReadId,
+      'version': instance.version,
+      'updated_at': const SafeDateTimeConverter().toJson(instance.updatedAt),
+    };

--- a/lib/src/models/mastodon_media_attachment.dart
+++ b/lib/src/models/mastodon_media_attachment.dart
@@ -13,7 +13,7 @@ enum MastodonMediaType {
 }
 
 /// Mastodon のメディア添付ファイル
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonMediaAttachment {
   const MastodonMediaAttachment({
     required this.id,
@@ -27,6 +27,9 @@ class MastodonMediaAttachment {
 
   factory MastodonMediaAttachment.fromJson(Map<String, dynamic> json) =>
       _$MastodonMediaAttachmentFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonMediaAttachmentToJson(this);
 
   static Object? _readType(Map<dynamic, dynamic> json, String key) =>
       json['type'] ?? 'unknown';

--- a/lib/src/models/mastodon_media_attachment.g.dart
+++ b/lib/src/models/mastodon_media_attachment.g.dart
@@ -22,6 +22,18 @@ MastodonMediaAttachment _$MastodonMediaAttachmentFromJson(
   blurhash: json['blurhash'] as String?,
 );
 
+Map<String, dynamic> _$MastodonMediaAttachmentToJson(
+  MastodonMediaAttachment instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'type': _$MastodonMediaTypeEnumMap[instance.type]!,
+  'url': instance.url,
+  'preview_url': instance.previewUrl,
+  'remote_url': instance.remoteUrl,
+  'description': instance.description,
+  'blurhash': instance.blurhash,
+};
+
 const _$MastodonMediaTypeEnumMap = {
   MastodonMediaType.unknown: 'unknown',
   MastodonMediaType.image: 'image',

--- a/lib/src/models/mastodon_notification.dart
+++ b/lib/src/models/mastodon_notification.dart
@@ -61,7 +61,7 @@ enum MastodonNotificationType {
 }
 
 /// フォロー関係の強制解除イベント（Mastodon 4.3+）
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonRelationshipSeveranceEvent {
   const MastodonRelationshipSeveranceEvent({
     required this.id,
@@ -76,6 +76,10 @@ class MastodonRelationshipSeveranceEvent {
   factory MastodonRelationshipSeveranceEvent.fromJson(
     Map<String, dynamic> json,
   ) => _$MastodonRelationshipSeveranceEventFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() =>
+      _$MastodonRelationshipSeveranceEventToJson(this);
 
   final String id;
 
@@ -102,7 +106,7 @@ class MastodonRelationshipSeveranceEvent {
 }
 
 /// モデレーション警告（Mastodon 4.3+）
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAccountWarning {
   const MastodonAccountWarning({
     required this.id,
@@ -114,6 +118,9 @@ class MastodonAccountWarning {
 
   factory MastodonAccountWarning.fromJson(Map<String, dynamic> json) =>
       _$MastodonAccountWarningFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonAccountWarningToJson(this);
 
   static Object? _readAppeal(Map<dynamic, dynamic> json, String key) =>
       json['appeal'] != null;
@@ -139,7 +146,7 @@ class MastodonAccountWarning {
 /// Mastodonの通知
 ///
 /// `/api/v1/notifications` のレスポンスに対応する
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonNotification {
   const MastodonNotification({
     required this.id,
@@ -153,6 +160,9 @@ class MastodonNotification {
 
   factory MastodonNotification.fromJson(Map<String, dynamic> json) =>
       _$MastodonNotificationFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonNotificationToJson(this);
 
   static Object? _readType(Map<dynamic, dynamic> json, String key) =>
       json['type'] ?? 'unknown';

--- a/lib/src/models/mastodon_notification.g.dart
+++ b/lib/src/models/mastodon_notification.g.dart
@@ -20,6 +20,18 @@ MastodonRelationshipSeveranceEvent _$MastodonRelationshipSeveranceEventFromJson(
   ),
 );
 
+Map<String, dynamic> _$MastodonRelationshipSeveranceEventToJson(
+  MastodonRelationshipSeveranceEvent instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'type': instance.type,
+  'purged': instance.purged,
+  'target_name': instance.targetName,
+  'followers_count': instance.followersCount,
+  'following_count': instance.followingCount,
+  'created_at': const SafeDateTimeConverter().toJson(instance.createdAt),
+};
+
 MastodonAccountWarning _$MastodonAccountWarningFromJson(
   Map<String, dynamic> json,
 ) => MastodonAccountWarning(
@@ -31,6 +43,16 @@ MastodonAccountWarning _$MastodonAccountWarningFromJson(
     json['created_at'] as String?,
   ),
 );
+
+Map<String, dynamic> _$MastodonAccountWarningToJson(
+  MastodonAccountWarning instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'action': instance.action,
+  'text': instance.text,
+  'appeal': instance.appeal,
+  'created_at': const SafeDateTimeConverter().toJson(instance.createdAt),
+};
 
 MastodonNotification _$MastodonNotificationFromJson(
   Map<String, dynamic> json,
@@ -57,6 +79,18 @@ MastodonNotification _$MastodonNotificationFromJson(
           json['moderation_warning'] as Map<String, dynamic>,
         ),
 );
+
+Map<String, dynamic> _$MastodonNotificationToJson(
+  MastodonNotification instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'type': _$MastodonNotificationTypeEnumMap[instance.type]!,
+  'created_at': instance.createdAt.toIso8601String(),
+  'account': instance.account,
+  'status': instance.status,
+  'relationship_severance_event': instance.relationshipSeveranceEvent,
+  'moderation_warning': instance.moderationWarning,
+};
 
 const _$MastodonNotificationTypeEnumMap = {
   MastodonNotificationType.mention: 'mention',

--- a/lib/src/models/mastodon_notification_group.dart
+++ b/lib/src/models/mastodon_notification_group.dart
@@ -10,7 +10,7 @@ part 'mastodon_notification_group.g.dart';
 ///
 /// `/api/v2/notifications` のレスポンスで返される通知グループを表すモデル。
 /// 同一タイプ・同一対象の通知がグループ化され、効率的に表示できる。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonNotificationGroup {
   const MastodonNotificationGroup({
     required this.groupKey,
@@ -29,6 +29,9 @@ class MastodonNotificationGroup {
 
   factory MastodonNotificationGroup.fromJson(Map<String, dynamic> json) =>
       _$MastodonNotificationGroupFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonNotificationGroupToJson(this);
 
   static Object? _readType(Map<dynamic, dynamic> json, String key) =>
       json['type'] ?? 'unknown';

--- a/lib/src/models/mastodon_notification_group.g.dart
+++ b/lib/src/models/mastodon_notification_group.g.dart
@@ -43,6 +43,25 @@ MastodonNotificationGroup _$MastodonNotificationGroupFromJson(
         ),
 );
 
+Map<String, dynamic> _$MastodonNotificationGroupToJson(
+  MastodonNotificationGroup instance,
+) => <String, dynamic>{
+  'group_key': instance.groupKey,
+  'notifications_count': instance.notificationsCount,
+  'type': _$MastodonNotificationTypeEnumMap[instance.type]!,
+  'most_recent_notification_id': instance.mostRecentNotificationId,
+  'page_min_id': instance.pageMinId,
+  'page_max_id': instance.pageMaxId,
+  'latest_page_notification_at': const SafeDateTimeConverter().toJson(
+    instance.latestPageNotificationAt,
+  ),
+  'sample_account_ids': instance.sampleAccountIds,
+  'status_id': instance.statusId,
+  'report': instance.report,
+  'event': instance.event,
+  'moderation_warning': instance.moderationWarning,
+};
+
 const _$MastodonNotificationTypeEnumMap = {
   MastodonNotificationType.mention: 'mention',
   MastodonNotificationType.status: 'status',

--- a/lib/src/models/mastodon_notification_policy.dart
+++ b/lib/src/models/mastodon_notification_policy.dart
@@ -20,7 +20,7 @@ enum NotificationFilterAction {
 /// 通知ポリシーのサマリー
 ///
 /// フィルタリングされた通知の統計情報を保持
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonNotificationPolicySummary {
   const MastodonNotificationPolicySummary({
     required this.pendingRequestsCount,
@@ -30,6 +30,10 @@ class MastodonNotificationPolicySummary {
   factory MastodonNotificationPolicySummary.fromJson(
     Map<String, dynamic> json,
   ) => _$MastodonNotificationPolicySummaryFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() =>
+      _$MastodonNotificationPolicySummaryToJson(this);
 
   /// 未処理の通知リクエスト数（最大 100）
   @JsonKey(defaultValue: 0)
@@ -45,7 +49,7 @@ class MastodonNotificationPolicySummary {
 /// `/api/v2/notifications/policy`
 ///
 /// 各カテゴリの通知に対するフィルタリングルールを保持
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonNotificationPolicy {
   const MastodonNotificationPolicy({
     required this.forNotFollowing,
@@ -58,6 +62,9 @@ class MastodonNotificationPolicy {
 
   factory MastodonNotificationPolicy.fromJson(Map<String, dynamic> json) =>
       _$MastodonNotificationPolicyFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonNotificationPolicyToJson(this);
 
   /// フォローしていないアカウントからの通知に対するアクション
   @JsonKey(

--- a/lib/src/models/mastodon_notification_policy.g.dart
+++ b/lib/src/models/mastodon_notification_policy.g.dart
@@ -14,6 +14,13 @@ MastodonNotificationPolicySummary _$MastodonNotificationPolicySummaryFromJson(
       (json['pending_notifications_count'] as num?)?.toInt() ?? 0,
 );
 
+Map<String, dynamic> _$MastodonNotificationPolicySummaryToJson(
+  MastodonNotificationPolicySummary instance,
+) => <String, dynamic>{
+  'pending_requests_count': instance.pendingRequestsCount,
+  'pending_notifications_count': instance.pendingNotificationsCount,
+};
+
 MastodonNotificationPolicy _$MastodonNotificationPolicyFromJson(
   Map<String, dynamic> json,
 ) => MastodonNotificationPolicy(
@@ -48,6 +55,22 @@ MastodonNotificationPolicy _$MastodonNotificationPolicyFromJson(
           json['summary'] as Map<String, dynamic>,
         ),
 );
+
+Map<String, dynamic> _$MastodonNotificationPolicyToJson(
+  MastodonNotificationPolicy instance,
+) => <String, dynamic>{
+  'for_not_following':
+      _$NotificationFilterActionEnumMap[instance.forNotFollowing]!,
+  'for_not_followers':
+      _$NotificationFilterActionEnumMap[instance.forNotFollowers]!,
+  'for_new_accounts':
+      _$NotificationFilterActionEnumMap[instance.forNewAccounts]!,
+  'for_private_mentions':
+      _$NotificationFilterActionEnumMap[instance.forPrivateMentions]!,
+  'for_limited_accounts':
+      _$NotificationFilterActionEnumMap[instance.forLimitedAccounts]!,
+  'summary': instance.summary,
+};
 
 const _$NotificationFilterActionEnumMap = {
   NotificationFilterAction.accept: 'accept',

--- a/lib/src/models/mastodon_notification_request.dart
+++ b/lib/src/models/mastodon_notification_request.dart
@@ -11,7 +11,7 @@ part 'mastodon_notification_request.g.dart';
 /// `/api/v1/notifications/requests`
 ///
 /// 特定のアカウントからフィルタリングされた通知をまとめて保持
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonNotificationRequest {
   const MastodonNotificationRequest({
     required this.id,
@@ -24,6 +24,9 @@ class MastodonNotificationRequest {
 
   factory MastodonNotificationRequest.fromJson(Map<String, dynamic> json) =>
       _$MastodonNotificationRequestFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonNotificationRequestToJson(this);
 
   /// 通知リクエストの内部 ID
   final String id;

--- a/lib/src/models/mastodon_notification_request.g.dart
+++ b/lib/src/models/mastodon_notification_request.g.dart
@@ -22,3 +22,14 @@ MastodonNotificationRequest _$MastodonNotificationRequestFromJson(
       ? null
       : MastodonStatus.fromJson(json['last_status'] as Map<String, dynamic>),
 );
+
+Map<String, dynamic> _$MastodonNotificationRequestToJson(
+  MastodonNotificationRequest instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'created_at': const SafeDateTimeConverter().toJson(instance.createdAt),
+  'updated_at': const SafeDateTimeConverter().toJson(instance.updatedAt),
+  'notifications_count': instance.notificationsCount,
+  'account': instance.account,
+  'last_status': instance.lastStatus,
+};

--- a/lib/src/models/mastodon_oauth_server_metadata.dart
+++ b/lib/src/models/mastodon_oauth_server_metadata.dart
@@ -5,7 +5,7 @@ part 'mastodon_oauth_server_metadata.g.dart';
 /// OAuth 認可サーバーメタデータを表すモデル
 ///
 /// `GET /.well-known/oauth-authorization-server` のレスポンスに対応する
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonOAuthServerMetadata {
   /// 各フィールドを指定して [MastodonOAuthServerMetadata] を生成する
   const MastodonOAuthServerMetadata({
@@ -27,6 +27,9 @@ class MastodonOAuthServerMetadata {
   /// JSON マップから [MastodonOAuthServerMetadata] を生成する
   factory MastodonOAuthServerMetadata.fromJson(Map<String, dynamic> json) =>
       _$MastodonOAuthServerMetadataFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonOAuthServerMetadataToJson(this);
 
   /// 認可サーバーの識別子 URL
   final String issuer;

--- a/lib/src/models/mastodon_oauth_server_metadata.g.dart
+++ b/lib/src/models/mastodon_oauth_server_metadata.g.dart
@@ -37,3 +37,22 @@ MastodonOAuthServerMetadata _$MastodonOAuthServerMetadataFromJson(
           .map((e) => e as String)
           .toList(),
 );
+
+Map<String, dynamic> _$MastodonOAuthServerMetadataToJson(
+  MastodonOAuthServerMetadata instance,
+) => <String, dynamic>{
+  'issuer': instance.issuer,
+  'service_documentation': instance.serviceDocumentation,
+  'authorization_endpoint': instance.authorizationEndpoint,
+  'token_endpoint': instance.tokenEndpoint,
+  'app_registration_endpoint': instance.appRegistrationEndpoint,
+  'revocation_endpoint': instance.revocationEndpoint,
+  'userinfo_endpoint': instance.userinfoEndpoint,
+  'scopes_supported': instance.scopesSupported,
+  'response_types_supported': instance.responseTypesSupported,
+  'response_modes_supported': instance.responseModesSupported,
+  'code_challenge_methods_supported': instance.codeChallengeMethodsSupported,
+  'grant_types_supported': instance.grantTypesSupported,
+  'token_endpoint_auth_methods_supported':
+      instance.tokenEndpointAuthMethodsSupported,
+};

--- a/lib/src/models/mastodon_oauth_user_info.dart
+++ b/lib/src/models/mastodon_oauth_user_info.dart
@@ -5,7 +5,7 @@ part 'mastodon_oauth_user_info.g.dart';
 /// OAuth userinfo エンドポイントのレスポンスを表すモデル
 ///
 /// `GET /oauth/userinfo` のレスポンスに対応する
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonOAuthUserInfo {
   /// 各フィールドを指定して [MastodonOAuthUserInfo] を生成する
   const MastodonOAuthUserInfo({
@@ -20,6 +20,9 @@ class MastodonOAuthUserInfo {
   /// JSON マップから [MastodonOAuthUserInfo] を生成する
   factory MastodonOAuthUserInfo.fromJson(Map<String, dynamic> json) =>
       _$MastodonOAuthUserInfoFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonOAuthUserInfoToJson(this);
 
   /// トークンを発行したインスタンスの URL
   final String iss;

--- a/lib/src/models/mastodon_oauth_user_info.g.dart
+++ b/lib/src/models/mastodon_oauth_user_info.g.dart
@@ -16,3 +16,14 @@ MastodonOAuthUserInfo _$MastodonOAuthUserInfoFromJson(
   profile: json['profile'] as String,
   picture: json['picture'] as String,
 );
+
+Map<String, dynamic> _$MastodonOAuthUserInfoToJson(
+  MastodonOAuthUserInfo instance,
+) => <String, dynamic>{
+  'iss': instance.iss,
+  'sub': instance.sub,
+  'name': instance.name,
+  'preferred_username': instance.preferredUsername,
+  'profile': instance.profile,
+  'picture': instance.picture,
+};

--- a/lib/src/models/mastodon_oembed.dart
+++ b/lib/src/models/mastodon_oembed.dart
@@ -5,7 +5,7 @@ part 'mastodon_oembed.g.dart';
 /// Mastodon の OEmbed メタデータ
 ///
 /// `/api/oembed` のレスポンスに対応する
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonOEmbed {
   const MastodonOEmbed({
     required this.type,
@@ -23,6 +23,9 @@ class MastodonOEmbed {
 
   factory MastodonOEmbed.fromJson(Map<String, dynamic> json) =>
       _$MastodonOEmbedFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonOEmbedToJson(this);
 
   /// OEmbed タイプ。常に `"rich"`
   final String type;

--- a/lib/src/models/mastodon_oembed.g.dart
+++ b/lib/src/models/mastodon_oembed.g.dart
@@ -20,3 +20,18 @@ MastodonOEmbed _$MastodonOEmbedFromJson(Map<String, dynamic> json) =>
       width: (json['width'] as num).toInt(),
       height: (json['height'] as num?)?.toInt(),
     );
+
+Map<String, dynamic> _$MastodonOEmbedToJson(MastodonOEmbed instance) =>
+    <String, dynamic>{
+      'type': instance.type,
+      'version': instance.version,
+      'title': instance.title,
+      'author_name': instance.authorName,
+      'author_url': instance.authorUrl,
+      'provider_name': instance.providerName,
+      'provider_url': instance.providerUrl,
+      'cache_age': instance.cacheAge,
+      'html': instance.html,
+      'width': instance.width,
+      'height': instance.height,
+    };

--- a/lib/src/models/mastodon_partial_account.dart
+++ b/lib/src/models/mastodon_partial_account.dart
@@ -6,7 +6,7 @@ part 'mastodon_partial_account.g.dart';
 ///
 /// グループ化通知APIで返される、必要最低限のアカウント情報を表すモデル。
 /// `expand_accounts=partial_avatars` を指定した場合に使用される。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonPartialAccount {
   const MastodonPartialAccount({
     required this.id,
@@ -20,6 +20,9 @@ class MastodonPartialAccount {
 
   factory MastodonPartialAccount.fromJson(Map<String, dynamic> json) =>
       _$MastodonPartialAccountFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonPartialAccountToJson(this);
 
   /// アカウントID
   final String id;

--- a/lib/src/models/mastodon_partial_account.g.dart
+++ b/lib/src/models/mastodon_partial_account.g.dart
@@ -17,3 +17,15 @@ MastodonPartialAccount _$MastodonPartialAccountFromJson(
   locked: json['locked'] as bool? ?? false,
   bot: json['bot'] as bool? ?? false,
 );
+
+Map<String, dynamic> _$MastodonPartialAccountToJson(
+  MastodonPartialAccount instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'acct': instance.acct,
+  'url': instance.url,
+  'avatar': instance.avatar,
+  'avatar_static': instance.avatarStatic,
+  'locked': instance.locked,
+  'bot': instance.bot,
+};

--- a/lib/src/models/mastodon_poll.dart
+++ b/lib/src/models/mastodon_poll.dart
@@ -6,7 +6,7 @@ import 'mastodon_custom_emoji.dart';
 part 'mastodon_poll.g.dart';
 
 /// 投票の選択肢
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonPollOption {
   const MastodonPollOption({
     required this.title,
@@ -16,6 +16,9 @@ class MastodonPollOption {
   factory MastodonPollOption.fromJson(Map<String, dynamic> json) =>
       _$MastodonPollOptionFromJson(json);
 
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonPollOptionToJson(this);
+
   /// 選択肢のテキスト
   final String title;
 
@@ -24,7 +27,7 @@ class MastodonPollOption {
 }
 
 /// Mastodonの投票
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonPoll {
   const MastodonPoll({
     required this.id,
@@ -41,6 +44,9 @@ class MastodonPoll {
 
   factory MastodonPoll.fromJson(Map<String, dynamic> json) =>
       _$MastodonPollFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonPollToJson(this);
 
   /// 投票の内部ID
   final String id;

--- a/lib/src/models/mastodon_poll.g.dart
+++ b/lib/src/models/mastodon_poll.g.dart
@@ -12,6 +12,12 @@ MastodonPollOption _$MastodonPollOptionFromJson(Map<String, dynamic> json) =>
       votesCount: (json['votes_count'] as num?)?.toInt(),
     );
 
+Map<String, dynamic> _$MastodonPollOptionToJson(MastodonPollOption instance) =>
+    <String, dynamic>{
+      'title': instance.title,
+      'votes_count': instance.votesCount,
+    };
+
 MastodonPoll _$MastodonPollFromJson(Map<String, dynamic> json) => MastodonPoll(
   id: json['id'] as String,
   expired: json['expired'] as bool? ?? false,
@@ -34,3 +40,17 @@ MastodonPoll _$MastodonPollFromJson(Map<String, dynamic> json) => MastodonPoll(
       ?.map((e) => (e as num).toInt())
       .toList(),
 );
+
+Map<String, dynamic> _$MastodonPollToJson(MastodonPoll instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'expires_at': const SafeDateTimeConverter().toJson(instance.expiresAt),
+      'expired': instance.expired,
+      'multiple': instance.multiple,
+      'votes_count': instance.votesCount,
+      'voters_count': instance.votersCount,
+      'options': instance.options,
+      'emojis': instance.emojis,
+      'voted': instance.voted,
+      'own_votes': instance.ownVotes,
+    };

--- a/lib/src/models/mastodon_preferences.dart
+++ b/lib/src/models/mastodon_preferences.dart
@@ -6,7 +6,7 @@ part 'mastodon_preferences.g.dart';
 ///
 /// `GET /api/v1/preferences` で取得される。
 /// 設定の変更は `PATCH /api/v1/accounts/update_credentials` で行う。
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class MastodonPreferences {
   /// 各フィールドを指定して [MastodonPreferences] を生成する
   const MastodonPreferences({
@@ -21,6 +21,9 @@ class MastodonPreferences {
   /// JSON マップから [MastodonPreferences] を生成する
   factory MastodonPreferences.fromJson(Map<String, dynamic> json) =>
       _$MastodonPreferencesFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonPreferencesToJson(this);
 
   /// 新規投稿のデフォルト公開範囲（`public` / `unlisted` / `private` / `direct`）
   @JsonKey(name: 'posting:default:visibility', defaultValue: 'public')

--- a/lib/src/models/mastodon_preferences.g.dart
+++ b/lib/src/models/mastodon_preferences.g.dart
@@ -17,3 +17,14 @@ MastodonPreferences _$MastodonPreferencesFromJson(
   readingExpandMedia: json['reading:expand:media'] as String? ?? 'default',
   readingExpandSpoilers: json['reading:expand:spoilers'] as bool? ?? false,
 );
+
+Map<String, dynamic> _$MastodonPreferencesToJson(
+  MastodonPreferences instance,
+) => <String, dynamic>{
+  'posting:default:visibility': instance.postingDefaultVisibility,
+  'posting:default:sensitive': instance.postingDefaultSensitive,
+  'posting:default:language': instance.postingDefaultLanguage,
+  'posting:default:quote_policy': instance.postingDefaultQuotePolicy,
+  'reading:expand:media': instance.readingExpandMedia,
+  'reading:expand:spoilers': instance.readingExpandSpoilers,
+};

--- a/lib/src/models/mastodon_preview_card.dart
+++ b/lib/src/models/mastodon_preview_card.dart
@@ -21,7 +21,7 @@ enum MastodonPreviewCardType {
 /// リンク先のプレビューカード
 ///
 /// `GET /api/v1/statuses/:id/card` のレスポンスに対応する
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonPreviewCard {
   const MastodonPreviewCard({
     required this.url,
@@ -43,6 +43,9 @@ class MastodonPreviewCard {
 
   factory MastodonPreviewCard.fromJson(Map<String, dynamic> json) =>
       _$MastodonPreviewCardFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonPreviewCardToJson(this);
 
   static Object? _readType(Map<dynamic, dynamic> json, String key) =>
       json['type'] ?? 'link';
@@ -110,12 +113,15 @@ class MastodonPreviewCard {
 }
 
 /// プレビューカードの作成者情報（Mastodon 4.3.0+）
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonPreviewCardAuthor {
   const MastodonPreviewCardAuthor({required this.name, this.url, this.account});
 
   factory MastodonPreviewCardAuthor.fromJson(Map<String, dynamic> json) =>
       _$MastodonPreviewCardAuthorFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonPreviewCardAuthorToJson(this);
 
   /// 作成者の名前
   @JsonKey(defaultValue: '')

--- a/lib/src/models/mastodon_preview_card.g.dart
+++ b/lib/src/models/mastodon_preview_card.g.dart
@@ -37,6 +37,26 @@ MastodonPreviewCard _$MastodonPreviewCardFromJson(Map<String, dynamic> json) =>
       blurhash: json['blurhash'] as String?,
     );
 
+Map<String, dynamic> _$MastodonPreviewCardToJson(
+  MastodonPreviewCard instance,
+) => <String, dynamic>{
+  'url': instance.url,
+  'title': instance.title,
+  'description': instance.description,
+  'type': _$MastodonPreviewCardTypeEnumMap[instance.type]!,
+  'author_name': instance.authorName,
+  'author_url': instance.authorUrl,
+  'provider_name': instance.providerName,
+  'provider_url': instance.providerUrl,
+  'html': instance.html,
+  'width': instance.width,
+  'height': instance.height,
+  'image': instance.image,
+  'embed_url': instance.embedUrl,
+  'blurhash': instance.blurhash,
+  'authors': instance.authors,
+};
+
 const _$MastodonPreviewCardTypeEnumMap = {
   MastodonPreviewCardType.link: 'link',
   MastodonPreviewCardType.photo: 'photo',
@@ -51,3 +71,11 @@ MastodonPreviewCardAuthor _$MastodonPreviewCardAuthorFromJson(
   url: json['url'] as String?,
   account: json['account'] as String?,
 );
+
+Map<String, dynamic> _$MastodonPreviewCardAuthorToJson(
+  MastodonPreviewCardAuthor instance,
+) => <String, dynamic>{
+  'name': instance.name,
+  'url': instance.url,
+  'account': instance.account,
+};

--- a/lib/src/models/mastodon_privacy_policy.dart
+++ b/lib/src/models/mastodon_privacy_policy.dart
@@ -7,7 +7,7 @@ part 'mastodon_privacy_policy.g.dart';
 /// インスタンスのプライバシーポリシー
 ///
 /// `GET /api/v1/instance/privacy_policy`
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonPrivacyPolicy {
   const MastodonPrivacyPolicy({
     this.updatedAt,
@@ -16,6 +16,9 @@ class MastodonPrivacyPolicy {
 
   factory MastodonPrivacyPolicy.fromJson(Map<String, dynamic> json) =>
       _$MastodonPrivacyPolicyFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonPrivacyPolicyToJson(this);
 
   /// プライバシーポリシーの最終更新日時
   @SafeDateTimeConverter()

--- a/lib/src/models/mastodon_privacy_policy.g.dart
+++ b/lib/src/models/mastodon_privacy_policy.g.dart
@@ -14,3 +14,10 @@ MastodonPrivacyPolicy _$MastodonPrivacyPolicyFromJson(
   ),
   content: json['content'] as String? ?? '',
 );
+
+Map<String, dynamic> _$MastodonPrivacyPolicyToJson(
+  MastodonPrivacyPolicy instance,
+) => <String, dynamic>{
+  'updated_at': const SafeDateTimeConverter().toJson(instance.updatedAt),
+  'content': instance.content,
+};

--- a/lib/src/models/mastodon_proof.dart
+++ b/lib/src/models/mastodon_proof.dart
@@ -8,7 +8,7 @@ part 'mastodon_proof.g.dart';
 ///
 /// **非推奨**: Mastodon 3.5.0 以降では本人確認証明機能は削除されている。
 /// 古いサーバーバージョンとの互換性のために提供される。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonProof {
   /// 各フィールドを指定して [MastodonProof] を生成する
   const MastodonProof({
@@ -20,6 +20,9 @@ class MastodonProof {
   factory MastodonProof.fromJson(Map<String, dynamic> json) =>
       _$MastodonProofFromJson(json);
 
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonProofToJson(this);
+
   /// プロバイダー上のアバターURL
   final String avatar;
 
@@ -29,7 +32,7 @@ class MastodonProof {
 }
 
 /// 本人確認証明の署名情報
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonProofSignature {
   /// 各フィールドを指定して [MastodonProofSignature] を生成する
   const MastodonProofSignature({
@@ -40,6 +43,9 @@ class MastodonProofSignature {
   /// JSON マップから [MastodonProofSignature] を生成する
   factory MastodonProofSignature.fromJson(Map<String, dynamic> json) =>
       _$MastodonProofSignatureFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonProofSignatureToJson(this);
 
   /// 署名のハッシュ値
   final String sigHash;

--- a/lib/src/models/mastodon_proof.g.dart
+++ b/lib/src/models/mastodon_proof.g.dart
@@ -19,9 +19,22 @@ MastodonProof _$MastodonProofFromJson(Map<String, dynamic> json) =>
           [],
     );
 
+Map<String, dynamic> _$MastodonProofToJson(MastodonProof instance) =>
+    <String, dynamic>{
+      'avatar': instance.avatar,
+      'signatures': instance.signatures,
+    };
+
 MastodonProofSignature _$MastodonProofSignatureFromJson(
   Map<String, dynamic> json,
 ) => MastodonProofSignature(
   sigHash: json['sig_hash'] as String,
   kbUsername: json['kb_username'] as String,
 );
+
+Map<String, dynamic> _$MastodonProofSignatureToJson(
+  MastodonProofSignature instance,
+) => <String, dynamic>{
+  'sig_hash': instance.sigHash,
+  'kb_username': instance.kbUsername,
+};

--- a/lib/src/models/mastodon_relationship.dart
+++ b/lib/src/models/mastodon_relationship.dart
@@ -3,7 +3,7 @@ import 'package:json_annotation/json_annotation.dart';
 part 'mastodon_relationship.g.dart';
 
 /// 2つのアカウント間のリレーションシップ（フォロー・ブロック・ミュート等の関係）
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonRelationship {
   /// 各フィールドを指定して [MastodonRelationship] を生成する
   const MastodonRelationship({
@@ -27,6 +27,9 @@ class MastodonRelationship {
   /// JSON マップから [MastodonRelationship] を生成する
   factory MastodonRelationship.fromJson(Map<String, dynamic> json) =>
       _$MastodonRelationshipFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonRelationshipToJson(this);
 
   /// 対象アカウントの ID
   final String id;

--- a/lib/src/models/mastodon_relationship.g.dart
+++ b/lib/src/models/mastodon_relationship.g.dart
@@ -27,3 +27,23 @@ MastodonRelationship _$MastodonRelationshipFromJson(
       ?.map((e) => e as String)
       .toList(),
 );
+
+Map<String, dynamic> _$MastodonRelationshipToJson(
+  MastodonRelationship instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'following': instance.following,
+  'showing_reblogs': instance.showingReblogs,
+  'notifying': instance.notifying,
+  'languages': instance.languages,
+  'followed_by': instance.followedBy,
+  'blocking': instance.blocking,
+  'blocked_by': instance.blockedBy,
+  'muting': instance.muting,
+  'muting_notifications': instance.mutingNotifications,
+  'requested': instance.requested,
+  'requested_by': instance.requestedBy,
+  'domain_blocking': instance.domainBlocking,
+  'endorsed': instance.endorsed,
+  'note': instance.note,
+};

--- a/lib/src/models/mastodon_report.dart
+++ b/lib/src/models/mastodon_report.dart
@@ -8,7 +8,7 @@ part 'mastodon_report.g.dart';
 /// 通報エンティティ
 ///
 /// 管理者向け通知やグループ化通知で参照される通報情報を表すモデル。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonReport {
   const MastodonReport({
     required this.id,
@@ -25,6 +25,9 @@ class MastodonReport {
 
   factory MastodonReport.fromJson(Map<String, dynamic> json) =>
       _$MastodonReportFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonReportToJson(this);
 
   /// 通報のID
   final String id;

--- a/lib/src/models/mastodon_report.g.dart
+++ b/lib/src/models/mastodon_report.g.dart
@@ -31,3 +31,19 @@ MastodonReport _$MastodonReportFromJson(Map<String, dynamic> json) =>
               json['target_account'] as Map<String, dynamic>,
             ),
     );
+
+Map<String, dynamic> _$MastodonReportToJson(MastodonReport instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'action_taken': instance.actionTaken,
+      'action_taken_at': const SafeDateTimeConverter().toJson(
+        instance.actionTakenAt,
+      ),
+      'category': instance.category,
+      'comment': instance.comment,
+      'forwarded': instance.forwarded,
+      'created_at': const SafeDateTimeConverter().toJson(instance.createdAt),
+      'status_ids': instance.statusIds,
+      'rule_ids': instance.ruleIds,
+      'target_account': instance.targetAccount,
+    };

--- a/lib/src/models/mastodon_scheduled_status.dart
+++ b/lib/src/models/mastodon_scheduled_status.dart
@@ -6,7 +6,7 @@ import 'mastodon_media_attachment.dart';
 part 'mastodon_scheduled_status.g.dart';
 
 /// 予約投稿を表すモデル
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonScheduledStatus {
   /// 各フィールドを指定して [MastodonScheduledStatus] を生成する
   const MastodonScheduledStatus({
@@ -19,6 +19,9 @@ class MastodonScheduledStatus {
   /// JSON マップから [MastodonScheduledStatus] を生成する
   factory MastodonScheduledStatus.fromJson(Map<String, dynamic> json) =>
       _$MastodonScheduledStatusFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonScheduledStatusToJson(this);
 
   /// 予約投稿のデータベース ID
   final String id;
@@ -36,7 +39,7 @@ class MastodonScheduledStatus {
 }
 
 /// 予約投稿のパラメータ
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonScheduledStatusParams {
   /// 各フィールドを指定して [MastodonScheduledStatusParams] を生成する
   const MastodonScheduledStatusParams({
@@ -54,6 +57,9 @@ class MastodonScheduledStatusParams {
   /// JSON マップから [MastodonScheduledStatusParams] を生成する
   factory MastodonScheduledStatusParams.fromJson(Map<String, dynamic> json) =>
       _$MastodonScheduledStatusParamsFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonScheduledStatusParamsToJson(this);
 
   /// ステータスの本文テキスト
   @JsonKey(defaultValue: '')
@@ -88,7 +94,7 @@ class MastodonScheduledStatusParams {
 }
 
 /// 予約投稿の投票パラメータ
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonScheduledStatusPoll {
   /// 各フィールドを指定して [MastodonScheduledStatusPoll] を生成する
   const MastodonScheduledStatusPoll({
@@ -101,6 +107,9 @@ class MastodonScheduledStatusPoll {
   /// JSON マップから [MastodonScheduledStatusPoll] を生成する
   factory MastodonScheduledStatusPoll.fromJson(Map<String, dynamic> json) =>
       _$MastodonScheduledStatusPollFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonScheduledStatusPollToJson(this);
 
   /// 投票の選択肢
   @JsonKey(defaultValue: [])

--- a/lib/src/models/mastodon_scheduled_status.g.dart
+++ b/lib/src/models/mastodon_scheduled_status.g.dart
@@ -27,6 +27,15 @@ MastodonScheduledStatus _$MastodonScheduledStatusFromJson(
       [],
 );
 
+Map<String, dynamic> _$MastodonScheduledStatusToJson(
+  MastodonScheduledStatus instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'scheduled_at': const SafeDateTimeConverter().toJson(instance.scheduledAt),
+  'params': instance.params,
+  'media_attachments': instance.mediaAttachments,
+};
+
 MastodonScheduledStatusParams _$MastodonScheduledStatusParamsFromJson(
   Map<String, dynamic> json,
 ) => MastodonScheduledStatusParams(
@@ -47,6 +56,20 @@ MastodonScheduledStatusParams _$MastodonScheduledStatusParamsFromJson(
   idempotency: json['idempotency'] as String?,
 );
 
+Map<String, dynamic> _$MastodonScheduledStatusParamsToJson(
+  MastodonScheduledStatusParams instance,
+) => <String, dynamic>{
+  'text': instance.text,
+  'poll': instance.poll,
+  'media_ids': instance.mediaIds,
+  'sensitive': instance.sensitive,
+  'spoiler_text': instance.spoilerText,
+  'visibility': instance.visibility,
+  'in_reply_to_id': instance.inReplyToId,
+  'language': instance.language,
+  'idempotency': instance.idempotency,
+};
+
 MastodonScheduledStatusPoll _$MastodonScheduledStatusPollFromJson(
   Map<String, dynamic> json,
 ) => MastodonScheduledStatusPoll(
@@ -57,3 +80,12 @@ MastodonScheduledStatusPoll _$MastodonScheduledStatusPollFromJson(
   multiple: json['multiple'] as bool?,
   hideTotals: json['hide_totals'] as bool?,
 );
+
+Map<String, dynamic> _$MastodonScheduledStatusPollToJson(
+  MastodonScheduledStatusPoll instance,
+) => <String, dynamic>{
+  'options': instance.options,
+  'expires_in': instance.expiresIn,
+  'multiple': instance.multiple,
+  'hide_totals': instance.hideTotals,
+};

--- a/lib/src/models/mastodon_search_result.dart
+++ b/lib/src/models/mastodon_search_result.dart
@@ -9,7 +9,7 @@ part 'mastodon_search_result.g.dart';
 ///
 /// `GET /api/v2/search` のレスポンスに対応する。
 /// [hashtags] は [MastodonTag] オブジェクトの配列として返される。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonSearchResult {
   const MastodonSearchResult({
     required this.accounts,
@@ -19,6 +19,9 @@ class MastodonSearchResult {
 
   factory MastodonSearchResult.fromJson(Map<String, dynamic> json) =>
       _$MastodonSearchResultFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonSearchResultToJson(this);
 
   /// 検索にマッチしたアカウントの一覧
   @JsonKey(defaultValue: <MastodonAccount>[])
@@ -42,7 +45,7 @@ class MastodonSearchResult {
 /// Mastodon 3.0.0 で v1 search エンドポイントは削除されたため、
 /// 2.x 系以前のインスタンスでのみ使用可能。
 @Deprecated('Mastodon 3.0.0 で削除済み。代わりに MastodonSearchResult (v2) を使用してください')
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonSearchResultV1 {
   @Deprecated('Mastodon 3.0.0 で削除済み。代わりに MastodonSearchResult (v2) を使用してください')
   const MastodonSearchResultV1({
@@ -54,6 +57,9 @@ class MastodonSearchResultV1 {
   @Deprecated('Mastodon 3.0.0 で削除済み。代わりに MastodonSearchResult (v2) を使用してください')
   factory MastodonSearchResultV1.fromJson(Map<String, dynamic> json) =>
       _$MastodonSearchResultV1FromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonSearchResultV1ToJson(this);
 
   /// 検索にマッチしたアカウントの一覧
   @JsonKey(defaultValue: <MastodonAccount>[])

--- a/lib/src/models/mastodon_search_result.g.dart
+++ b/lib/src/models/mastodon_search_result.g.dart
@@ -26,6 +26,14 @@ MastodonSearchResult _$MastodonSearchResultFromJson(
       [],
 );
 
+Map<String, dynamic> _$MastodonSearchResultToJson(
+  MastodonSearchResult instance,
+) => <String, dynamic>{
+  'accounts': instance.accounts,
+  'statuses': instance.statuses,
+  'hashtags': instance.hashtags,
+};
+
 MastodonSearchResultV1 _$MastodonSearchResultV1FromJson(
   Map<String, dynamic> json,
 ) => MastodonSearchResultV1(
@@ -43,3 +51,11 @@ MastodonSearchResultV1 _$MastodonSearchResultV1FromJson(
       (json['hashtags'] as List<dynamic>?)?.map((e) => e as String).toList() ??
       [],
 );
+
+Map<String, dynamic> _$MastodonSearchResultV1ToJson(
+  MastodonSearchResultV1 instance,
+) => <String, dynamic>{
+  'accounts': instance.accounts,
+  'statuses': instance.statuses,
+  'hashtags': instance.hashtags,
+};

--- a/lib/src/models/mastodon_status.dart
+++ b/lib/src/models/mastodon_status.dart
@@ -21,7 +21,7 @@ enum MastodonVisibility {
 }
 
 /// メンション（投稿内の`@username`部分）
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonMention {
   const MastodonMention({
     required this.id,
@@ -33,6 +33,9 @@ class MastodonMention {
   factory MastodonMention.fromJson(Map<String, dynamic> json) =>
       _$MastodonMentionFromJson(json);
 
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonMentionToJson(this);
+
   final String id;
   final String username;
   final String acct;
@@ -42,7 +45,7 @@ class MastodonMention {
 /// Mastodon の投稿（Status）
 ///
 /// `/api/v1/statuses/:id`や各タイムラインAPIのレスポンスに対応する
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonStatus {
   const MastodonStatus({
     required this.id,
@@ -78,6 +81,9 @@ class MastodonStatus {
 
   factory MastodonStatus.fromJson(Map<String, dynamic> json) =>
       _$MastodonStatusFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonStatusToJson(this);
 
   static Object? _readVisibility(Map<dynamic, dynamic> json, String key) =>
       json['visibility'] ?? 'public';

--- a/lib/src/models/mastodon_status.g.dart
+++ b/lib/src/models/mastodon_status.g.dart
@@ -14,6 +14,14 @@ MastodonMention _$MastodonMentionFromJson(Map<String, dynamic> json) =>
       url: json['url'] as String,
     );
 
+Map<String, dynamic> _$MastodonMentionToJson(MastodonMention instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'username': instance.username,
+      'acct': instance.acct,
+      'url': instance.url,
+    };
+
 MastodonStatus _$MastodonStatusFromJson(
   Map<String, dynamic> json,
 ) => MastodonStatus(
@@ -67,6 +75,39 @@ MastodonStatus _$MastodonStatusFromJson(
       ? null
       : MastodonStatus.fromJson(json['quote'] as Map<String, dynamic>),
 );
+
+Map<String, dynamic> _$MastodonStatusToJson(MastodonStatus instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'uri': instance.uri,
+      'url': instance.url,
+      'created_at': instance.createdAt.toIso8601String(),
+      'in_reply_to_id': instance.inReplyToId,
+      'in_reply_to_account_id': instance.inReplyToAccountId,
+      'sensitive': instance.sensitive,
+      'spoiler_text': instance.spoilerText,
+      'visibility': _$MastodonVisibilityEnumMap[instance.visibility]!,
+      'language': instance.language,
+      'content': instance.content,
+      'text': instance.text,
+      'edited_at': const SafeDateTimeConverter().toJson(instance.editedAt),
+      'reblogs_count': instance.reblogsCount,
+      'favourites_count': instance.favouritesCount,
+      'replies_count': instance.repliesCount,
+      'favourited': instance.favourited,
+      'reblogged': instance.reblogged,
+      'bookmarked': instance.bookmarked,
+      'muted': instance.muted,
+      'pinned': instance.pinned,
+      'account': instance.account,
+      'media_attachments': instance.mediaAttachments,
+      'mentions': instance.mentions,
+      'tags': instance.tags,
+      'emojis': instance.emojis,
+      'reblog': instance.reblog,
+      'poll': instance.poll,
+      'quote': instance.quote,
+    };
 
 const _$MastodonVisibilityEnumMap = {
   MastodonVisibility.public: 'public',

--- a/lib/src/models/mastodon_status_context.dart
+++ b/lib/src/models/mastodon_status_context.dart
@@ -7,7 +7,7 @@ part 'mastodon_status_context.g.dart';
 /// 投稿のコンテキスト（祖先と子孫）
 ///
 /// `GET /api/v1/statuses/{id}/context` のレスポンスに対応する
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonStatusContext {
   const MastodonStatusContext({
     required this.ancestors,
@@ -16,6 +16,9 @@ class MastodonStatusContext {
 
   factory MastodonStatusContext.fromJson(Map<String, dynamic> json) =>
       _$MastodonStatusContextFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonStatusContextToJson(this);
 
   /// 対象投稿より前の投稿（スレッドの先祖）
   @JsonKey(defaultValue: <MastodonStatus>[])

--- a/lib/src/models/mastodon_status_context.g.dart
+++ b/lib/src/models/mastodon_status_context.g.dart
@@ -20,3 +20,10 @@ MastodonStatusContext _$MastodonStatusContextFromJson(
           .toList() ??
       [],
 );
+
+Map<String, dynamic> _$MastodonStatusContextToJson(
+  MastodonStatusContext instance,
+) => <String, dynamic>{
+  'ancestors': instance.ancestors,
+  'descendants': instance.descendants,
+};

--- a/lib/src/models/mastodon_status_edit.dart
+++ b/lib/src/models/mastodon_status_edit.dart
@@ -10,7 +10,7 @@ part 'mastodon_status_edit.g.dart';
 ///
 /// `GET /api/v1/statuses/:id/history` のレスポンス要素に対応する
 /// 各リビジョンの時点での投稿内容を保持する。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonStatusEdit {
   const MastodonStatusEdit({
     required this.content,
@@ -25,6 +25,9 @@ class MastodonStatusEdit {
 
   factory MastodonStatusEdit.fromJson(Map<String, dynamic> json) =>
       _$MastodonStatusEditFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonStatusEditToJson(this);
 
   /// リビジョン時点の投稿本文（HTML形式）
   @JsonKey(defaultValue: '')
@@ -59,12 +62,15 @@ class MastodonStatusEdit {
 /// 編集履歴内の投票スナップショット。
 ///
 /// `MastodonPoll` とは異なり、投票結果を持たない選択肢のみの構造
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonStatusEditPoll {
   const MastodonStatusEditPoll({required this.options});
 
   factory MastodonStatusEditPoll.fromJson(Map<String, dynamic> json) =>
       _$MastodonStatusEditPollFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonStatusEditPollToJson(this);
 
   /// 投票の選択肢リスト
   @JsonKey(defaultValue: <MastodonStatusEditPollOption>[])
@@ -72,12 +78,15 @@ class MastodonStatusEditPoll {
 }
 
 /// 編集履歴内の投票選択肢
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonStatusEditPollOption {
   const MastodonStatusEditPollOption({required this.title});
 
   factory MastodonStatusEditPollOption.fromJson(Map<String, dynamic> json) =>
       _$MastodonStatusEditPollOptionFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonStatusEditPollOptionToJson(this);
 
   /// 選択肢のテキスト
   final String title;

--- a/lib/src/models/mastodon_status_edit.g.dart
+++ b/lib/src/models/mastodon_status_edit.g.dart
@@ -31,6 +31,18 @@ MastodonStatusEdit _$MastodonStatusEditFromJson(
       : MastodonStatusEditPoll.fromJson(json['poll'] as Map<String, dynamic>),
 );
 
+Map<String, dynamic> _$MastodonStatusEditToJson(MastodonStatusEdit instance) =>
+    <String, dynamic>{
+      'content': instance.content,
+      'spoiler_text': instance.spoilerText,
+      'sensitive': instance.sensitive,
+      'created_at': instance.createdAt.toIso8601String(),
+      'account': instance.account,
+      'media_attachments': instance.mediaAttachments,
+      'emojis': instance.emojis,
+      'poll': instance.poll,
+    };
+
 MastodonStatusEditPoll _$MastodonStatusEditPollFromJson(
   Map<String, dynamic> json,
 ) => MastodonStatusEditPoll(
@@ -45,6 +57,14 @@ MastodonStatusEditPoll _$MastodonStatusEditPollFromJson(
       [],
 );
 
+Map<String, dynamic> _$MastodonStatusEditPollToJson(
+  MastodonStatusEditPoll instance,
+) => <String, dynamic>{'options': instance.options};
+
 MastodonStatusEditPollOption _$MastodonStatusEditPollOptionFromJson(
   Map<String, dynamic> json,
 ) => MastodonStatusEditPollOption(title: json['title'] as String);
+
+Map<String, dynamic> _$MastodonStatusEditPollOptionToJson(
+  MastodonStatusEditPollOption instance,
+) => <String, dynamic>{'title': instance.title};

--- a/lib/src/models/mastodon_status_source.dart
+++ b/lib/src/models/mastodon_status_source.dart
@@ -7,7 +7,7 @@ part 'mastodon_status_source.g.dart';
 /// `GET /api/v1/statuses/:id/source`
 ///
 /// 編集画面で使用するプレーンテキストの投稿内容を保持
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonStatusSource {
   const MastodonStatusSource({
     required this.id,
@@ -17,6 +17,9 @@ class MastodonStatusSource {
 
   factory MastodonStatusSource.fromJson(Map<String, dynamic> json) =>
       _$MastodonStatusSourceFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonStatusSourceToJson(this);
 
   /// 投稿の内部ID
   final String id;

--- a/lib/src/models/mastodon_status_source.g.dart
+++ b/lib/src/models/mastodon_status_source.g.dart
@@ -13,3 +13,11 @@ MastodonStatusSource _$MastodonStatusSourceFromJson(
   text: json['text'] as String,
   spoilerText: json['spoiler_text'] as String? ?? '',
 );
+
+Map<String, dynamic> _$MastodonStatusSourceToJson(
+  MastodonStatusSource instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'text': instance.text,
+  'spoiler_text': instance.spoilerText,
+};

--- a/lib/src/models/mastodon_suggestion.dart
+++ b/lib/src/models/mastodon_suggestion.dart
@@ -5,7 +5,7 @@ import 'mastodon_account.dart';
 part 'mastodon_suggestion.g.dart';
 
 /// フォロー候補として提案されたアカウントとその理由
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonSuggestion {
   /// 各フィールドを指定して [MastodonSuggestion] を生成する
   const MastodonSuggestion({
@@ -16,6 +16,9 @@ class MastodonSuggestion {
   /// JSON マップから [MastodonSuggestion] を生成する
   factory MastodonSuggestion.fromJson(Map<String, dynamic> json) =>
       _$MastodonSuggestionFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonSuggestionToJson(this);
 
   /// 提案の理由を示す文字列
   ///

--- a/lib/src/models/mastodon_suggestion.g.dart
+++ b/lib/src/models/mastodon_suggestion.g.dart
@@ -13,3 +13,6 @@ MastodonSuggestion _$MastodonSuggestionFromJson(Map<String, dynamic> json) =>
         json['account'] as Map<String, dynamic>,
       ),
     );
+
+Map<String, dynamic> _$MastodonSuggestionToJson(MastodonSuggestion instance) =>
+    <String, dynamic>{'source': instance.source, 'account': instance.account};

--- a/lib/src/models/mastodon_tag.dart
+++ b/lib/src/models/mastodon_tag.dart
@@ -3,7 +3,7 @@ import 'package:json_annotation/json_annotation.dart';
 part 'mastodon_tag.g.dart';
 
 /// ハッシュタグ情報を表すモデル
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonTag {
   /// 各フィールドを指定して [MastodonTag] を生成する
   const MastodonTag({
@@ -18,6 +18,9 @@ class MastodonTag {
   /// JSON マップから [MastodonTag] を生成する
   factory MastodonTag.fromJson(Map<String, dynamic> json) =>
       _$MastodonTagFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonTagToJson(this);
 
   /// タグのデータベース ID
   @JsonKey(defaultValue: '')
@@ -42,7 +45,7 @@ class MastodonTag {
 }
 
 /// ハッシュタグの日別利用統計
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonTagHistory {
   /// 各フィールドを指定して [MastodonTagHistory] を生成する
   const MastodonTagHistory({
@@ -54,6 +57,9 @@ class MastodonTagHistory {
   /// JSON マップから [MastodonTagHistory] を生成する
   factory MastodonTagHistory.fromJson(Map<String, dynamic> json) =>
       _$MastodonTagHistoryFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonTagHistoryToJson(this);
 
   /// 該当日の深夜0時の UNIX タイムスタンプ（文字列）
   final String day;

--- a/lib/src/models/mastodon_tag.g.dart
+++ b/lib/src/models/mastodon_tag.g.dart
@@ -19,9 +19,26 @@ MastodonTag _$MastodonTagFromJson(Map<String, dynamic> json) => MastodonTag(
   featuring: json['featuring'] as bool?,
 );
 
+Map<String, dynamic> _$MastodonTagToJson(MastodonTag instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'url': instance.url,
+      'history': instance.history,
+      'following': instance.following,
+      'featuring': instance.featuring,
+    };
+
 MastodonTagHistory _$MastodonTagHistoryFromJson(Map<String, dynamic> json) =>
     MastodonTagHistory(
       day: json['day'] as String,
       uses: json['uses'] as String,
       accounts: json['accounts'] as String,
     );
+
+Map<String, dynamic> _$MastodonTagHistoryToJson(MastodonTagHistory instance) =>
+    <String, dynamic>{
+      'day': instance.day,
+      'uses': instance.uses,
+      'accounts': instance.accounts,
+    };

--- a/lib/src/models/mastodon_terms_of_service.dart
+++ b/lib/src/models/mastodon_terms_of_service.dart
@@ -5,7 +5,7 @@ part 'mastodon_terms_of_service.g.dart';
 /// インスタンスの利用規約
 ///
 /// `GET /api/v1/instance/terms_of_service`
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonTermsOfService {
   const MastodonTermsOfService({
     required this.effectiveDate,
@@ -16,6 +16,9 @@ class MastodonTermsOfService {
 
   factory MastodonTermsOfService.fromJson(Map<String, dynamic> json) =>
       _$MastodonTermsOfServiceFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonTermsOfServiceToJson(this);
 
   /// 利用規約の発効日
   final String effectiveDate;

--- a/lib/src/models/mastodon_terms_of_service.g.dart
+++ b/lib/src/models/mastodon_terms_of_service.g.dart
@@ -14,3 +14,12 @@ MastodonTermsOfService _$MastodonTermsOfServiceFromJson(
   content: json['content'] as String? ?? '',
   succeededBy: json['succeeded_by'] as String?,
 );
+
+Map<String, dynamic> _$MastodonTermsOfServiceToJson(
+  MastodonTermsOfService instance,
+) => <String, dynamic>{
+  'effective_date': instance.effectiveDate,
+  'effective': instance.effective,
+  'content': instance.content,
+  'succeeded_by': instance.succeededBy,
+};

--- a/lib/src/models/mastodon_token.dart
+++ b/lib/src/models/mastodon_token.dart
@@ -3,7 +3,7 @@ import 'package:json_annotation/json_annotation.dart';
 part 'mastodon_token.g.dart';
 
 /// OAuth アクセストークン
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonToken {
   /// 各フィールドを指定して [MastodonToken] を生成する
   const MastodonToken({
@@ -16,6 +16,9 @@ class MastodonToken {
   /// JSON マップから [MastodonToken] を生成する
   factory MastodonToken.fromJson(Map<String, dynamic> json) =>
       _$MastodonTokenFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonTokenToJson(this);
 
   /// 認可に使用する OAuth トークン文字列
   final String accessToken;

--- a/lib/src/models/mastodon_token.g.dart
+++ b/lib/src/models/mastodon_token.g.dart
@@ -13,3 +13,11 @@ MastodonToken _$MastodonTokenFromJson(Map<String, dynamic> json) =>
       scope: json['scope'] as String,
       createdAt: (json['created_at'] as num).toInt(),
     );
+
+Map<String, dynamic> _$MastodonTokenToJson(MastodonToken instance) =>
+    <String, dynamic>{
+      'access_token': instance.accessToken,
+      'token_type': instance.tokenType,
+      'scope': instance.scope,
+      'created_at': instance.createdAt,
+    };

--- a/lib/src/models/mastodon_translation.dart
+++ b/lib/src/models/mastodon_translation.dart
@@ -5,7 +5,7 @@ part 'mastodon_translation.g.dart';
 /// 投稿の翻訳結果
 ///
 /// `POST /api/v1/statuses/:id/translate`
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonTranslation {
   const MastodonTranslation({
     required this.content,
@@ -19,6 +19,9 @@ class MastodonTranslation {
 
   factory MastodonTranslation.fromJson(Map<String, dynamic> json) =>
       _$MastodonTranslationFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonTranslationToJson(this);
 
   /// 翻訳済みの投稿本文（HTML形式）
   @JsonKey(defaultValue: '')
@@ -49,7 +52,7 @@ class MastodonTranslation {
 }
 
 /// 翻訳結果内のメディア添付情報
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonTranslationAttachment {
   const MastodonTranslationAttachment({
     required this.id,
@@ -58,6 +61,9 @@ class MastodonTranslationAttachment {
 
   factory MastodonTranslationAttachment.fromJson(Map<String, dynamic> json) =>
       _$MastodonTranslationAttachmentFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonTranslationAttachmentToJson(this);
 
   /// メディアの内部ID
   final String id;
@@ -68,7 +74,7 @@ class MastodonTranslationAttachment {
 }
 
 /// 翻訳結果内の投票情報
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonTranslationPoll {
   const MastodonTranslationPoll({
     required this.id,
@@ -77,6 +83,9 @@ class MastodonTranslationPoll {
 
   factory MastodonTranslationPoll.fromJson(Map<String, dynamic> json) =>
       _$MastodonTranslationPollFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonTranslationPollToJson(this);
 
   /// 投票の内部ID
   final String id;
@@ -87,12 +96,15 @@ class MastodonTranslationPoll {
 }
 
 /// 翻訳結果内の投票選択肢
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonTranslationPollOption {
   const MastodonTranslationPollOption({required this.title});
 
   factory MastodonTranslationPollOption.fromJson(Map<String, dynamic> json) =>
       _$MastodonTranslationPollOptionFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonTranslationPollOptionToJson(this);
 
   /// 翻訳済みの選択肢テキスト
   final String title;

--- a/lib/src/models/mastodon_translation.g.dart
+++ b/lib/src/models/mastodon_translation.g.dart
@@ -29,12 +29,28 @@ MastodonTranslation _$MastodonTranslationFromJson(Map<String, dynamic> json) =>
             ),
     );
 
+Map<String, dynamic> _$MastodonTranslationToJson(
+  MastodonTranslation instance,
+) => <String, dynamic>{
+  'content': instance.content,
+  'spoiler_text': instance.spoilerText,
+  'language': instance.language,
+  'detected_source_language': instance.detectedSourceLanguage,
+  'provider': instance.provider,
+  'media_attachments': instance.mediaAttachments,
+  'poll': instance.poll,
+};
+
 MastodonTranslationAttachment _$MastodonTranslationAttachmentFromJson(
   Map<String, dynamic> json,
 ) => MastodonTranslationAttachment(
   id: json['id'] as String,
   description: json['description'] as String? ?? '',
 );
+
+Map<String, dynamic> _$MastodonTranslationAttachmentToJson(
+  MastodonTranslationAttachment instance,
+) => <String, dynamic>{'id': instance.id, 'description': instance.description};
 
 MastodonTranslationPoll _$MastodonTranslationPollFromJson(
   Map<String, dynamic> json,
@@ -51,6 +67,14 @@ MastodonTranslationPoll _$MastodonTranslationPollFromJson(
       [],
 );
 
+Map<String, dynamic> _$MastodonTranslationPollToJson(
+  MastodonTranslationPoll instance,
+) => <String, dynamic>{'id': instance.id, 'options': instance.options};
+
 MastodonTranslationPollOption _$MastodonTranslationPollOptionFromJson(
   Map<String, dynamic> json,
 ) => MastodonTranslationPollOption(title: json['title'] as String);
+
+Map<String, dynamic> _$MastodonTranslationPollOptionToJson(
+  MastodonTranslationPollOption instance,
+) => <String, dynamic>{'title': instance.title};

--- a/lib/src/models/mastodon_trends_link.dart
+++ b/lib/src/models/mastodon_trends_link.dart
@@ -5,7 +5,7 @@ import 'mastodon_preview_card.dart';
 part 'mastodon_trends_link.g.dart';
 
 /// トレンドリンクの利用履歴（日別統計）
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonTrendsLinkHistory {
   const MastodonTrendsLinkHistory({
     required this.day,
@@ -15,6 +15,9 @@ class MastodonTrendsLinkHistory {
 
   factory MastodonTrendsLinkHistory.fromJson(Map<String, dynamic> json) =>
       _$MastodonTrendsLinkHistoryFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonTrendsLinkHistoryToJson(this);
 
   /// UNIX タイムスタンプ（秒）を文字列で表した日付
   @JsonKey(defaultValue: '0')
@@ -33,7 +36,7 @@ class MastodonTrendsLinkHistory {
 ///
 /// `GET /api/v1/trends/links` のレスポンスに対応する。
 /// [MastodonPreviewCard] の全フィールドに加え、トレンド固有の [history] を持つ。
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonTrendsLink {
   const MastodonTrendsLink({
     required this.url,
@@ -56,6 +59,9 @@ class MastodonTrendsLink {
 
   factory MastodonTrendsLink.fromJson(Map<String, dynamic> json) =>
       _$MastodonTrendsLinkFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonTrendsLinkToJson(this);
 
   static Object? _readType(Map<dynamic, dynamic> json, String key) =>
       json['type'] ?? 'link';

--- a/lib/src/models/mastodon_trends_link.g.dart
+++ b/lib/src/models/mastodon_trends_link.g.dart
@@ -14,6 +14,14 @@ MastodonTrendsLinkHistory _$MastodonTrendsLinkHistoryFromJson(
   uses: json['uses'] as String? ?? '0',
 );
 
+Map<String, dynamic> _$MastodonTrendsLinkHistoryToJson(
+  MastodonTrendsLinkHistory instance,
+) => <String, dynamic>{
+  'day': instance.day,
+  'accounts': instance.accounts,
+  'uses': instance.uses,
+};
+
 MastodonTrendsLink _$MastodonTrendsLinkFromJson(
   Map<String, dynamic> json,
 ) => MastodonTrendsLink(
@@ -52,6 +60,26 @@ MastodonTrendsLink _$MastodonTrendsLinkFromJson(
   image: json['image'] as String?,
   blurhash: json['blurhash'] as String?,
 );
+
+Map<String, dynamic> _$MastodonTrendsLinkToJson(MastodonTrendsLink instance) =>
+    <String, dynamic>{
+      'url': instance.url,
+      'title': instance.title,
+      'description': instance.description,
+      'type': _$MastodonPreviewCardTypeEnumMap[instance.type]!,
+      'author_name': instance.authorName,
+      'author_url': instance.authorUrl,
+      'provider_name': instance.providerName,
+      'provider_url': instance.providerUrl,
+      'html': instance.html,
+      'width': instance.width,
+      'height': instance.height,
+      'image': instance.image,
+      'embed_url': instance.embedUrl,
+      'blurhash': instance.blurhash,
+      'authors': instance.authors,
+      'history': instance.history,
+    };
 
 const _$MastodonPreviewCardTypeEnumMap = {
   MastodonPreviewCardType.link: 'link',

--- a/lib/src/models/mastodon_unread_notification_count.dart
+++ b/lib/src/models/mastodon_unread_notification_count.dart
@@ -5,13 +5,17 @@ part 'mastodon_unread_notification_count.g.dart';
 /// 未読通知の件数（Mastodon 4.3+）
 ///
 /// `GET /api/v1/notifications/unread_count`
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonUnreadNotificationCount {
   const MastodonUnreadNotificationCount({required this.count});
 
   factory MastodonUnreadNotificationCount.fromJson(
     Map<String, dynamic> json,
   ) => _$MastodonUnreadNotificationCountFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() =>
+      _$MastodonUnreadNotificationCountToJson(this);
 
   /// 未読通知の件数
   @JsonKey(defaultValue: 0)

--- a/lib/src/models/mastodon_unread_notification_count.g.dart
+++ b/lib/src/models/mastodon_unread_notification_count.g.dart
@@ -11,3 +11,7 @@ MastodonUnreadNotificationCount _$MastodonUnreadNotificationCountFromJson(
 ) => MastodonUnreadNotificationCount(
   count: (json['count'] as num?)?.toInt() ?? 0,
 );
+
+Map<String, dynamic> _$MastodonUnreadNotificationCountToJson(
+  MastodonUnreadNotificationCount instance,
+) => <String, dynamic>{'count': instance.count};

--- a/lib/src/models/mastodon_web_push_subscription.dart
+++ b/lib/src/models/mastodon_web_push_subscription.dart
@@ -5,7 +5,7 @@ part 'mastodon_web_push_subscription.g.dart';
 /// Web Push 通知のアラート種別ごとの設定
 ///
 /// 各フィールドは、対応する通知タイプの Push 通知を受け取るかどうかを表す
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonPushAlerts {
   const MastodonPushAlerts({
     required this.mention,
@@ -24,6 +24,9 @@ class MastodonPushAlerts {
 
   factory MastodonPushAlerts.fromJson(Map<String, dynamic> json) =>
       _$MastodonPushAlertsFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonPushAlertsToJson(this);
 
   /// メンション通知を受け取るかどうか
   @JsonKey(defaultValue: false)
@@ -78,7 +81,7 @@ class MastodonPushAlerts {
 ///
 /// `/api/v1/push/subscription` で取得・作成・更新される
 /// Push 通知の受信設定を表すエンティティ
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonWebPushSubscription {
   const MastodonWebPushSubscription({
     required this.id,
@@ -91,6 +94,9 @@ class MastodonWebPushSubscription {
 
   factory MastodonWebPushSubscription.fromJson(Map<String, dynamic> json) =>
       _$MastodonWebPushSubscriptionFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonWebPushSubscriptionToJson(this);
 
   /// サブスクリプション ID
   final String id;

--- a/lib/src/models/mastodon_web_push_subscription.g.dart
+++ b/lib/src/models/mastodon_web_push_subscription.g.dart
@@ -22,6 +22,22 @@ MastodonPushAlerts _$MastodonPushAlertsFromJson(Map<String, dynamic> json) =>
       adminReport: json['admin.report'] as bool? ?? false,
     );
 
+Map<String, dynamic> _$MastodonPushAlertsToJson(MastodonPushAlerts instance) =>
+    <String, dynamic>{
+      'mention': instance.mention,
+      'quote': instance.quote,
+      'status': instance.status,
+      'reblog': instance.reblog,
+      'follow': instance.follow,
+      'follow_request': instance.followRequest,
+      'favourite': instance.favourite,
+      'poll': instance.poll,
+      'update': instance.update,
+      'quoted_update': instance.quotedUpdate,
+      'admin.sign_up': instance.adminSignUp,
+      'admin.report': instance.adminReport,
+    };
+
 MastodonWebPushSubscription _$MastodonWebPushSubscriptionFromJson(
   Map<String, dynamic> json,
 ) => MastodonWebPushSubscription(
@@ -32,3 +48,14 @@ MastodonWebPushSubscription _$MastodonWebPushSubscriptionFromJson(
   policy: json['policy'] as String,
   standard: json['standard'] as bool?,
 );
+
+Map<String, dynamic> _$MastodonWebPushSubscriptionToJson(
+  MastodonWebPushSubscription instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'endpoint': instance.endpoint,
+  'server_key': instance.serverKey,
+  'alerts': instance.alerts,
+  'policy': instance.policy,
+  'standard': instance.standard,
+};

--- a/lib/src/models/mastodon_weekly_activity.dart
+++ b/lib/src/models/mastodon_weekly_activity.dart
@@ -5,7 +5,7 @@ part 'mastodon_weekly_activity.g.dart';
 /// インスタンスの週間アクティビティ統計
 ///
 /// `GET /api/v1/instance/activity`
-@JsonSerializable(createToJson: false, fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonWeeklyActivity {
   const MastodonWeeklyActivity({
     required this.week,
@@ -16,6 +16,9 @@ class MastodonWeeklyActivity {
 
   factory MastodonWeeklyActivity.fromJson(Map<String, dynamic> json) =>
       _$MastodonWeeklyActivityFromJson(json);
+
+  /// JSON シリアライズ
+  Map<String, dynamic> toJson() => _$MastodonWeeklyActivityToJson(this);
 
   /// 週の開始時点の UNIX タイムスタンプ（文字列）
   @JsonKey(defaultValue: '0')

--- a/lib/src/models/mastodon_weekly_activity.g.dart
+++ b/lib/src/models/mastodon_weekly_activity.g.dart
@@ -14,3 +14,12 @@ MastodonWeeklyActivity _$MastodonWeeklyActivityFromJson(
   logins: json['logins'] as String? ?? '0',
   registrations: json['registrations'] as String? ?? '0',
 );
+
+Map<String, dynamic> _$MastodonWeeklyActivityToJson(
+  MastodonWeeklyActivity instance,
+) => <String, dynamic>{
+  'week': instance.week,
+  'statuses': instance.statuses,
+  'logins': instance.logins,
+  'registrations': instance.registrations,
+};


### PR DESCRIPTION
pub.dev公開およびライブラリ利用者のローカルキャッシュ・デバッグ用途に対応するため、全レスポンスモデルの @JsonSerializable(createToJson: false) を解除し toJson() を追加。