### PR TITLE
issue #13: 主要エンティティの欠落フィールドを実装

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `MastodonWebPushSubscription.id`: `String` → `String?`
   - `MastodonNotificationGroup.mostRecentNotificationId`: `String` → `String?`
 - **Breaking:** `MastodonOEmbed.title`, `.authorName`, `.authorUrl`, `.providerName`, and `.providerUrl` are now `String?`. Real responses omit them for some providers, so the previous non-nullable typing could not represent them
+- `MastodonRole` now lives in `mastodon_account.dart` instead of `mastodon_credential_account.dart`, so that both `MastodonAccount.roles` and `MastodonCredentialAccount.role` can reference it without a circular import. The class itself is unchanged and is still exported from `package:mastodon_client/mastodon_client.dart`
 - Refreshed fixtures against a live, federated world (multi-account, cross-server posts/reactions/follows) via the fixture collection tool in `fediverse_e2e`, replacing the single-server March snapshot. Corresponding model tests were updated to assert on structural properties rather than hardcoded IDs/counts where the underlying data is inherently dynamic (timestamps, counters, federated content). Notably `MastodonCredentialAccount`'s `role: Owner` fixture now comes from an actual admin-scoped account rather than a stub
 
 ### Added
@@ -30,6 +31,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tests covering the `unknownEnumValue` fallback for `MastodonFilterAction`, `MastodonTimelineAccessLevel`, `MastodonPreviewCardType`, `MastodonMediaType`, `MastodonVisibility`, `MastodonAdminIpBlockSeverity`, and `MastodonAdminDomainBlockSeverity` when the server returns a value not yet known to this client
 - Tests for the HTTP error conversion logic (`convertDioException`): all status-code branches (401/403/404/422/429/5xx/unmapped), error body parsing (`{"error": "..."}` extraction and fallbacks), retry-after header parsing, and network-level errors (connection/timeout/cancel)
 - Tests pinning the `int` → `String` coercion of `MastodonRole.id` and `MastodonAdminRole.id`, and the deserialization of every Mastodon 4.6.0 field from a live server response
+- `MastodonStatus.card`, exposing the link preview as a `MastodonPreviewCard`. From Mastodon 4.6.0 this is the only way to obtain a status's preview card, as `GET /api/v1/statuses/:id/card` was removed
+- `MastodonStatus.filtered`, listing the filters a status matched for the authenticated user as `MastodonFilterResult`s. Without it, the v2 filters already implemented in `FiltersApi` could not be honoured on the timeline side
+- `MastodonStatus.application`, the app a status was posted from, as a `MastodonStatusApplication` (`name` / `website` only — the status API does not disclose client credentials)
+- `MastodonStatus.quoteApproval` (as `MastodonQuoteApproval`) and `MastodonStatus.quotesCount` (Mastodon 4.5.0)
+- `MastodonFilterResult` model, corresponding to the entries of `MastodonStatus.filtered`. Its nested `filter` is serialized without rules, so `MastodonFilter.keywords` and `.statuses` are always empty there
+- `MastodonAccount` fields `uri` (ActivityPub identifier), `roles` (publicly visible role badges), `indexable`, and `group`
+- `MastodonCredentialAccount` fields that had been added to `MastodonAccount` only: `uri`, `roles`, `indexable`, `group`, `avatarDescription`, `headerDescription`, `featureApproval`, `showFeatured`, `showMedia`, `showMediaReplies`
+- `MastodonInstance.wrapstodon` (Mastodon 4.6.0), the year of the annual report campaign currently on offer, or null outside a campaign window
+- `MastodonNotification.groupKey`, correlating a v1 notification with its v2 `MastodonNotificationGroup`
+- `MastodonRelationship.mutingExpiresAt`, the expiry of a timed mute
+- `MastodonSuggestion.sources`, the suggestion reasons in the current vocabulary. `source` is a lossy mapping of the first entry onto the legacy three-value vocabulary
+- `MastodonPreferences.readingAutoplayGifs`
+- Fixture key coverage test (`test/models/fixture_key_coverage_test.dart`), asserting that every top-level key in a fixture is read back by its model. Ordinary fixture tests cannot catch this class of drift, because `json_serializable` discards unknown keys silently. Fields known to be missing but out of scope are listed explicitly in the test rather than being excluded silently
+- `status_filtered.json` fixture, a live response carrying a non-empty `filtered`. It pins that the server returns `status_matches` as `null` rather than an empty array
 
 ### Fixed
 

--- a/lib/src/models/mastodon_account.dart
+++ b/lib/src/models/mastodon_account.dart
@@ -29,7 +29,10 @@ class MastodonAccount {
     required this.statusesCount,
     required this.fields,
     required this.emojis,
+    this.uri,
     this.discoverable,
+    this.indexable,
+    this.group,
     this.noindex,
     this.createdAt,
     this.lastStatusAt,
@@ -45,6 +48,7 @@ class MastodonAccount {
     this.showFeatured,
     this.showMedia,
     this.showMediaReplies,
+    this.roles = const <MastodonRole>[],
   });
 
   factory MastodonAccount.fromJson(Map<String, dynamic> json) =>
@@ -75,6 +79,11 @@ class MastodonAccount {
   @JsonKey(defaultValue: '')
   final String url;
 
+  /// ActivityPub URI identifying the account.
+  ///
+  /// Differs from [url], which points at the human-readable profile page.
+  final String? uri;
+
   /// URL of the avatar image (animated version).
   @JsonKey(name: 'avatar', defaultValue: '')
   final String avatarUrl;
@@ -102,7 +111,16 @@ class MastodonAccount {
   /// Whether the account opts in to discovery features.
   final bool? discoverable;
 
+  /// Whether the account allows its public statuses to be indexed by the
+  /// instance's full-text search.
+  final bool? indexable;
+
+  /// Whether this is a group actor rather than a person.
+  final bool? group;
+
   /// Whether the account opts out of search engine indexing.
+  ///
+  /// Returned for local accounts only.
   final bool? noindex;
 
   /// Number of followers.
@@ -183,6 +201,60 @@ class MastodonAccount {
   ///
   /// Added in Mastodon 4.6.0.
   final bool? showMediaReplies;
+
+  /// Publicly visible roles assigned to the account, for badge display.
+  ///
+  /// Only roles flagged as highlighted are exposed, and only for local
+  /// accounts; remote accounts omit the key entirely, yielding an empty list.
+  /// Elements carry only [MastodonRole.id], [MastodonRole.name] and
+  /// [MastodonRole.color]; the remaining fields are null.
+  @JsonKey(defaultValue: <MastodonRole>[])
+  final List<MastodonRole> roles;
+}
+
+/// User role information.
+@JsonSerializable(fieldRename: FieldRename.snake)
+class MastodonRole {
+  const MastodonRole({
+    this.id,
+    required this.name,
+    this.permissions,
+    this.color,
+    this.highlighted,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  factory MastodonRole.fromJson(Map<String, dynamic> json) =>
+      _$MastodonRoleFromJson(json);
+
+  /// Serializes to JSON.
+  Map<String, dynamic> toJson() => _$MastodonRoleToJson(this);
+
+  /// Role ID.
+  @JsonKey(fromJson: flexibleIdFromJson)
+  final String? id;
+
+  /// Role name.
+  final String name;
+
+  /// Permission bitmask (string format).
+  final String? permissions;
+
+  /// Color of the role badge.
+  @JsonKey(defaultValue: '')
+  final String? color;
+
+  /// Whether to display the role badge.
+  final bool? highlighted;
+
+  /// Timestamp when the role was created.
+  @SafeDateTimeConverter()
+  final DateTime? createdAt;
+
+  /// Timestamp when the role was updated.
+  @SafeDateTimeConverter()
+  final DateTime? updatedAt;
 }
 
 /// An account's approval policy for being tagged into collections

--- a/lib/src/models/mastodon_account.g.dart
+++ b/lib/src/models/mastodon_account.g.dart
@@ -37,7 +37,10 @@ MastodonAccount _$MastodonAccountFromJson(Map<String, dynamic> json) =>
               )
               .toList() ??
           [],
+      uri: json['uri'] as String?,
       discoverable: json['discoverable'] as bool?,
+      indexable: json['indexable'] as bool?,
+      group: json['group'] as bool?,
       noindex: json['noindex'] as bool?,
       createdAt: const SafeDateTimeConverter().fromJson(
         json['created_at'] as String?,
@@ -63,6 +66,11 @@ MastodonAccount _$MastodonAccountFromJson(Map<String, dynamic> json) =>
       showFeatured: json['show_featured'] as bool?,
       showMedia: json['show_media'] as bool?,
       showMediaReplies: json['show_media_replies'] as bool?,
+      roles:
+          (json['roles'] as List<dynamic>?)
+              ?.map((e) => MastodonRole.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [],
     );
 
 Map<String, dynamic> _$MastodonAccountToJson(
@@ -74,6 +82,7 @@ Map<String, dynamic> _$MastodonAccountToJson(
   'display_name': instance.displayName,
   'note': instance.note,
   'url': instance.url,
+  'uri': instance.uri,
   'avatar': instance.avatarUrl,
   'avatar_static': instance.avatarStaticUrl,
   'header': instance.headerUrl,
@@ -81,6 +90,8 @@ Map<String, dynamic> _$MastodonAccountToJson(
   'locked': instance.locked,
   'bot': instance.bot,
   'discoverable': instance.discoverable,
+  'indexable': instance.indexable,
+  'group': instance.group,
   'noindex': instance.noindex,
   'followers_count': instance.followersCount,
   'following_count': instance.followingCount,
@@ -101,7 +112,33 @@ Map<String, dynamic> _$MastodonAccountToJson(
   'show_featured': instance.showFeatured,
   'show_media': instance.showMedia,
   'show_media_replies': instance.showMediaReplies,
+  'roles': instance.roles.map((e) => e.toJson()).toList(),
 };
+
+MastodonRole _$MastodonRoleFromJson(Map<String, dynamic> json) => MastodonRole(
+  id: flexibleIdFromJson(json['id']),
+  name: json['name'] as String,
+  permissions: json['permissions'] as String?,
+  color: json['color'] as String? ?? '',
+  highlighted: json['highlighted'] as bool?,
+  createdAt: const SafeDateTimeConverter().fromJson(
+    json['created_at'] as String?,
+  ),
+  updatedAt: const SafeDateTimeConverter().fromJson(
+    json['updated_at'] as String?,
+  ),
+);
+
+Map<String, dynamic> _$MastodonRoleToJson(MastodonRole instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'permissions': instance.permissions,
+      'color': instance.color,
+      'highlighted': instance.highlighted,
+      'created_at': const SafeDateTimeConverter().toJson(instance.createdAt),
+      'updated_at': const SafeDateTimeConverter().toJson(instance.updatedAt),
+    };
 
 MastodonFeatureApproval _$MastodonFeatureApprovalFromJson(
   Map<String, dynamic> json,

--- a/lib/src/models/mastodon_credential_account.dart
+++ b/lib/src/models/mastodon_credential_account.dart
@@ -35,7 +35,10 @@ class MastodonCredentialAccount {
     required this.statusesCount,
     required this.fields,
     required this.emojis,
+    this.uri,
     this.discoverable,
+    this.indexable,
+    this.group,
     this.noindex,
     this.createdAt,
     this.lastStatusAt,
@@ -45,6 +48,13 @@ class MastodonCredentialAccount {
     this.hideCollections,
     this.avatarBlurhash,
     this.headerBlurhash,
+    this.avatarDescription,
+    this.headerDescription,
+    this.featureApproval,
+    this.showFeatured,
+    this.showMedia,
+    this.showMediaReplies,
+    this.roles = const <MastodonRole>[],
     this.source,
     this.role,
   });
@@ -76,6 +86,11 @@ class MastodonCredentialAccount {
   @JsonKey(defaultValue: '')
   final String url;
 
+  /// ActivityPub URI identifying the account.
+  ///
+  /// Differs from [url], which points at the human-readable profile page.
+  final String? uri;
+
   /// URL of the avatar image (animated version).
   @JsonKey(name: 'avatar', defaultValue: '')
   final String avatarUrl;
@@ -102,6 +117,13 @@ class MastodonCredentialAccount {
 
   /// Whether the account opts in to discovery features.
   final bool? discoverable;
+
+  /// Whether the account allows its public statuses to be indexed by the
+  /// instance's full-text search.
+  final bool? indexable;
+
+  /// Whether this is a group actor rather than a person.
+  final bool? group;
 
   /// Whether the account opts out of search engine indexing.
   final bool? noindex;
@@ -152,11 +174,54 @@ class MastodonCredentialAccount {
   /// Blurhash of the header image.
   final String? headerBlurhash;
 
+  /// Alt text describing the avatar image, for accessibility.
+  ///
+  /// Added in Mastodon 4.6.0.
+  final String? avatarDescription;
+
+  /// Alt text describing the header image, for accessibility.
+  ///
+  /// Added in Mastodon 4.6.0.
+  final String? headerDescription;
+
+  /// This account's approval policy for being tagged into collections.
+  ///
+  /// Added in Mastodon 4.6.0.
+  final MastodonFeatureApproval? featureApproval;
+
+  /// Whether this account's featured collections are shown on its profile.
+  ///
+  /// Added in Mastodon 4.6.0.
+  final bool? showFeatured;
+
+  /// Whether media attachments are shown on this account's profile.
+  ///
+  /// Added in Mastodon 4.6.0.
+  final bool? showMedia;
+
+  /// Whether media attachments from replies are shown on this account's
+  /// profile.
+  ///
+  /// Added in Mastodon 4.6.0.
+  final bool? showMediaReplies;
+
+  /// Publicly visible roles assigned to the account, for badge display.
+  ///
+  /// Only roles flagged as highlighted are exposed. Elements carry only
+  /// [MastodonRole.id], [MastodonRole.name] and [MastodonRole.color]; the
+  /// remaining fields are null. Use [role] for the authenticated user's own
+  /// role, which is returned in full.
+  @JsonKey(defaultValue: <MastodonRole>[])
+  final List<MastodonRole> roles;
+
   /// Private information including default posting settings and follow request
   /// count.
   final MastodonAccountSource? source;
 
-  /// User role information.
+  /// The authenticated user's own role, including permissions.
+  ///
+  /// Unlike the entries in [roles], this is returned in full regardless of
+  /// whether the role is flagged as highlighted.
   final MastodonRole? role;
 }
 
@@ -201,49 +266,4 @@ class MastodonAccountSource {
 
   /// Default quote approval policy.
   final String? quotePolicy;
-}
-
-/// User role information.
-@JsonSerializable(fieldRename: FieldRename.snake)
-class MastodonRole {
-  const MastodonRole({
-    this.id,
-    required this.name,
-    this.permissions,
-    this.color,
-    this.highlighted,
-    this.createdAt,
-    this.updatedAt,
-  });
-
-  factory MastodonRole.fromJson(Map<String, dynamic> json) =>
-      _$MastodonRoleFromJson(json);
-
-  /// Serializes to JSON.
-  Map<String, dynamic> toJson() => _$MastodonRoleToJson(this);
-
-  /// Role ID.
-  @JsonKey(fromJson: flexibleIdFromJson)
-  final String? id;
-
-  /// Role name.
-  final String name;
-
-  /// Permission bitmask (string format).
-  final String? permissions;
-
-  /// Color of the role badge.
-  @JsonKey(defaultValue: '')
-  final String? color;
-
-  /// Whether to display the role badge.
-  final bool? highlighted;
-
-  /// Timestamp when the role was created.
-  @SafeDateTimeConverter()
-  final DateTime? createdAt;
-
-  /// Timestamp when the role was updated.
-  @SafeDateTimeConverter()
-  final DateTime? updatedAt;
 }

--- a/lib/src/models/mastodon_credential_account.g.dart
+++ b/lib/src/models/mastodon_credential_account.g.dart
@@ -36,7 +36,10 @@ MastodonCredentialAccount _$MastodonCredentialAccountFromJson(
           ?.map((e) => MastodonCustomEmoji.fromJson(e as Map<String, dynamic>))
           .toList() ??
       [],
+  uri: json['uri'] as String?,
   discoverable: json['discoverable'] as bool?,
+  indexable: json['indexable'] as bool?,
+  group: json['group'] as bool?,
   noindex: json['noindex'] as bool?,
   createdAt: const SafeDateTimeConverter().fromJson(
     json['created_at'] as String?,
@@ -52,6 +55,21 @@ MastodonCredentialAccount _$MastodonCredentialAccountFromJson(
   hideCollections: json['hide_collections'] as bool?,
   avatarBlurhash: json['avatar_blurhash'] as String?,
   headerBlurhash: json['header_blurhash'] as String?,
+  avatarDescription: json['avatar_description'] as String?,
+  headerDescription: json['header_description'] as String?,
+  featureApproval: json['feature_approval'] == null
+      ? null
+      : MastodonFeatureApproval.fromJson(
+          json['feature_approval'] as Map<String, dynamic>,
+        ),
+  showFeatured: json['show_featured'] as bool?,
+  showMedia: json['show_media'] as bool?,
+  showMediaReplies: json['show_media_replies'] as bool?,
+  roles:
+      (json['roles'] as List<dynamic>?)
+          ?.map((e) => MastodonRole.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      [],
   source: json['source'] == null
       ? null
       : MastodonAccountSource.fromJson(json['source'] as Map<String, dynamic>),
@@ -69,6 +87,7 @@ Map<String, dynamic> _$MastodonCredentialAccountToJson(
   'display_name': instance.displayName,
   'note': instance.note,
   'url': instance.url,
+  'uri': instance.uri,
   'avatar': instance.avatarUrl,
   'avatar_static': instance.avatarStaticUrl,
   'header': instance.headerUrl,
@@ -76,6 +95,8 @@ Map<String, dynamic> _$MastodonCredentialAccountToJson(
   'locked': instance.locked,
   'bot': instance.bot,
   'discoverable': instance.discoverable,
+  'indexable': instance.indexable,
+  'group': instance.group,
   'noindex': instance.noindex,
   'followers_count': instance.followersCount,
   'following_count': instance.followingCount,
@@ -90,6 +111,13 @@ Map<String, dynamic> _$MastodonCredentialAccountToJson(
   'hide_collections': instance.hideCollections,
   'avatar_blurhash': instance.avatarBlurhash,
   'header_blurhash': instance.headerBlurhash,
+  'avatar_description': instance.avatarDescription,
+  'header_description': instance.headerDescription,
+  'feature_approval': instance.featureApproval?.toJson(),
+  'show_featured': instance.showFeatured,
+  'show_media': instance.showMedia,
+  'show_media_replies': instance.showMediaReplies,
+  'roles': instance.roles.map((e) => e.toJson()).toList(),
   'source': instance.source?.toJson(),
   'role': instance.role?.toJson(),
 };
@@ -121,28 +149,3 @@ Map<String, dynamic> _$MastodonAccountSourceToJson(
   'follow_requests_count': instance.followRequestsCount,
   'quote_policy': instance.quotePolicy,
 };
-
-MastodonRole _$MastodonRoleFromJson(Map<String, dynamic> json) => MastodonRole(
-  id: flexibleIdFromJson(json['id']),
-  name: json['name'] as String,
-  permissions: json['permissions'] as String?,
-  color: json['color'] as String? ?? '',
-  highlighted: json['highlighted'] as bool?,
-  createdAt: const SafeDateTimeConverter().fromJson(
-    json['created_at'] as String?,
-  ),
-  updatedAt: const SafeDateTimeConverter().fromJson(
-    json['updated_at'] as String?,
-  ),
-);
-
-Map<String, dynamic> _$MastodonRoleToJson(MastodonRole instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'name': instance.name,
-      'permissions': instance.permissions,
-      'color': instance.color,
-      'highlighted': instance.highlighted,
-      'created_at': const SafeDateTimeConverter().toJson(instance.createdAt),
-      'updated_at': const SafeDateTimeConverter().toJson(instance.updatedAt),
-    };

--- a/lib/src/models/mastodon_filter.dart
+++ b/lib/src/models/mastodon_filter.dart
@@ -174,3 +174,39 @@ class MastodonFilterV1 {
   @JsonKey(defaultValue: false)
   final bool wholeWord;
 }
+
+/// Result of a filter matching a status.
+///
+/// Returned in `MastodonStatus.filtered` for authenticated requests, one
+/// element per filter the status matched. Clients are expected to honour
+/// [MastodonFilter.filterAction] of the matched [filter] rather than
+/// re-evaluating the filter rules themselves.
+@JsonSerializable(fieldRename: FieldRename.snake)
+class MastodonFilterResult {
+  const MastodonFilterResult({
+    required this.filter,
+    this.keywordMatches = const <String>[],
+    this.statusMatches = const <String>[],
+  });
+
+  factory MastodonFilterResult.fromJson(Map<String, dynamic> json) =>
+      _$MastodonFilterResultFromJson(json);
+
+  /// Serializes to JSON.
+  Map<String, dynamic> toJson() => _$MastodonFilterResultToJson(this);
+
+  /// The filter that was matched.
+  ///
+  /// The server omits the filter's rules here, so
+  /// [MastodonFilter.keywords] and [MastodonFilter.statuses] are always
+  /// empty. Fetch the filter via the v2 filters API to obtain its rules.
+  final MastodonFilter filter;
+
+  /// Keywords within the filter that matched.
+  @JsonKey(defaultValue: <String>[])
+  final List<String> keywordMatches;
+
+  /// IDs of statuses within the filter that matched.
+  @JsonKey(defaultValue: <String>[])
+  final List<String> statusMatches;
+}

--- a/lib/src/models/mastodon_filter.g.dart
+++ b/lib/src/models/mastodon_filter.g.dart
@@ -107,3 +107,27 @@ Map<String, dynamic> _$MastodonFilterV1ToJson(MastodonFilterV1 instance) =>
       'irreversible': instance.irreversible,
       'whole_word': instance.wholeWord,
     };
+
+MastodonFilterResult _$MastodonFilterResultFromJson(
+  Map<String, dynamic> json,
+) => MastodonFilterResult(
+  filter: MastodonFilter.fromJson(json['filter'] as Map<String, dynamic>),
+  keywordMatches:
+      (json['keyword_matches'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList() ??
+      [],
+  statusMatches:
+      (json['status_matches'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList() ??
+      [],
+);
+
+Map<String, dynamic> _$MastodonFilterResultToJson(
+  MastodonFilterResult instance,
+) => <String, dynamic>{
+  'filter': instance.filter.toJson(),
+  'keyword_matches': instance.keywordMatches,
+  'status_matches': instance.statusMatches,
+};

--- a/lib/src/models/mastodon_instance.dart
+++ b/lib/src/models/mastodon_instance.dart
@@ -547,6 +547,7 @@ class MastodonInstance {
     this.registrations,
     this.languages,
     this.apiVersionMastodon,
+    this.wrapstodon,
   });
 
   factory MastodonInstance.fromJson(Map<String, dynamic> json) =>
@@ -609,6 +610,15 @@ class MastodonInstance {
   /// Mastodon API version number (`api_versions.mastodon`).
   @JsonKey(readValue: _readApiVersionMastodon)
   final int? apiVersionMastodon;
+
+  /// Year of the annual report campaign currently being offered, or null
+  /// when no campaign is running.
+  ///
+  /// The instance only advertises a campaign while the feature is enabled and
+  /// the campaign window is open, so this is null for most of the year.
+  ///
+  /// Added in Mastodon 4.6.0.
+  final int? wrapstodon;
 }
 
 /// Instance icon image (`icon`, Mastodon 4.3+).

--- a/lib/src/models/mastodon_instance.g.dart
+++ b/lib/src/models/mastodon_instance.g.dart
@@ -414,6 +414,7 @@ MastodonInstance _$MastodonInstanceFromJson(
       (MastodonInstance._readApiVersionMastodon(json, 'api_version_mastodon')
               as num?)
           ?.toInt(),
+  wrapstodon: (json['wrapstodon'] as num?)?.toInt(),
 );
 
 Map<String, dynamic> _$MastodonInstanceToJson(MastodonInstance instance) =>
@@ -432,6 +433,7 @@ Map<String, dynamic> _$MastodonInstanceToJson(MastodonInstance instance) =>
       'languages': instance.languages,
       'rules': instance.rules.map((e) => e.toJson()).toList(),
       'api_version_mastodon': instance.apiVersionMastodon,
+      'wrapstodon': instance.wrapstodon,
     };
 
 MastodonInstanceIcon _$MastodonInstanceIconFromJson(

--- a/lib/src/models/mastodon_notification.dart
+++ b/lib/src/models/mastodon_notification.dart
@@ -153,6 +153,7 @@ class MastodonNotification {
     required this.type,
     required this.createdAt,
     required this.account,
+    this.groupKey,
     this.status,
     this.relationshipSeveranceEvent,
     this.moderationWarning,
@@ -182,6 +183,15 @@ class MastodonNotification {
 
   /// Account that triggered the notification.
   final MastodonAccount account;
+
+  /// Key identifying the group this notification belongs to.
+  ///
+  /// Matches `MastodonNotificationGroup.groupKey`, so it can be used to
+  /// correlate a v1 notification with its v2 group. Notifications that were
+  /// not grouped receive a synthetic `ungrouped-<id>` key.
+  ///
+  /// Added in Mastodon 4.3.0.
+  final String? groupKey;
 
   /// Associated status. Null depending on the notification type.
   final MastodonStatus? status;

--- a/lib/src/models/mastodon_notification.g.dart
+++ b/lib/src/models/mastodon_notification.g.dart
@@ -67,6 +67,7 @@ MastodonNotification _$MastodonNotificationFromJson(
   ),
   createdAt: DateTime.parse(json['created_at'] as String),
   account: MastodonAccount.fromJson(json['account'] as Map<String, dynamic>),
+  groupKey: json['group_key'] as String?,
   status: json['status'] == null
       ? null
       : MastodonStatus.fromJson(json['status'] as Map<String, dynamic>),
@@ -89,6 +90,7 @@ Map<String, dynamic> _$MastodonNotificationToJson(
   'type': _$MastodonNotificationTypeEnumMap[instance.type]!,
   'created_at': instance.createdAt.toIso8601String(),
   'account': instance.account.toJson(),
+  'group_key': instance.groupKey,
   'status': instance.status?.toJson(),
   'relationship_severance_event': instance.relationshipSeveranceEvent?.toJson(),
   'moderation_warning': instance.moderationWarning?.toJson(),

--- a/lib/src/models/mastodon_preferences.dart
+++ b/lib/src/models/mastodon_preferences.dart
@@ -16,6 +16,7 @@ class MastodonPreferences {
     this.postingDefaultQuotePolicy,
     required this.readingExpandMedia,
     required this.readingExpandSpoilers,
+    this.readingAutoplayGifs = false,
   });
 
   /// Creates a [MastodonPreferences] from a JSON map.
@@ -48,4 +49,8 @@ class MastodonPreferences {
   /// Whether to expand content warnings (CW) by default.
   @JsonKey(name: 'reading:expand:spoilers', defaultValue: false)
   final bool readingExpandSpoilers;
+
+  /// Whether to autoplay animated GIFs.
+  @JsonKey(name: 'reading:autoplay:gifs', defaultValue: false)
+  final bool readingAutoplayGifs;
 }

--- a/lib/src/models/mastodon_preferences.g.dart
+++ b/lib/src/models/mastodon_preferences.g.dart
@@ -18,6 +18,7 @@ MastodonPreferences _$MastodonPreferencesFromJson(
   postingDefaultQuotePolicy: json['posting:default:quote_policy'] as String?,
   readingExpandMedia: json['reading:expand:media'] as String? ?? 'default',
   readingExpandSpoilers: json['reading:expand:spoilers'] as bool? ?? false,
+  readingAutoplayGifs: json['reading:autoplay:gifs'] as bool? ?? false,
 );
 
 Map<String, dynamic> _$MastodonPreferencesToJson(
@@ -29,4 +30,5 @@ Map<String, dynamic> _$MastodonPreferencesToJson(
   'posting:default:quote_policy': instance.postingDefaultQuotePolicy,
   'reading:expand:media': instance.readingExpandMedia,
   'reading:expand:spoilers': instance.readingExpandSpoilers,
+  'reading:autoplay:gifs': instance.readingAutoplayGifs,
 };

--- a/lib/src/models/mastodon_relationship.dart
+++ b/lib/src/models/mastodon_relationship.dart
@@ -1,5 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 
+import 'json_converters.dart';
+
 part 'mastodon_relationship.g.dart';
 
 /// Relationship between two accounts (follow, block, mute, etc.).
@@ -22,6 +24,7 @@ class MastodonRelationship {
     required this.endorsed,
     required this.note,
     this.languages,
+    this.mutingExpiresAt,
   });
 
   /// Creates a [MastodonRelationship] from a JSON map.
@@ -64,6 +67,11 @@ class MastodonRelationship {
   /// Whether you are muting this account.
   @JsonKey(defaultValue: false)
   final bool muting;
+
+  /// Expiry of a timed mute. Null when the mute is indefinite or when you are
+  /// not muting this account.
+  @SafeDateTimeConverter()
+  final DateTime? mutingExpiresAt;
 
   /// Whether you are muting notifications from this account.
   @JsonKey(defaultValue: false)

--- a/lib/src/models/mastodon_relationship.g.dart
+++ b/lib/src/models/mastodon_relationship.g.dart
@@ -28,6 +28,9 @@ MastodonRelationship _$MastodonRelationshipFromJson(
   languages: (json['languages'] as List<dynamic>?)
       ?.map((e) => e as String)
       .toList(),
+  mutingExpiresAt: const SafeDateTimeConverter().fromJson(
+    json['muting_expires_at'] as String?,
+  ),
 );
 
 Map<String, dynamic> _$MastodonRelationshipToJson(
@@ -42,6 +45,9 @@ Map<String, dynamic> _$MastodonRelationshipToJson(
   'blocking': instance.blocking,
   'blocked_by': instance.blockedBy,
   'muting': instance.muting,
+  'muting_expires_at': const SafeDateTimeConverter().toJson(
+    instance.mutingExpiresAt,
+  ),
   'muting_notifications': instance.mutingNotifications,
   'requested': instance.requested,
   'requested_by': instance.requestedBy,

--- a/lib/src/models/mastodon_status.dart
+++ b/lib/src/models/mastodon_status.dart
@@ -4,8 +4,10 @@ import 'json_converters.dart';
 import 'mastodon_account.dart';
 import 'mastodon_collection.dart';
 import 'mastodon_custom_emoji.dart';
+import 'mastodon_filter.dart';
 import 'mastodon_media_attachment.dart';
 import 'mastodon_poll.dart';
+import 'mastodon_preview_card.dart';
 import 'mastodon_tag.dart';
 
 export 'mastodon_tag.dart';
@@ -78,6 +80,11 @@ class MastodonStatus {
     this.reblog,
     this.poll,
     this.quote,
+    this.card,
+    this.application,
+    this.quoteApproval,
+    this.quotesCount = 0,
+    this.filtered = const <MastodonFilterResult>[],
     this.taggedCollections = const <MastodonCollection>[],
   });
 
@@ -150,6 +157,12 @@ class MastodonStatus {
   @JsonKey(defaultValue: 0)
   final int repliesCount;
 
+  /// Number of quotes of this status.
+  ///
+  /// Added in Mastodon 4.5.0.
+  @JsonKey(defaultValue: 0)
+  final int quotesCount;
+
   /// Whether the authenticated user has favourited this status.
   final bool? favourited;
 
@@ -189,9 +202,94 @@ class MastodonStatus {
   /// Quoted status (Mastodon 4.5+ / FEP-044f). Null if not a quote.
   final MastodonStatus? quote;
 
+  /// Link preview card for the first link in the status.
+  ///
+  /// Null when the status contains no link, or when the card has not been
+  /// fetched yet. From Mastodon 4.6.0 this is the only way to obtain a
+  /// status's preview card; the dedicated `GET /api/v1/statuses/:id/card`
+  /// endpoint was removed.
+  final MastodonPreviewCard? card;
+
+  /// Application used to post the status.
+  ///
+  /// Returned only when the author has opted in to disclosing it, or when
+  /// the status belongs to the authenticated user.
+  final MastodonStatusApplication? application;
+
+  /// Filters the status matched for the authenticated user.
+  ///
+  /// Empty for unauthenticated requests. Clients are expected to honour these
+  /// results rather than applying filter rules themselves.
+  @JsonKey(defaultValue: <MastodonFilterResult>[])
+  final List<MastodonFilterResult> filtered;
+
+  /// Quote approval policy of the status.
+  ///
+  /// Added in Mastodon 4.5.0.
+  final MastodonQuoteApproval? quoteApproval;
+
   /// Collections this status has been tagged into.
   ///
   /// Added in Mastodon 4.6.0.
   @JsonKey(defaultValue: <MastodonCollection>[])
   final List<MastodonCollection> taggedCollections;
+}
+
+/// Application that published a status.
+///
+/// A reduced form of `MastodonApplication` carrying only the fields the
+/// status API exposes; client credentials and registration details are not
+/// disclosed for other users' statuses.
+@JsonSerializable(fieldRename: FieldRename.snake)
+class MastodonStatusApplication {
+  const MastodonStatusApplication({
+    required this.name,
+    this.website,
+  });
+
+  factory MastodonStatusApplication.fromJson(Map<String, dynamic> json) =>
+      _$MastodonStatusApplicationFromJson(json);
+
+  /// Serializes to JSON.
+  Map<String, dynamic> toJson() => _$MastodonStatusApplicationToJson(this);
+
+  /// Name of the application.
+  @JsonKey(defaultValue: '')
+  final String name;
+
+  /// Website URL of the application. Null if the application declared none.
+  final String? website;
+}
+
+/// Quote approval policy of a status (Mastodon 4.5.0+).
+///
+/// [automatic] and [manual] each list the visibility scopes (e.g. `public`,
+/// `followers`) whose members may quote the status without approval or with
+/// manual approval, respectively.
+@JsonSerializable(fieldRename: FieldRename.snake)
+class MastodonQuoteApproval {
+  const MastodonQuoteApproval({
+    this.automatic = const <String>[],
+    this.manual = const <String>[],
+    this.currentUser,
+  });
+
+  factory MastodonQuoteApproval.fromJson(Map<String, dynamic> json) =>
+      _$MastodonQuoteApprovalFromJson(json);
+
+  /// Serializes to JSON.
+  Map<String, dynamic> toJson() => _$MastodonQuoteApprovalToJson(this);
+
+  /// Visibility scopes whose members may quote without approval.
+  @JsonKey(defaultValue: <String>[])
+  final List<String> automatic;
+
+  /// Visibility scopes whose members may quote with manual approval.
+  @JsonKey(defaultValue: <String>[])
+  final List<String> manual;
+
+  /// Whether the authenticated user may quote this status
+  /// (e.g. `automatic`, `manual`, `denied`). Null for unauthenticated
+  /// requests.
+  final String? currentUser;
 }

--- a/lib/src/models/mastodon_status.g.dart
+++ b/lib/src/models/mastodon_status.g.dart
@@ -76,6 +76,25 @@ MastodonStatus _$MastodonStatusFromJson(
   quote: json['quote'] == null
       ? null
       : MastodonStatus.fromJson(json['quote'] as Map<String, dynamic>),
+  card: json['card'] == null
+      ? null
+      : MastodonPreviewCard.fromJson(json['card'] as Map<String, dynamic>),
+  application: json['application'] == null
+      ? null
+      : MastodonStatusApplication.fromJson(
+          json['application'] as Map<String, dynamic>,
+        ),
+  quoteApproval: json['quote_approval'] == null
+      ? null
+      : MastodonQuoteApproval.fromJson(
+          json['quote_approval'] as Map<String, dynamic>,
+        ),
+  quotesCount: (json['quotes_count'] as num?)?.toInt() ?? 0,
+  filtered:
+      (json['filtered'] as List<dynamic>?)
+          ?.map((e) => MastodonFilterResult.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      [],
   taggedCollections:
       (json['tagged_collections'] as List<dynamic>?)
           ?.map((e) => MastodonCollection.fromJson(e as Map<String, dynamic>))
@@ -101,6 +120,7 @@ Map<String, dynamic> _$MastodonStatusToJson(MastodonStatus instance) =>
       'reblogs_count': instance.reblogsCount,
       'favourites_count': instance.favouritesCount,
       'replies_count': instance.repliesCount,
+      'quotes_count': instance.quotesCount,
       'favourited': instance.favourited,
       'reblogged': instance.reblogged,
       'bookmarked': instance.bookmarked,
@@ -116,6 +136,10 @@ Map<String, dynamic> _$MastodonStatusToJson(MastodonStatus instance) =>
       'reblog': instance.reblog?.toJson(),
       'poll': instance.poll?.toJson(),
       'quote': instance.quote?.toJson(),
+      'card': instance.card?.toJson(),
+      'application': instance.application?.toJson(),
+      'filtered': instance.filtered.map((e) => e.toJson()).toList(),
+      'quote_approval': instance.quoteApproval?.toJson(),
       'tagged_collections': instance.taggedCollections
           .map((e) => e.toJson())
           .toList(),
@@ -126,4 +150,35 @@ const _$MastodonVisibilityEnumMap = {
   MastodonVisibility.unlisted: 'unlisted',
   MastodonVisibility.private: 'private',
   MastodonVisibility.direct: 'direct',
+};
+
+MastodonStatusApplication _$MastodonStatusApplicationFromJson(
+  Map<String, dynamic> json,
+) => MastodonStatusApplication(
+  name: json['name'] as String? ?? '',
+  website: json['website'] as String?,
+);
+
+Map<String, dynamic> _$MastodonStatusApplicationToJson(
+  MastodonStatusApplication instance,
+) => <String, dynamic>{'name': instance.name, 'website': instance.website};
+
+MastodonQuoteApproval _$MastodonQuoteApprovalFromJson(
+  Map<String, dynamic> json,
+) => MastodonQuoteApproval(
+  automatic:
+      (json['automatic'] as List<dynamic>?)?.map((e) => e as String).toList() ??
+      [],
+  manual:
+      (json['manual'] as List<dynamic>?)?.map((e) => e as String).toList() ??
+      [],
+  currentUser: json['current_user'] as String?,
+);
+
+Map<String, dynamic> _$MastodonQuoteApprovalToJson(
+  MastodonQuoteApproval instance,
+) => <String, dynamic>{
+  'automatic': instance.automatic,
+  'manual': instance.manual,
+  'current_user': instance.currentUser,
 };

--- a/lib/src/models/mastodon_suggestion.dart
+++ b/lib/src/models/mastodon_suggestion.dart
@@ -11,6 +11,7 @@ class MastodonSuggestion {
   const MastodonSuggestion({
     required this.source,
     required this.account,
+    this.sources = const <String>[],
   });
 
   /// Creates a [MastodonSuggestion] from a JSON map.
@@ -29,4 +30,13 @@ class MastodonSuggestion {
 
   /// Suggested account.
   final MastodonAccount account;
+
+  /// Reasons for the suggestion, in the current (non-legacy) vocabulary.
+  ///
+  /// Values include `featured`, `most_followed`, `most_interactions`,
+  /// `similar_to_recently_followed` and `friends_of_friends`. [source] is a
+  /// lossy mapping of the first entry onto the legacy three-value vocabulary,
+  /// so prefer this field when distinguishing suggestion reasons.
+  @JsonKey(defaultValue: <String>[])
+  final List<String> sources;
 }

--- a/lib/src/models/mastodon_suggestion.g.dart
+++ b/lib/src/models/mastodon_suggestion.g.dart
@@ -8,16 +8,19 @@ part of 'mastodon_suggestion.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-MastodonSuggestion _$MastodonSuggestionFromJson(Map<String, dynamic> json) =>
-    MastodonSuggestion(
-      source: json['source'] as String,
-      account: MastodonAccount.fromJson(
-        json['account'] as Map<String, dynamic>,
-      ),
-    );
+MastodonSuggestion _$MastodonSuggestionFromJson(
+  Map<String, dynamic> json,
+) => MastodonSuggestion(
+  source: json['source'] as String,
+  account: MastodonAccount.fromJson(json['account'] as Map<String, dynamic>),
+  sources:
+      (json['sources'] as List<dynamic>?)?.map((e) => e as String).toList() ??
+      [],
+);
 
 Map<String, dynamic> _$MastodonSuggestionToJson(MastodonSuggestion instance) =>
     <String, dynamic>{
       'source': instance.source,
       'account': instance.account.toJson(),
+      'sources': instance.sources,
     };

--- a/test/fixtures/status_filtered.json
+++ b/test/fixtures/status_filtered.json
@@ -1,0 +1,94 @@
+{
+  "id": "117038175857262829",
+  "created_at": "2026-08-04T16:27:17.000Z",
+  "in_reply_to_id": null,
+  "in_reply_to_account_id": null,
+  "sensitive": false,
+  "spoiler_text": "",
+  "visibility": "public",
+  "language": "ja",
+  "uri": "https://fedibird.test/users/fb_jun/statuses/117038175838405651",
+  "url": "https://fedibird.test/@fb_jun/117038175838405651",
+  "replies_count": 0,
+  "reblogs_count": 0,
+  "favourites_count": 0,
+  "quotes_count": 0,
+  "edited_at": null,
+  "favourited": false,
+  "reblogged": false,
+  "muted": false,
+  "bookmarked": false,
+  "content": "<p>タイムラインを眺めています <a href=\"https://fedibird.test/tags/e2edaily\" class=\"mention hashtag\" rel=\"nofollow noopener\" target=\"_blank\">#<span>e2edaily</span></a></p>",
+  "filtered": [
+    {
+      "filter": {
+        "id": "1",
+        "title": "tmp-verify-13",
+        "context": [
+          "public"
+        ],
+        "expires_at": null,
+        "filter_action": "warn"
+      },
+      "keyword_matches": [
+        "e2e"
+      ],
+      "status_matches": null
+    }
+  ],
+  "reblog": null,
+  "account": {
+    "id": "117025600270518912",
+    "username": "fb_jun",
+    "acct": "fb_jun@fedibird.test",
+    "display_name": "Fb Jun",
+    "locked": false,
+    "bot": false,
+    "discoverable": true,
+    "indexable": false,
+    "group": false,
+    "created_at": "2026-08-02T00:00:00.000Z",
+    "note": "<p>e2e world resident on fedibird.test</p>",
+    "url": "https://fedibird.test/@fb_jun",
+    "uri": "https://fedibird.test/users/fb_jun",
+    "avatar": "https://mastodon.test/avatars/original/missing.png",
+    "avatar_static": "https://mastodon.test/avatars/original/missing.png",
+    "avatar_description": "",
+    "header": "https://mastodon.test/headers/original/missing.png",
+    "header_static": "https://mastodon.test/headers/original/missing.png",
+    "header_description": "",
+    "followers_count": 2,
+    "following_count": 2,
+    "statuses_count": 153,
+    "last_status_at": "2026-08-04",
+    "hide_collections": false,
+    "show_media": true,
+    "show_media_replies": true,
+    "show_featured": true,
+    "feature_approval": {
+      "automatic": [],
+      "manual": [],
+      "current_user": "missing"
+    },
+    "emojis": [],
+    "fields": []
+  },
+  "media_attachments": [],
+  "mentions": [],
+  "tags": [
+    {
+      "name": "e2edaily",
+      "url": "https://mastodon.test/tags/e2edaily"
+    }
+  ],
+  "emojis": [],
+  "tagged_collections": [],
+  "quote": null,
+  "card": null,
+  "poll": null,
+  "quote_approval": {
+    "automatic": [],
+    "manual": [],
+    "current_user": "denied"
+  }
+}

--- a/test/models/fixture_key_coverage_test.dart
+++ b/test/models/fixture_key_coverage_test.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:mastodon_client/mastodon_client.dart';
+import 'package:test/test.dart';
+
+/// 実応答のキーがモデルに取り込まれているかを機械的に検証する。
+///
+/// 通常の fixture テストは「モデルが読むフィールドが正しく読めているか」しか
+/// 見ておらず、モデルが読んでいないキーは json_serializable が黙って捨てるため
+/// 素通りする。issue #13 の欠落フィールド群はこの穴から入り込んだ。
+///
+/// ここでは fixture のトップレベルキーが `toJson()` の出力キーに含まれることを
+/// 確認し、含まれないものを欠落として検出する。
+void main() {
+  /// `toJson()` のキーが実応答のキーと意図的に食い違う箇所。
+  ///
+  /// readValue でネストした値を平坦化しているフィールドは、出力キーが実応答の
+  /// キーと一致しないため個別に除外する。
+  const knownDivergences = <String, Set<String>>{
+    // apiVersionMastodon が api_versions.mastodon を平坦化して読む
+    'instance_v2.json': {'api_versions'},
+  };
+
+  /// 未実装と分かっているが issue #13 の対象外のフィールド。
+  ///
+  /// このチェックを導入した際に検出されたもので、実装した時点でここから外す。
+  /// 新しい欠落を素通りさせないために、除外は一覧として明示しておく。
+  const outstandingGaps = <String, Set<String>>{
+    'preview_card.json': {'language', 'image_description', 'published_at'},
+    'media_attachment.json': {'preview_remote_url', 'text_url', 'meta'},
+    'collection.json': {'items'},
+  };
+
+  final cases = <String, Map<String, dynamic> Function(Map<String, dynamic>)>{
+    'status.json': (json) => MastodonStatus.fromJson(json).toJson(),
+    'status_filtered.json': (json) => MastodonStatus.fromJson(json).toJson(),
+    'timelines_public.json': (json) => MastodonStatus.fromJson(json).toJson(),
+    'account.json': (json) => MastodonAccount.fromJson(json).toJson(),
+    'verify_credentials.json': (json) =>
+        MastodonCredentialAccount.fromJson(json).toJson(),
+    'instance_v2.json': (json) => MastodonInstance.fromJson(json).toJson(),
+    'notifications.json': (json) =>
+        MastodonNotification.fromJson(json).toJson(),
+    'relationships.json': (json) =>
+        MastodonRelationship.fromJson(json).toJson(),
+    'suggestions.json': (json) => MastodonSuggestion.fromJson(json).toJson(),
+    'preferences.json': (json) => MastodonPreferences.fromJson(json).toJson(),
+    'preview_card.json': (json) => MastodonPreviewCard.fromJson(json).toJson(),
+    'poll.json': (json) => MastodonPoll.fromJson(json).toJson(),
+    'media_attachment.json': (json) =>
+        MastodonMediaAttachment.fromJson(json).toJson(),
+    'collection.json': (json) => MastodonCollection.fromJson(json).toJson(),
+  };
+
+  group('fixture key coverage', () {
+    cases.forEach((fixture, roundTrip) {
+      test('$fixture: every response key is read by the model', () {
+        final decoded = jsonDecode(
+          File('test/fixtures/$fixture').readAsStringSync(),
+        );
+        final json =
+            (decoded is List ? decoded.first : decoded) as Map<String, dynamic>;
+
+        final missing = json.keys.toSet()
+          ..removeAll(roundTrip(json).keys)
+          ..removeAll(knownDivergences[fixture] ?? const <String>{})
+          ..removeAll(outstandingGaps[fixture] ?? const <String>{});
+
+        expect(
+          missing,
+          isEmpty,
+          reason:
+              'サーバーが返しているが $fixture のモデルが読んでいないキー: '
+              '${missing.toList()..sort()}\n'
+              'モデルにフィールドを追加するか、意図的な差異なら '
+              'knownDivergences に登録すること',
+        );
+      });
+    });
+  });
+}

--- a/test/models/mastodon_account_test.dart
+++ b/test/models/mastodon_account_test.dart
@@ -86,6 +86,49 @@ void main() {
     });
   });
 
+  group('MastodonAccount - fields the client had been dropping', () {
+    Map<String, dynamic> loadAccount() =>
+        jsonDecode(File('test/fixtures/account.json').readAsStringSync())
+            as Map<String, dynamic>;
+
+    test('deserializes uri, indexable and group', () {
+      final account = MastodonAccount.fromJson(loadAccount());
+
+      // uri は ActivityPub 識別子で、プロフィールページの url とは別物
+      expect(account.uri, startsWith('https://mastodon.test/ap/users/'));
+      expect(account.uri, isNot(account.url));
+      expect(account.indexable, false);
+      expect(account.group, false);
+    });
+
+    test('roles defaults to an empty list', () {
+      final account = MastodonAccount.fromJson(loadAccount());
+
+      expect(account.roles, isEmpty);
+    });
+
+    test('roles is empty when the key is absent (remote accounts)', () {
+      final json = loadAccount()..remove('roles');
+
+      expect(MastodonAccount.fromJson(json).roles, isEmpty);
+    });
+
+    test('deserializes publicly visible roles', () {
+      // roles は local? 条件付きで、id / name / color のみを含む縮約形
+      final json = loadAccount()
+        ..['roles'] = <Map<String, dynamic>>[
+          <String, dynamic>{'id': '3', 'name': 'Owner', 'color': '#ff0000'},
+        ];
+      final account = MastodonAccount.fromJson(json);
+
+      expect(account.roles, hasLength(1));
+      expect(account.roles.first.id, '3');
+      expect(account.roles.first.name, 'Owner');
+      expect(account.roles.first.color, '#ff0000');
+      expect(account.roles.first.permissions, isNull);
+    });
+  });
+
   group('MastodonAccount.fromJson (list) - account_search.json', () {
     test('deserializes list from fixture', () {
       final file = File('test/fixtures/account_search.json');

--- a/test/models/mastodon_credential_account_test.dart
+++ b/test/models/mastodon_credential_account_test.dart
@@ -61,4 +61,74 @@ void main() {
       expect(role.name, 'Owner');
     });
   });
+
+  group('MastodonCredentialAccount - parity with MastodonAccount', () {
+    Map<String, dynamic> loadCredentials() =>
+        jsonDecode(
+              File('test/fixtures/verify_credentials.json').readAsStringSync(),
+            )
+            as Map<String, dynamic>;
+
+    test('deserializes uri, indexable and group', () {
+      final account = MastodonCredentialAccount.fromJson(loadCredentials());
+
+      expect(account.uri, startsWith('https://mastodon.test/ap/users/'));
+      expect(account.uri, isNot(account.url));
+      expect(account.indexable, false);
+      expect(account.group, false);
+    });
+
+    test('deserializes the 4.6.0 fields that were added to '
+        'MastodonAccount only', () {
+      final account = MastodonCredentialAccount.fromJson(loadCredentials());
+
+      expect(account.avatarDescription, '');
+      expect(account.headerDescription, '');
+      expect(account.showFeatured, true);
+      expect(account.showMedia, true);
+      expect(account.showMediaReplies, true);
+
+      expect(account.featureApproval, isNotNull);
+      expect(account.featureApproval!.automatic, isEmpty);
+      expect(account.featureApproval!.manual, isEmpty);
+      expect(account.featureApproval!.currentUser, 'denied');
+    });
+
+    test('deserializes roles alongside the full role', () {
+      final account = MastodonCredentialAccount.fromJson(loadCredentials());
+
+      // roles は縮約形（id/name/color）、role は権限まで含む完全形
+      expect(account.roles, hasLength(1));
+      expect(account.roles.first.name, 'Owner');
+      expect(account.roles.first.permissions, isNull);
+      expect(account.role!.name, 'Owner');
+      expect(account.role!.permissions, isNotEmpty);
+    });
+
+    test('every key MastodonAccount reads is also read here', () {
+      final json = loadCredentials();
+      final asAccount = MastodonAccount.fromJson(json);
+      final asCredentials = MastodonCredentialAccount.fromJson(json);
+
+      // PR #9 で片側にだけフィールドを足したことによるドリフトの再発防止
+      expect(asCredentials.uri, asAccount.uri);
+      expect(asCredentials.indexable, asAccount.indexable);
+      expect(asCredentials.group, asAccount.group);
+      expect(asCredentials.avatarDescription, asAccount.avatarDescription);
+      expect(asCredentials.headerDescription, asAccount.headerDescription);
+      expect(asCredentials.showFeatured, asAccount.showFeatured);
+      expect(asCredentials.showMedia, asAccount.showMedia);
+      expect(asCredentials.showMediaReplies, asAccount.showMediaReplies);
+      expect(asCredentials.hideCollections, asAccount.hideCollections);
+      expect(asCredentials.noindex, asAccount.noindex);
+      expect(
+        asCredentials.roles.map((r) => r.name),
+        asAccount.roles.map((r) => r.name),
+      );
+      expect(
+        asCredentials.featureApproval!.currentUser,
+        asAccount.featureApproval!.currentUser,
+      );
+    });
+  });
 }

--- a/test/models/mastodon_filter_test.dart
+++ b/test/models/mastodon_filter_test.dart
@@ -70,4 +70,61 @@ void main() {
       expect(kw.wholeWord, isTrue);
     });
   });
+
+  group('MastodonFilterResult.fromJson', () {
+    test('deserializes a filter result from a live filtered status', () {
+      final file = File('test/fixtures/status_filtered.json');
+      final json = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+      final results = (json['filtered'] as List<dynamic>)
+          .map((e) => MastodonFilterResult.fromJson(e as Map<String, dynamic>))
+          .toList();
+
+      expect(results, hasLength(1));
+
+      final result = results.first;
+      expect(result.filter.id, isNotEmpty);
+      expect(result.filter.title, isNotEmpty);
+      expect(result.filter.filterAction, MastodonFilterAction.warn);
+      expect(result.keywordMatches, isNotEmpty);
+      expect(result.statusMatches, isEmpty);
+    });
+
+    test('status_matches null is coerced to an empty list', () {
+      // 実サーバーは status_matches を null で返す。デフォルト値が無いと
+      // ここでパースが落ちる
+      final result = MastodonFilterResult.fromJson(<String, dynamic>{
+        'filter': <String, dynamic>{
+          'id': '1',
+          'title': 'spoilers',
+          'context': <String>['home'],
+          'expires_at': null,
+          'filter_action': 'hide',
+        },
+        'keyword_matches': <String>['spoiler'],
+        'status_matches': null,
+      });
+
+      expect(result.filter.filterAction, MastodonFilterAction.hide);
+      expect(result.keywordMatches, <String>['spoiler']);
+      expect(result.statusMatches, isEmpty);
+    });
+
+    test('the nested filter never carries its rules', () {
+      // FilterResult 内の filter は rules_requested なしで直列化されるため
+      // keywords / statuses は返らない。ルールは v2 filters API で取得する
+      final result = MastodonFilterResult.fromJson(<String, dynamic>{
+        'filter': <String, dynamic>{
+          'id': '1',
+          'title': 'spoilers',
+          'context': <String>['home'],
+          'filter_action': 'warn',
+        },
+      });
+
+      expect(result.filter.keywords, isEmpty);
+      expect(result.filter.statuses, isEmpty);
+      expect(result.keywordMatches, isEmpty);
+      expect(result.statusMatches, isEmpty);
+    });
+  });
 }

--- a/test/models/mastodon_instance_test.dart
+++ b/test/models/mastodon_instance_test.dart
@@ -18,6 +18,10 @@ void main() {
       expect(instance.languages, ['en']);
       expect(instance.apiVersionMastodon, isPositive);
 
+      // wrapstodon は Annual reports のキャンペーン年。キャンペーン期間外
+      // (12月10〜31日以外) は常に null で返る
+      expect(instance.wrapstodon, isNull);
+
       // rules
       // (サーバールールはWeb管理画面のみで設定可能でREST APIが無いため、
       // 閉域E2E環境では常に空になる)
@@ -81,6 +85,22 @@ void main() {
       expect(instance.contact, isNotNull);
       expect(instance.contact!.email, '');
       expect(instance.contact!.account, isNull);
+    });
+
+    test('wrapstodon carries the campaign year while one is running', () {
+      final file = File('test/fixtures/instance_v2.json');
+      final json = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>
+        ..['wrapstodon'] = 2026;
+
+      expect(MastodonInstance.fromJson(json).wrapstodon, 2026);
+    });
+
+    test('wrapstodon is null on servers older than 4.6.0', () {
+      final file = File('test/fixtures/instance_v2.json');
+      final json = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>
+        ..remove('wrapstodon');
+
+      expect(MastodonInstance.fromJson(json).wrapstodon, isNull);
     });
   });
 

--- a/test/models/mastodon_notification_test.dart
+++ b/test/models/mastodon_notification_test.dart
@@ -32,5 +32,29 @@ void main() {
       expect(reblog.type, MastodonNotificationType.reblog);
       expect(reblog.account.username, isNotEmpty);
     });
+
+    test('groupKey links a v1 notification to its v2 group', () {
+      final file = File('test/fixtures/notifications.json');
+      final list = jsonDecode(file.readAsStringSync()) as List<dynamic>;
+      final notifications = list
+          .map((e) => MastodonNotification.fromJson(e as Map<String, dynamic>))
+          .toList();
+
+      expect(notifications.first.groupKey, isNotEmpty);
+
+      // グループ化されなかった通知には ungrouped-<id> が割り当てられる
+      final ungrouped = notifications.firstWhere(
+        (n) => n.groupKey!.startsWith('ungrouped-'),
+      );
+      expect(ungrouped.groupKey, 'ungrouped-${ungrouped.id}');
+    });
+
+    test('groupKey is null on servers older than 4.3.0', () {
+      final file = File('test/fixtures/notifications.json');
+      final list = jsonDecode(file.readAsStringSync()) as List<dynamic>;
+      final json = list.first as Map<String, dynamic>..remove('group_key');
+
+      expect(MastodonNotification.fromJson(json).groupKey, isNull);
+    });
   });
 }

--- a/test/models/mastodon_preferences_test.dart
+++ b/test/models/mastodon_preferences_test.dart
@@ -16,6 +16,23 @@ void main() {
       expect(obj.postingDefaultQuotePolicy, 'public');
       expect(obj.readingExpandMedia, 'default');
       expect(obj.readingExpandSpoilers, false);
+      expect(obj.readingAutoplayGifs, false);
+    });
+
+    test('readingAutoplayGifs falls back to false when the key is absent', () {
+      final file = File('test/fixtures/preferences.json');
+      final json = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>
+        ..remove('reading:autoplay:gifs');
+
+      expect(MastodonPreferences.fromJson(json).readingAutoplayGifs, false);
+    });
+
+    test('readingAutoplayGifs reflects an enabled preference', () {
+      final file = File('test/fixtures/preferences.json');
+      final json = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>
+        ..['reading:autoplay:gifs'] = true;
+
+      expect(MastodonPreferences.fromJson(json).readingAutoplayGifs, true);
     });
   });
 }

--- a/test/models/mastodon_relationship_test.dart
+++ b/test/models/mastodon_relationship_test.dart
@@ -32,6 +32,30 @@ void main() {
       expect(rel.endorsed, isFalse);
       expect(rel.note, equals(''));
       expect(rel.languages, isNull);
+      expect(rel.mutingExpiresAt, isNull);
+    });
+
+    test('mutingExpiresAt deserializes a timed mute', () {
+      final file = File('test/fixtures/relationships.json');
+      final list = jsonDecode(file.readAsStringSync()) as List<dynamic>;
+      final json = list.first as Map<String, dynamic>
+        ..['muting'] = true
+        ..['muting_expires_at'] = '2026-08-05T12:00:00.000Z';
+
+      final rel = MastodonRelationship.fromJson(json);
+
+      expect(rel.muting, isTrue);
+      expect(rel.mutingExpiresAt, DateTime.utc(2026, 8, 5, 12));
+    });
+
+    test('mutingExpiresAt is null for an indefinite mute', () {
+      final file = File('test/fixtures/relationships.json');
+      final list = jsonDecode(file.readAsStringSync()) as List<dynamic>;
+      final json = list.first as Map<String, dynamic>
+        ..['muting'] = true
+        ..['muting_expires_at'] = null;
+
+      expect(MastodonRelationship.fromJson(json).mutingExpiresAt, isNull);
     });
   });
 }

--- a/test/models/mastodon_status_test.dart
+++ b/test/models/mastodon_status_test.dart
@@ -72,6 +72,120 @@ void main() {
     });
   });
 
+  group('MastodonStatus.application', () {
+    test('deserializes the reduced application entity', () {
+      final file = File('test/fixtures/status.json');
+      final json = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+      final status = MastodonStatus.fromJson(json);
+
+      // 投稿APIが返す application は {name, website} のみで、
+      // MastodonApplication のような id / scopes / redirect_uris は含まない
+      expect(status.application, isNotNull);
+      expect(status.application!.name, isNotEmpty);
+      expect(status.application!.website, isNull);
+    });
+
+    test('is null when the author does not disclose it', () {
+      final file = File('test/fixtures/timelines_public.json');
+      final list = jsonDecode(file.readAsStringSync()) as List<dynamic>;
+      final json = list.first as Map<String, dynamic>;
+
+      expect(json.containsKey('application'), isFalse);
+      expect(MastodonStatus.fromJson(json).application, isNull);
+    });
+  });
+
+  group('MastodonStatus.card', () {
+    test('deserializes a link preview card embedded in the status', () {
+      final json =
+          jsonDecode(File('test/fixtures/status.json').readAsStringSync())
+              as Map<String, dynamic>;
+      final card =
+          jsonDecode(File('test/fixtures/preview_card.json').readAsStringSync())
+              as Map<String, dynamic>;
+
+      final status = MastodonStatus.fromJson({...json, 'card': card});
+
+      expect(status.card, isNotNull);
+      expect(status.card!.url, card['url']);
+      expect(status.card!.title, card['title']);
+      expect(status.card!.type, MastodonPreviewCardType.link);
+    });
+
+    test('is null for a status without a link', () {
+      final json =
+          jsonDecode(File('test/fixtures/status.json').readAsStringSync())
+              as Map<String, dynamic>;
+
+      expect(json['card'], isNull);
+      expect(MastodonStatus.fromJson(json).card, isNull);
+    });
+  });
+
+  group('MastodonStatus.filtered', () {
+    test('deserializes filter results from a live filtered response', () {
+      final file = File('test/fixtures/status_filtered.json');
+      final json = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+      final status = MastodonStatus.fromJson(json);
+
+      expect(status.filtered, hasLength(1));
+
+      final result = status.filtered.first;
+      expect(result.filter.id, isNotEmpty);
+      expect(result.filter.title, isNotEmpty);
+      expect(result.filter.context, contains('public'));
+      expect(result.filter.filterAction, MastodonFilterAction.warn);
+      expect(result.keywordMatches, isNotEmpty);
+
+      // サーバーは status_matches を null で返す（空配列ではない）
+      final rawFiltered = json['filtered'] as List<dynamic>;
+      expect(
+        (rawFiltered.first as Map<String, dynamic>)['status_matches'],
+        isNull,
+      );
+      expect(result.statusMatches, isEmpty);
+
+      // FilterResult 内の filter はルールを含まない形で返る
+      expect(result.filter.keywords, isEmpty);
+      expect(result.filter.statuses, isEmpty);
+    });
+
+    test('is empty for unauthenticated responses that omit the key', () {
+      final json =
+          jsonDecode(File('test/fixtures/status.json').readAsStringSync())
+                as Map<String, dynamic>
+            ..remove('filtered');
+
+      expect(MastodonStatus.fromJson(json).filtered, isEmpty);
+    });
+  });
+
+  group('MastodonStatus quote fields (Mastodon 4.5.0)', () {
+    test('deserializes quoteApproval and quotesCount', () {
+      final file = File('test/fixtures/status.json');
+      final json = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+      final status = MastodonStatus.fromJson(json);
+
+      expect(status.quotesCount, 0);
+      expect(status.quoteApproval, isNotNull);
+      expect(status.quoteApproval!.automatic, contains('public'));
+      expect(status.quoteApproval!.manual, isEmpty);
+      expect(status.quoteApproval!.currentUser, 'automatic');
+    });
+
+    test('falls back on servers older than 4.5.0', () {
+      final json =
+          jsonDecode(File('test/fixtures/status.json').readAsStringSync())
+                as Map<String, dynamic>
+            ..remove('quote_approval')
+            ..remove('quotes_count');
+      final status = MastodonStatus.fromJson(json);
+
+      expect(status.quoteApproval, isNull);
+      expect(status.quotesCount, 0);
+    });
+  });
+
   group('MastodonStatus.fromJson - status_with_poll.json', () {
     test('deserializes poll from fixture', () {
       final file = File('test/fixtures/status_with_poll.json');

--- a/test/models/mastodon_suggestion_test.dart
+++ b/test/models/mastodon_suggestion_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+import 'dart:io';
 import 'package:mastodon_client/mastodon_client.dart';
 import 'package:test/test.dart';
 
@@ -79,6 +81,42 @@ void main() {
       final suggestion = MastodonSuggestion.fromJson(json);
 
       expect(suggestion.account.note, '<p>A great person to follow.</p>');
+    });
+  });
+
+  group('MastodonSuggestion.sources', () {
+    test('deserializes sources from fixture', () {
+      final file = File('test/fixtures/suggestions.json');
+      final list = jsonDecode(file.readAsStringSync()) as List<dynamic>;
+      final suggestions = list
+          .map((e) => MastodonSuggestion.fromJson(e as Map<String, dynamic>))
+          .toList();
+
+      expect(suggestions, isNotEmpty);
+      expect(suggestions.first.sources, contains('featured'));
+    });
+
+    test('sources carries values that source flattens away', () {
+      // source は sources.first を旧3値へ写像した劣化版。
+      // most_followed と most_interactions はどちらも global に潰れる
+      final json = <String, dynamic>{
+        'source': 'global',
+        'sources': <String>['most_interactions'],
+        'account': _minimalAccountJson(),
+      };
+      final suggestion = MastodonSuggestion.fromJson(json);
+
+      expect(suggestion.source, 'global');
+      expect(suggestion.sources, <String>['most_interactions']);
+    });
+
+    test('sources defaults to an empty list when the key is absent', () {
+      final json = <String, dynamic>{
+        'source': 'staff',
+        'account': _minimalAccountJson(),
+      };
+
+      expect(MastodonSuggestion.fromJson(json).sources, isEmpty);
     });
   });
 }


### PR DESCRIPTION
Closes #13

`fediverse_e2e`（Mastodon v4.6.3）の実応答に存在するのに、モデルが読み捨てていたフィールドを実装しました。

## 型の確定方法

issue は実応答のキー集合を基準にしていましたが、`card` / `filtered` / `wrapstodon` は fixture 上で null・空配列のため、そこからは型を決められません。稼働中の E2E 環境のコンテナに入り、**Mastodon 4.6.3 のシリアライザ実装そのもの**を参照して型を確定しました。

これにより issue の記述から2点修正が入っています。

- **`wrapstodon` はオブジェクトではなく `int?`** — `AnnualReport.current_campaign` はキャンペーン年（`datetime.year`）を返す。12月10〜31日かつ機能が有効なときだけ非 null
- **`application` は既存の `MastodonApplication` を流用できない** — 投稿APIが返すのは `{name, website}` のみ。既存クラスは `id` / `scopes` / `redirect_uris` が必須のため、そのまま使うとパースが落ちる。縮約形の `MastodonStatusApplication` を新設

## 実サーバーで採取した `filtered` の実形状

fixture に空配列しか無かったため、E2E 環境に一時フィルタを作成して実応答を採取しました（採取後に削除済み、環境は元の状態）。

```json
{
  "filter": { "id": "1", "title": "tmp-verify-13", "context": ["public"],
              "expires_at": null, "filter_action": "warn" },
  "keyword_matches": ["e2e"],
  "status_matches": null
}
```

2点、実装上重要な性質が分かりました。

- **`status_matches` は空配列ではなく `null`** で返る。デフォルト値を持たせなければここでパースが落ちる
- **`filter` はルールを含まない**。`REST::FilterSerializer` は `keywords` / `statuses` を `rules_requested?` の条件付きでしか出さないため、`MastodonFilter.keywords` / `.statuses` は常に空になる。ルールが要るなら v2 filters API を別途叩く必要がある

この応答を `test/fixtures/status_filtered.json` として固定しました。

## 変更内容

### `MastodonStatus`（5件）

| フィールド | 型 |
|---|---|
| `card` | `MastodonPreviewCard?` |
| `filtered` | `List<MastodonFilterResult>` |
| `application` | `MastodonStatusApplication?` |
| `quoteApproval` | `MastodonQuoteApproval?` |
| `quotesCount` | `int` |

`card` は #12 の実質的な修正でもあります。4.6.3 で `GET /api/v1/statuses/:id/card` が削除済みのため、これがリンクプレビューの唯一の取得経路です。

### `MastodonAccount` / `MastodonCredentialAccount`

両モデルに `uri` / `roles` / `indexable` / `group` を追加し、加えて PR #9 で `MastodonAccount` にだけ入れた 4.6.0 の6フィールド（`avatarDescription`, `headerDescription`, `featureApproval`, `showFeatured`, `showMedia`, `showMediaReplies`）を `MastodonCredentialAccount` に反映しました。

`MastodonRole` は両モデルから参照されるため、循環 import を避けて `mastodon_account.dart` に移動しています。クラス定義自体は変更なし、バレルファイル経由の export も従来どおりです。

再発防止として、同一 JSON を両モデルでパースして全フィールドが一致することを確認するテストを入れました。

### その他5件

`MastodonInstance.wrapstodon` (`int?`) / `MastodonNotification.groupKey` / `MastodonRelationship.mutingExpiresAt` / `MastodonSuggestion.sources` / `MastodonPreferences.readingAutoplayGifs`

## 根本原因への対処

issue 末尾で提案されていたキー網羅チェックを、テストとして入れました（`test/models/fixture_key_coverage_test.dart`）。

fixture のトップレベルキーが `toJson()` の出力キーに含まれることを検証します。`json_serializable` が未知キーを黙って捨てる以上、通常の fixture テストではこの種のドリフトは原理的に検出できません。実際、`card` / `filtered` / `quote_approval` / `quotes_count` は**既に fixture に入っていた**にもかかわらずテストは通っていました。

なお issue には「fixture に元々入っていないフィールドは検出できない」とありますが、実際の問題は fixture の鮮度ではなく検証手段の不在でした。

### 導入時に検出された、本 issue 対象外の欠落

このチェックを入れた時点で、#13 に挙がっていない欠落が3モデル分見つかりました。本 PR の範囲外なので**修正はせず**、テスト内の `outstandingGaps` に一覧として明示してあります。

| モデル | 欠落 |
|---|---|
| `MastodonPreviewCard` | `language`, `image_description`, `published_at` |
| `MastodonMediaAttachment` | `preview_remote_url`, `text_url`, `meta` |
| `MastodonCollection` | `items` |

`MastodonMediaAttachment.meta`（画像サイズ等）はクライアント実装で影響が出やすい箇所です。別 issue にするのが妥当だと思います。

## 検証

- `dart analyze`: No issues found
- `dart test`: **215 passed** / 3 skipped（E2E は `RUN_E2E` 未設定のためスキップ）— 導入前は 171
- fixture のキー突き合わせ: 対象9モデルで未読み取り **0件**
- 破壊的変更なし。追加フィールドは全て optional かデフォルト値付きで、既存のコンストラクタ呼び出しは影響を受けません

🤖 Generated with [Claude Code](https://claude.com/claude-code)