### PR TITLE
chore: CI導入前のSDK・依存関係と公開対象を整理

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -1,1 +1,18 @@
 docs/
+
+# 開発支援・ローカル環境用ファイル
+/AGENTS.md
+/CLAUDE.md
+/.claude/
+/firebase-debug.log
+/*.iml
+
+# ビルド・検証生成物
+/build/
+/coverage/
+
+# テスト用ファイル
+/test/
+
+# pub.dev 側で生成される API ドキュメント
+/doc/api/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** The minimum supported Dart SDK version is now 3.9.0
+- Updated runtime and development dependencies, including Dio, json_annotation, logger, build_runner, json_serializable, lints, and test
+- Replaced the Flutter-dependent `pedantic_mono` lint configuration with the official Dart `lints/recommended` ruleset, and removed the unused Flutter-dependent `pubspec_dependency_sorter`
+- Excluded tests, local build outputs, generated API documentation, and development-only configuration files from published package archives
 - **Breaking:** ID fields that some instances return as numbers are now typed `String?` and coerced from either representation, instead of being typed `int` or non-nullable `String`. Code that reads these fields as `int`, or that relies on them being non-null, needs updating:
   - `MastodonRole.id`: `int` (required) → `String?`
   - `MastodonAdminRole.id`: `int` (required) → `String?`

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,7 +2,7 @@ analyzer:
   exclude:
     - "**/*.g.dart"
     - "**/*.freezed.dart"
-include: package:pedantic_mono/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 linter:
   rules:

--- a/example/example.dart
+++ b/example/example.dart
@@ -28,9 +28,7 @@ void main() async {
   // 4. Post a status
   // -------------------------------------------------------
   final result = await client.statuses.create(
-    const MastodonStatusCreateRequest(
-      status: 'Hello from mastodon_client!',
-    ),
+    const MastodonStatusCreateRequest(status: 'Hello from mastodon_client!'),
   );
   if (result case MastodonStatusCreated(:final status)) {
     print('Posted: ${status.url}');

--- a/lib/src/api/accounts_api.dart
+++ b/lib/src/api/accounts_api.dart
@@ -479,16 +479,11 @@ class AccountsApi {
   /// remove the note.
   ///
   /// Throws a subclass of [MastodonException] on failure.
-  Future<MastodonRelationship> setNote(
-    String id, {
-    String? comment,
-  }) async {
+  Future<MastodonRelationship> setNote(String id, {String? comment}) async {
     final data = await _http.send<Map<String, dynamic>>(
       '/api/v1/accounts/$id/note',
       method: 'POST',
-      data: <String, dynamic>{
-        'comment': ?comment,
-      },
+      data: <String, dynamic>{'comment': ?comment},
     );
     return MastodonRelationship.fromJson(data!);
   }
@@ -557,9 +552,7 @@ class AccountsApi {
   ///
   /// Throws a subclass of [MastodonException] on failure.
   Future<List<MastodonList>> fetchLists(String id) async {
-    final data = await _http.send<List<dynamic>>(
-      '/api/v1/accounts/$id/lists',
-    );
+    final data = await _http.send<List<dynamic>>('/api/v1/accounts/$id/lists');
     return (data ?? const <dynamic>[])
         .cast<Map<String, dynamic>>()
         .map(MastodonList.fromJson)
@@ -588,15 +581,11 @@ class AccountsApi {
   Future<MastodonAccount> _lookupViaSearch(String acct) async {
     final results = await search(acct);
     final target = acct.toLowerCase();
-    final match = results.where(
-      (a) => a.acct.toLowerCase() == target,
-    );
+    final match = results.where((a) => a.acct.toLowerCase() == target);
     if (match.isNotEmpty) {
       return match.first;
     }
-    throw const MastodonNotFoundException(
-      message: 'Account not found',
-    );
+    throw const MastodonNotFoundException(message: 'Account not found');
   }
 
   Future<MastodonPage<MastodonAccount>> _fetchAccountPage(

--- a/lib/src/api/admin/admin_email_domain_blocks_api.dart
+++ b/lib/src/api/admin/admin_email_domain_blocks_api.dart
@@ -62,9 +62,7 @@ class AdminEmailDomainBlocksApi {
   /// `POST /api/v1/admin/email_domain_blocks`
   ///
   /// Throws a `MastodonException` on failure.
-  Future<MastodonAdminEmailDomainBlock> create({
-    required String domain,
-  }) async {
+  Future<MastodonAdminEmailDomainBlock> create({required String domain}) async {
     final data = await _http.send<Map<String, dynamic>>(
       '/api/v1/admin/email_domain_blocks',
       method: 'POST',

--- a/lib/src/api/admin/admin_trends_api.dart
+++ b/lib/src/api/admin/admin_trends_api.dart
@@ -24,9 +24,7 @@ class AdminTrendsApi {
   ///
   /// Throws a `MastodonException` on failure.
   Future<List<MastodonAdminTrendsLink>> fetchLinks() async {
-    final data = await _http.send<List<dynamic>>(
-      '/api/v1/admin/trends/links',
-    );
+    final data = await _http.send<List<dynamic>>('/api/v1/admin/trends/links');
     return (data ?? const <dynamic>[])
         .cast<Map<String, dynamic>>()
         .map(MastodonAdminTrendsLink.fromJson)
@@ -106,9 +104,7 @@ class AdminTrendsApi {
   ///
   /// Throws a `MastodonException` on failure.
   Future<List<MastodonAdminTag>> fetchTags() async {
-    final data = await _http.send<List<dynamic>>(
-      '/api/v1/admin/trends/tags',
-    );
+    final data = await _http.send<List<dynamic>>('/api/v1/admin/trends/tags');
     return (data ?? const <dynamic>[])
         .cast<Map<String, dynamic>>()
         .map(MastodonAdminTag.fromJson)

--- a/lib/src/api/announcements_api.dart
+++ b/lib/src/api/announcements_api.dart
@@ -21,9 +21,7 @@ class AnnouncementsApi {
   }) async {
     final data = await _http.send<List<dynamic>>(
       '/api/v1/announcements',
-      queryParameters: <String, dynamic>{
-        'with_dismissed': ?withDismissed,
-      },
+      queryParameters: <String, dynamic>{'with_dismissed': ?withDismissed},
     );
     return (data ?? const <dynamic>[])
         .cast<Map<String, dynamic>>()

--- a/lib/src/api/conversations_api.dart
+++ b/lib/src/api/conversations_api.dart
@@ -53,10 +53,7 @@ class ConversationsApi {
   ///
   /// Throws a `MastodonException` on failure.
   Future<void> delete(String id) async {
-    await _http.send<void>(
-      '/api/v1/conversations/$id',
-      method: 'DELETE',
-    );
+    await _http.send<void>('/api/v1/conversations/$id', method: 'DELETE');
   }
 
   /// Marks a conversation as read.

--- a/lib/src/api/emails_api.dart
+++ b/lib/src/api/emails_api.dart
@@ -22,9 +22,7 @@ class EmailsApi {
     await _http.send<dynamic>(
       '/api/v1/emails/confirmations',
       method: 'POST',
-      data: <String, dynamic>{
-        'email': ?email,
-      },
+      data: <String, dynamic>{'email': ?email},
     );
   }
 
@@ -37,8 +35,6 @@ class EmailsApi {
   ///
   /// Throws a `MastodonException` on failure.
   Future<void> checkConfirmation() async {
-    await _http.send<dynamic>(
-      '/api/v1/emails/check_confirmation',
-    );
+    await _http.send<dynamic>('/api/v1/emails/check_confirmation');
   }
 }

--- a/lib/src/api/featured_tags_api.dart
+++ b/lib/src/api/featured_tags_api.dart
@@ -15,9 +15,7 @@ class FeaturedTagsApi {
   ///
   /// Throws a `MastodonException` on failure.
   Future<List<MastodonFeaturedTag>> fetch() async {
-    final data = await _http.send<List<dynamic>>(
-      '/api/v1/featured_tags',
-    );
+    final data = await _http.send<List<dynamic>>('/api/v1/featured_tags');
     return (data ?? const <dynamic>[])
         .cast<Map<String, dynamic>>()
         .map(MastodonFeaturedTag.fromJson)
@@ -46,10 +44,7 @@ class FeaturedTagsApi {
   ///
   /// Throws a `MastodonException` on failure.
   Future<void> delete(String id) async {
-    await _http.send<void>(
-      '/api/v1/featured_tags/$id',
-      method: 'DELETE',
-    );
+    await _http.send<void>('/api/v1/featured_tags/$id', method: 'DELETE');
   }
 
   /// Fetches up to 10 recently used hashtags as feature candidates.

--- a/lib/src/api/filters_api.dart
+++ b/lib/src/api/filters_api.dart
@@ -30,9 +30,7 @@ class FiltersApi {
   ///
   /// Throws a `MastodonException` on failure.
   Future<MastodonFilter> fetchById(String id) async {
-    final data = await _http.send<Map<String, dynamic>>(
-      '/api/v2/filters/$id',
-    );
+    final data = await _http.send<Map<String, dynamic>>('/api/v2/filters/$id');
     return MastodonFilter.fromJson(data!);
   }
 
@@ -129,10 +127,7 @@ class FiltersApi {
   ///
   /// Throws a `MastodonException` on failure.
   Future<void> delete(String id) async {
-    await _http.send<void>(
-      '/api/v2/filters/$id',
-      method: 'DELETE',
-    );
+    await _http.send<void>('/api/v2/filters/$id', method: 'DELETE');
   }
 
   /// Fetches the keywords within a filter.
@@ -166,10 +161,7 @@ class FiltersApi {
     final data = await _http.send<Map<String, dynamic>>(
       '/api/v2/filters/$filterId/keywords',
       method: 'POST',
-      data: <String, dynamic>{
-        'keyword': keyword,
-        'whole_word': ?wholeWord,
-      },
+      data: <String, dynamic>{'keyword': keyword, 'whole_word': ?wholeWord},
     );
     return MastodonFilterKeyword.fromJson(data!);
   }
@@ -202,10 +194,7 @@ class FiltersApi {
     final data = await _http.send<Map<String, dynamic>>(
       '/api/v2/filters/keywords/$id',
       method: 'PUT',
-      data: <String, dynamic>{
-        'keyword': keyword,
-        'whole_word': ?wholeWord,
-      },
+      data: <String, dynamic>{'keyword': keyword, 'whole_word': ?wholeWord},
     );
     return MastodonFilterKeyword.fromJson(data!);
   }
@@ -216,10 +205,7 @@ class FiltersApi {
   ///
   /// Throws a `MastodonException` on failure.
   Future<void> deleteKeyword(String id) async {
-    await _http.send<void>(
-      '/api/v2/filters/keywords/$id',
-      method: 'DELETE',
-    );
+    await _http.send<void>('/api/v2/filters/keywords/$id', method: 'DELETE');
   }
 
   /// Fetches the status filters within a filter.
@@ -274,10 +260,7 @@ class FiltersApi {
   ///
   /// Throws a `MastodonException` on failure.
   Future<void> deleteStatus(String id) async {
-    await _http.send<void>(
-      '/api/v2/filters/statuses/$id',
-      method: 'DELETE',
-    );
+    await _http.send<void>('/api/v2/filters/statuses/$id', method: 'DELETE');
   }
 
   /// Fetches all filters (v1, deprecated).
@@ -307,9 +290,7 @@ class FiltersApi {
   // ignore: remove_deprecations_in_breaking_versions
   @Deprecated('Deprecated in Mastodon 4.0.0. Use fetchById() (v2) instead')
   Future<MastodonFilterV1> fetchByIdV1(String id) async {
-    final data = await _http.send<Map<String, dynamic>>(
-      '/api/v1/filters/$id',
-    );
+    final data = await _http.send<Map<String, dynamic>>('/api/v1/filters/$id');
     return MastodonFilterV1.fromJson(data!);
   }
 
@@ -400,20 +381,14 @@ class FiltersApi {
   // ignore: remove_deprecations_in_breaking_versions
   @Deprecated('Deprecated in Mastodon 4.0.0. Use delete() (v2) instead')
   Future<void> deleteV1(String id) async {
-    await _http.send<void>(
-      '/api/v1/filters/$id',
-      method: 'DELETE',
-    );
+    await _http.send<void>('/api/v1/filters/$id', method: 'DELETE');
   }
 }
 
 /// Keyword parameter for filter creation.
 class MastodonFilterKeywordParam {
   /// Creates a keyword parameter with [keyword] and optional [wholeWord] flag.
-  const MastodonFilterKeywordParam({
-    required this.keyword,
-    this.wholeWord,
-  });
+  const MastodonFilterKeywordParam({required this.keyword, this.wholeWord});
 
   /// Keyword string.
   final String keyword;

--- a/lib/src/api/instance_api.dart
+++ b/lib/src/api/instance_api.dart
@@ -115,9 +115,7 @@ class InstanceApi {
   /// `GET /api/v1/instance/terms_of_service/:date`
   ///
   /// Throws a `MastodonException` on failure.
-  Future<MastodonTermsOfService> fetchTermsOfServiceByDate(
-    String date,
-  ) async {
+  Future<MastodonTermsOfService> fetchTermsOfServiceByDate(String date) async {
     final data = await _http.send<Map<String, dynamic>>(
       '/api/v1/instance/terms_of_service/$date',
     );
@@ -152,10 +150,7 @@ class InstanceApi {
       '/api/v1/instance/translation_languages',
     );
     return (data ?? const <String, dynamic>{}).map(
-      (key, value) => MapEntry(
-        key,
-        (value as List<dynamic>).cast<String>(),
-      ),
+      (key, value) => MapEntry(key, (value as List<dynamic>).cast<String>()),
     );
   }
 }

--- a/lib/src/api/lists_api.dart
+++ b/lib/src/api/lists_api.dart
@@ -30,9 +30,7 @@ class ListsApi {
   ///
   /// Throws a `MastodonException` on failure.
   Future<MastodonList> fetchById(String id) async {
-    final data = await _http.send<Map<String, dynamic>>(
-      '/api/v1/lists/$id',
-    );
+    final data = await _http.send<Map<String, dynamic>>('/api/v1/lists/$id');
     return MastodonList.fromJson(data!);
   }
 
@@ -97,10 +95,7 @@ class ListsApi {
   ///
   /// Throws a `MastodonException` on failure.
   Future<void> delete(String id) async {
-    await _http.send<void>(
-      '/api/v1/lists/$id',
-      method: 'DELETE',
-    );
+    await _http.send<void>('/api/v1/lists/$id', method: 'DELETE');
   }
 
   /// Fetches the accounts belonging to a list.

--- a/lib/src/api/markers_api.dart
+++ b/lib/src/api/markers_api.dart
@@ -25,10 +25,8 @@ class MarkersApi {
     );
     if (data == null) return const {};
     return data.map(
-      (key, value) => MapEntry(
-        key,
-        MastodonMarker.fromJson(value as Map<String, dynamic>),
-      ),
+      (key, value) =>
+          MapEntry(key, MastodonMarker.fromJson(value as Map<String, dynamic>)),
     );
   }
 
@@ -57,10 +55,8 @@ class MarkersApi {
     );
     if (data == null) return const {};
     return data.map(
-      (key, value) => MapEntry(
-        key,
-        MastodonMarker.fromJson(value as Map<String, dynamic>),
-      ),
+      (key, value) =>
+          MapEntry(key, MastodonMarker.fromJson(value as Map<String, dynamic>)),
     );
   }
 }

--- a/lib/src/api/media_api.dart
+++ b/lib/src/api/media_api.dart
@@ -116,9 +116,7 @@ class MediaApi {
   ///
   /// Throws a `MastodonException` on failure.
   Future<MastodonMediaAttachment> fetchById(String id) async {
-    final data = await _http.send<Map<String, dynamic>>(
-      '/api/v1/media/$id',
-    );
+    final data = await _http.send<Map<String, dynamic>>('/api/v1/media/$id');
     if (data == null) {
       throw const MastodonApiException(
         statusCode: 0,
@@ -157,10 +155,7 @@ class MediaApi {
         'focus': ?focus,
       });
     } else {
-      body = <String, dynamic>{
-        'description': ?description,
-        'focus': ?focus,
-      };
+      body = <String, dynamic>{'description': ?description, 'focus': ?focus};
     }
 
     final data = await _http.send<Map<String, dynamic>>(
@@ -187,10 +182,7 @@ class MediaApi {
   ///
   /// Throws a `MastodonException` on failure.
   Future<void> delete(String id) async {
-    await _http.send<void>(
-      '/api/v1/media/$id',
-      method: 'DELETE',
-    );
+    await _http.send<void>('/api/v1/media/$id', method: 'DELETE');
   }
 
   /// Polls until the `url` field becomes non-null and returns the completed

--- a/lib/src/api/notifications_api.dart
+++ b/lib/src/api/notifications_api.dart
@@ -73,10 +73,7 @@ class NotificationsApi {
   ///
   /// `POST /api/v1/notifications/clear`
   Future<void> clear() async {
-    await _http.send<dynamic>(
-      '/api/v1/notifications/clear',
-      method: 'POST',
-    );
+    await _http.send<dynamic>('/api/v1/notifications/clear', method: 'POST');
   }
 
   /// Dismisses a notification by its ID.
@@ -96,9 +93,7 @@ class NotificationsApi {
   /// **Deprecated**: Deprecated in Mastodon 1.3.0, removed in 3.0.0.
   /// Use [dismiss] (path-based) instead.
   // ignore: remove_deprecations_in_breaking_versions
-  @Deprecated(
-    'Removed in Mastodon 3.0.0. Use dismiss() instead',
-  )
+  @Deprecated('Removed in Mastodon 3.0.0. Use dismiss() instead')
   Future<void> dismissV1(String id) async {
     await _http.send<dynamic>(
       '/api/v1/notifications/dismiss',

--- a/lib/src/api/oauth_api.dart
+++ b/lib/src/api/oauth_api.dart
@@ -85,9 +85,7 @@ class OAuthApi {
   ///
   /// Throws a `MastodonException` on failure.
   Future<MastodonOAuthUserInfo> fetchUserInfo() async {
-    final data = await _http.send<Map<String, dynamic>>(
-      '/oauth/userinfo',
-    );
+    final data = await _http.send<Map<String, dynamic>>('/oauth/userinfo');
     return MastodonOAuthUserInfo.fromJson(data!);
   }
 

--- a/lib/src/api/preferences_api.dart
+++ b/lib/src/api/preferences_api.dart
@@ -20,9 +20,7 @@ class PreferencesApi {
   ///
   /// Throws a `MastodonException` on failure.
   Future<MastodonPreferences> fetch() async {
-    final data = await _http.send<Map<String, dynamic>>(
-      '/api/v1/preferences',
-    );
+    final data = await _http.send<Map<String, dynamic>>('/api/v1/preferences');
     return MastodonPreferences.fromJson(data!);
   }
 }

--- a/lib/src/api/push_api.dart
+++ b/lib/src/api/push_api.dart
@@ -53,9 +53,6 @@ class PushApi {
   ///
   /// `DELETE /api/v1/push/subscription`
   Future<void> delete() async {
-    await _http.send<dynamic>(
-      '/api/v1/push/subscription',
-      method: 'DELETE',
-    );
+    await _http.send<dynamic>('/api/v1/push/subscription', method: 'DELETE');
   }
 }

--- a/lib/src/api/scheduled_statuses_api.dart
+++ b/lib/src/api/scheduled_statuses_api.dart
@@ -85,9 +85,6 @@ class ScheduledStatusesApi {
   ///
   /// Throws a `MastodonException` on failure.
   Future<void> delete(String id) async {
-    await _http.send<void>(
-      '/api/v1/scheduled_statuses/$id',
-      method: 'DELETE',
-    );
+    await _http.send<void>('/api/v1/scheduled_statuses/$id', method: 'DELETE');
   }
 }

--- a/lib/src/api/search_api.dart
+++ b/lib/src/api/search_api.dart
@@ -76,9 +76,7 @@ class SearchApi {
   ///
   /// Throws a `MastodonException` on failure.
   // ignore: remove_deprecations_in_breaking_versions
-  @Deprecated(
-    'Removed in Mastodon 3.0.0. Use search() (v2) instead',
-  )
+  @Deprecated('Removed in Mastodon 3.0.0. Use search() (v2) instead')
   Future<MastodonSearchResultV1> searchV1(
     String query, {
     String? type,

--- a/lib/src/api/statuses_api.dart
+++ b/lib/src/api/statuses_api.dart
@@ -393,9 +393,7 @@ class StatusesApi {
           : null,
     );
     if (request.scheduledAt != null) {
-      return MastodonStatusScheduled(
-        MastodonScheduledStatus.fromJson(data!),
-      );
+      return MastodonStatusScheduled(MastodonScheduledStatus.fromJson(data!));
     }
     return MastodonStatusCreated(MastodonStatus.fromJson(data!));
   }
@@ -432,9 +430,7 @@ class StatusesApi {
     final data = await _http.send<Map<String, dynamic>>(
       '/api/v1/statuses/$id',
       method: 'DELETE',
-      queryParameters: <String, dynamic>{
-        'delete_media': ?deleteMedia,
-      },
+      queryParameters: <String, dynamic>{'delete_media': ?deleteMedia},
     );
     return MastodonStatus.fromJson(data!);
   }
@@ -452,9 +448,7 @@ class StatusesApi {
     final data = await _http.send<Map<String, dynamic>>(
       '/api/v1/statuses/$id/translate',
       method: 'POST',
-      data: <String, dynamic>{
-        'lang': ?lang,
-      },
+      data: <String, dynamic>{'lang': ?lang},
     );
     return MastodonTranslation.fromJson(data!);
   }
@@ -474,9 +468,7 @@ class StatusesApi {
     final data = await _http.send<Map<String, dynamic>>(
       '/api/v1/statuses/$id/interaction_policy',
       method: 'PUT',
-      data: <String, dynamic>{
-        'quote_approval_policy': quoteApprovalPolicy,
-      },
+      data: <String, dynamic>{'quote_approval_policy': quoteApprovalPolicy},
     );
     return MastodonStatus.fromJson(data!);
   }
@@ -490,10 +482,7 @@ class StatusesApi {
   /// the status that performs the quote.
   ///
   /// Throws a `MastodonException` on failure.
-  Future<MastodonStatus> revokeQuote(
-    String id,
-    String quotingStatusId,
-  ) async {
+  Future<MastodonStatus> revokeQuote(String id, String quotingStatusId) async {
     final data = await _http.send<Map<String, dynamic>>(
       '/api/v1/statuses/$id/quotes/$quotingStatusId/revoke',
       method: 'POST',

--- a/lib/src/api/suggestions_api.dart
+++ b/lib/src/api/suggestions_api.dart
@@ -21,9 +21,7 @@ class SuggestionsApi {
   Future<List<MastodonSuggestion>> fetch({int? limit}) async {
     final data = await _http.send<List<dynamic>>(
       '/api/v2/suggestions',
-      queryParameters: <String, dynamic>{
-        'limit': ?limit,
-      },
+      queryParameters: <String, dynamic>{'limit': ?limit},
     );
     return (data ?? const <dynamic>[])
         .cast<Map<String, dynamic>>()
@@ -46,9 +44,7 @@ class SuggestionsApi {
   Future<List<MastodonAccount>> fetchV1({int? limit}) async {
     final data = await _http.send<List<dynamic>>(
       '/api/v1/suggestions',
-      queryParameters: <String, dynamic>{
-        'limit': ?limit,
-      },
+      queryParameters: <String, dynamic>{'limit': ?limit},
     );
     return (data ?? const <dynamic>[])
         .cast<Map<String, dynamic>>()
@@ -64,9 +60,6 @@ class SuggestionsApi {
   ///
   /// Throws a `MastodonException` on failure.
   Future<void> remove(String accountId) async {
-    await _http.send<void>(
-      '/api/v1/suggestions/$accountId',
-      method: 'DELETE',
-    );
+    await _http.send<void>('/api/v1/suggestions/$accountId', method: 'DELETE');
   }
 }

--- a/lib/src/api/tags_api.dart
+++ b/lib/src/api/tags_api.dart
@@ -17,9 +17,7 @@ class TagsApi {
   ///
   /// Throws a `MastodonException` on failure.
   Future<MastodonTag> fetch(String name) async {
-    final data = await _http.send<Map<String, dynamic>>(
-      '/api/v1/tags/$name',
-    );
+    final data = await _http.send<Map<String, dynamic>>('/api/v1/tags/$name');
     return MastodonTag.fromJson(data!);
   }
 

--- a/lib/src/api/timelines_api.dart
+++ b/lib/src/api/timelines_api.dart
@@ -49,10 +49,7 @@ class TimelinesApi {
     sinceId: sinceId,
     maxId: maxId,
     minId: minId,
-    extraQuery: {
-      'local': true,
-      'only_media': ?onlyMedia,
-    },
+    extraQuery: {'local': true, 'only_media': ?onlyMedia},
   );
 
   /// Fetches the federated timeline.
@@ -77,10 +74,7 @@ class TimelinesApi {
     sinceId: sinceId,
     maxId: maxId,
     minId: minId,
-    extraQuery: {
-      'only_media': ?onlyMedia,
-      'remote': ?remoteOnly,
-    },
+    extraQuery: {'only_media': ?onlyMedia, 'remote': ?remoteOnly},
   );
 
   /// Fetches the timeline for the specified hashtag.
@@ -177,9 +171,7 @@ class TimelinesApi {
   /// Use [sinceId] for newer statuses, [maxId] for older ones, and [minId]
   /// for forward pagination.
   // ignore: remove_deprecations_in_breaking_versions
-  @Deprecated(
-    'Removed in Mastodon 3.0.0. Use ConversationsApi instead',
-  )
+  @Deprecated('Removed in Mastodon 3.0.0. Use ConversationsApi instead')
   Future<MastodonPage<MastodonStatus>> fetchDirect({
     int? limit,
     String? sinceId,

--- a/lib/src/api/trends_api.dart
+++ b/lib/src/api/trends_api.dart
@@ -20,16 +20,10 @@ class TrendsApi {
   /// (default: 10, max: 20) and [offset] skips that many for pagination.
   ///
   /// Throws a `MastodonException` on failure.
-  Future<List<MastodonTag>> fetchTags({
-    int? limit,
-    int? offset,
-  }) async {
+  Future<List<MastodonTag>> fetchTags({int? limit, int? offset}) async {
     final data = await _http.send<List<dynamic>>(
       '/api/v1/trends/tags',
-      queryParameters: <String, dynamic>{
-        'limit': ?limit,
-        'offset': ?offset,
-      },
+      queryParameters: <String, dynamic>{'limit': ?limit, 'offset': ?offset},
     );
     return (data ?? const <dynamic>[])
         .cast<Map<String, dynamic>>()
@@ -46,16 +40,10 @@ class TrendsApi {
   /// and [offset] skips that many for pagination.
   ///
   /// Throws a `MastodonException` on failure.
-  Future<List<MastodonStatus>> fetchStatuses({
-    int? limit,
-    int? offset,
-  }) async {
+  Future<List<MastodonStatus>> fetchStatuses({int? limit, int? offset}) async {
     final data = await _http.send<List<dynamic>>(
       '/api/v1/trends/statuses',
-      queryParameters: <String, dynamic>{
-        'limit': ?limit,
-        'offset': ?offset,
-      },
+      queryParameters: <String, dynamic>{'limit': ?limit, 'offset': ?offset},
     );
     return (data ?? const <dynamic>[])
         .cast<Map<String, dynamic>>()
@@ -72,16 +60,10 @@ class TrendsApi {
   /// and [offset] skips that many for pagination.
   ///
   /// Throws a `MastodonException` on failure.
-  Future<List<MastodonTrendsLink>> fetchLinks({
-    int? limit,
-    int? offset,
-  }) async {
+  Future<List<MastodonTrendsLink>> fetchLinks({int? limit, int? offset}) async {
     final data = await _http.send<List<dynamic>>(
       '/api/v1/trends/links',
-      queryParameters: <String, dynamic>{
-        'limit': ?limit,
-        'offset': ?offset,
-      },
+      queryParameters: <String, dynamic>{'limit': ?limit, 'offset': ?offset},
     );
     return (data ?? const <dynamic>[])
         .cast<Map<String, dynamic>>()

--- a/lib/src/client/mastodon_http_client.dart
+++ b/lib/src/client/mastodon_http_client.dart
@@ -110,10 +110,7 @@ class MastodonHttpClient {
 }
 
 class _MastodonInterceptor extends Interceptor {
-  _MastodonInterceptor({
-    required this.enableLog,
-    required this.logger,
-  });
+  _MastodonInterceptor({required this.enableLog, required this.logger});
 
   final bool enableLog;
   final Logger logger;
@@ -121,9 +118,7 @@ class _MastodonInterceptor extends Interceptor {
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
     if (enableLog && kDebugMode) {
-      clientLog.d(
-        '[HTTP REQ] ${options.method} ${options.uri}',
-      );
+      clientLog.d('[HTTP REQ] ${options.method} ${options.uri}');
     }
     super.onRequest(options, handler);
   }

--- a/lib/src/models/admin/mastodon_admin_account.dart
+++ b/lib/src/models/admin/mastodon_admin_account.dart
@@ -110,10 +110,7 @@ class MastodonAdminAccount {
 /// Admin-level IP address information.
 @JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAdminIp {
-  const MastodonAdminIp({
-    required this.ip,
-    this.usedAt,
-  });
+  const MastodonAdminIp({required this.ip, this.usedAt});
 
   factory MastodonAdminIp.fromJson(Map<String, dynamic> json) =>
       _$MastodonAdminIpFromJson(json);

--- a/lib/src/models/admin/mastodon_admin_dimension.dart
+++ b/lib/src/models/admin/mastodon_admin_dimension.dart
@@ -7,10 +7,7 @@ part 'mastodon_admin_dimension.g.dart';
 /// Represents qualitative statistical information about the server.
 @JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAdminDimension {
-  const MastodonAdminDimension({
-    required this.key,
-    this.data = const [],
-  });
+  const MastodonAdminDimension({required this.key, this.data = const []});
 
   factory MastodonAdminDimension.fromJson(Map<String, dynamic> json) =>
       _$MastodonAdminDimensionFromJson(json);

--- a/lib/src/models/admin/mastodon_admin_measure.dart
+++ b/lib/src/models/admin/mastodon_admin_measure.dart
@@ -45,10 +45,7 @@ class MastodonAdminMeasure {
 /// Daily data entry for a measure.
 @JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAdminMeasureData {
-  const MastodonAdminMeasureData({
-    required this.date,
-    required this.value,
-  });
+  const MastodonAdminMeasureData({required this.date, required this.value});
 
   factory MastodonAdminMeasureData.fromJson(Map<String, dynamic> json) =>
       _$MastodonAdminMeasureDataFromJson(json);

--- a/lib/src/models/admin/mastodon_admin_report_update_request.dart
+++ b/lib/src/models/admin/mastodon_admin_report_update_request.dart
@@ -3,10 +3,7 @@
 /// Request body for `PUT /api/v1/admin/reports/:id`.
 class MastodonAdminReportUpdateRequest {
   /// Creates a [MastodonAdminReportUpdateRequest].
-  const MastodonAdminReportUpdateRequest({
-    this.category,
-    this.ruleIds,
-  });
+  const MastodonAdminReportUpdateRequest({this.category, this.ruleIds});
 
   /// Report category (`spam` / `legal` / `violation` / `other`).
   final String? category;

--- a/lib/src/models/admin/mastodon_admin_trends_link.dart
+++ b/lib/src/models/admin/mastodon_admin_trends_link.dart
@@ -56,10 +56,7 @@ class MastodonAdminTrendsLink {
   final String description;
 
   /// Type of the preview card.
-  @JsonKey(
-    readValue: _readType,
-    unknownEnumValue: MastodonPreviewCardType.link,
-  )
+  @JsonKey(readValue: _readType, unknownEnumValue: MastodonPreviewCardType.link)
   final MastodonPreviewCardType type;
 
   /// Name of the content author.

--- a/lib/src/models/mastodon_announcement.dart
+++ b/lib/src/models/mastodon_announcement.dart
@@ -121,10 +121,7 @@ class MastodonAnnouncement {
 /// Status referenced in an announcement body.
 @JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAnnouncementStatus {
-  const MastodonAnnouncementStatus({
-    required this.id,
-    required this.url,
-  });
+  const MastodonAnnouncementStatus({required this.id, required this.url});
 
   factory MastodonAnnouncementStatus.fromJson(Map<String, dynamic> json) =>
       _$MastodonAnnouncementStatusFromJson(json);

--- a/lib/src/models/mastodon_credential_account_update_request.dart
+++ b/lib/src/models/mastodon_credential_account_update_request.dart
@@ -84,12 +84,7 @@ class MastodonCredentialAccountUpdateRequest {
     }
     if (fieldsAttributes != null) {
       map['fields_attributes'] = fieldsAttributes!
-          .map(
-            (f) => <String, dynamic>{
-              'name': f.name,
-              'value': f.value,
-            },
-          )
+          .map((f) => <String, dynamic>{'name': f.name, 'value': f.value})
           .toList();
     }
     if (sourcePrivacy != null ||
@@ -111,10 +106,7 @@ class MastodonCredentialAccountUpdateRequest {
 /// Custom profile field attribute.
 class MastodonFieldAttribute {
   /// Creates with the given field name and value.
-  const MastodonFieldAttribute({
-    required this.name,
-    required this.value,
-  });
+  const MastodonFieldAttribute({required this.name, required this.value});
 
   /// Label name of the field.
   final String name;

--- a/lib/src/models/mastodon_extended_description.dart
+++ b/lib/src/models/mastodon_extended_description.dart
@@ -9,10 +9,7 @@ part 'mastodon_extended_description.g.dart';
 /// `GET /api/v1/instance/extended_description`
 @JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonExtendedDescription {
-  const MastodonExtendedDescription({
-    this.updatedAt,
-    required this.content,
-  });
+  const MastodonExtendedDescription({this.updatedAt, required this.content});
 
   factory MastodonExtendedDescription.fromJson(Map<String, dynamic> json) =>
       _$MastodonExtendedDescriptionFromJson(json);

--- a/lib/src/models/mastodon_familiar_followers.dart
+++ b/lib/src/models/mastodon_familiar_followers.dart
@@ -8,10 +8,7 @@ part 'mastodon_familiar_followers.g.dart';
 @JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonFamiliarFollowers {
   /// Creates a [MastodonFamiliarFollowers] with the given fields.
-  const MastodonFamiliarFollowers({
-    required this.id,
-    required this.accounts,
-  });
+  const MastodonFamiliarFollowers({required this.id, required this.accounts});
 
   /// Creates a [MastodonFamiliarFollowers] from a JSON map.
   factory MastodonFamiliarFollowers.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/models/mastodon_filter.dart
+++ b/lib/src/models/mastodon_filter.dart
@@ -103,10 +103,7 @@ class MastodonFilterKeyword {
 /// Corresponds to the response from `/api/v2/filters/:filter_id/statuses`.
 @JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonFilterStatus {
-  const MastodonFilterStatus({
-    required this.id,
-    required this.statusId,
-  });
+  const MastodonFilterStatus({required this.id, required this.statusId});
 
   factory MastodonFilterStatus.fromJson(Map<String, dynamic> json) =>
       _$MastodonFilterStatusFromJson(json);

--- a/lib/src/models/mastodon_instance.dart
+++ b/lib/src/models/mastodon_instance.dart
@@ -20,10 +20,7 @@ enum MastodonTimelineAccessLevel {
 /// Access settings for live feeds (real-time timelines).
 @JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonTimelineLiveFeeds {
-  const MastodonTimelineLiveFeeds({
-    required this.local,
-    required this.remote,
-  });
+  const MastodonTimelineLiveFeeds({required this.local, required this.remote});
 
   factory MastodonTimelineLiveFeeds.fromJson(Map<String, dynamic> json) =>
       _$MastodonTimelineLiveFeedsFromJson(json);
@@ -315,10 +312,8 @@ class MastodonInstanceConfiguration {
     String key,
   ) => (json['translation'] as Map<dynamic, dynamic>?)?['enabled'];
 
-  static Object? _readVapidPublicKey(
-    Map<dynamic, dynamic> json,
-    String key,
-  ) => (json['vapid'] as Map<dynamic, dynamic>?)?['public_key'];
+  static Object? _readVapidPublicKey(Map<dynamic, dynamic> json, String key) =>
+      (json['vapid'] as Map<dynamic, dynamic>?)?['public_key'];
 
   /// URL settings (including streaming URL).
   @JsonKey(readValue: _readUrls)
@@ -507,14 +502,10 @@ class MastodonInstanceRule {
 /// Translation of an instance rule (`rules[].translations`).
 @JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonInstanceRuleTranslation {
-  const MastodonInstanceRuleTranslation({
-    required this.text,
-    this.hint,
-  });
+  const MastodonInstanceRuleTranslation({required this.text, this.hint});
 
-  factory MastodonInstanceRuleTranslation.fromJson(
-    Map<String, dynamic> json,
-  ) => _$MastodonInstanceRuleTranslationFromJson(json);
+  factory MastodonInstanceRuleTranslation.fromJson(Map<String, dynamic> json) =>
+      _$MastodonInstanceRuleTranslationFromJson(json);
 
   /// Serializes to JSON.
   Map<String, dynamic> toJson() =>
@@ -624,10 +615,7 @@ class MastodonInstance {
 /// Instance icon image (`icon`, Mastodon 4.3+).
 @JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonInstanceIcon {
-  const MastodonInstanceIcon({
-    required this.src,
-    required this.size,
-  });
+  const MastodonInstanceIcon({required this.src, required this.size});
 
   factory MastodonInstanceIcon.fromJson(Map<String, dynamic> json) =>
       _$MastodonInstanceIconFromJson(json);

--- a/lib/src/models/mastodon_instance_v1.dart
+++ b/lib/src/models/mastodon_instance_v1.dart
@@ -57,9 +57,8 @@ class MastodonInstanceV1Configuration {
     this.polls,
   });
 
-  factory MastodonInstanceV1Configuration.fromJson(
-    Map<String, dynamic> json,
-  ) => _$MastodonInstanceV1ConfigurationFromJson(json);
+  factory MastodonInstanceV1Configuration.fromJson(Map<String, dynamic> json) =>
+      _$MastodonInstanceV1ConfigurationFromJson(json);
 
   /// Serializes to JSON.
   Map<String, dynamic> toJson() =>

--- a/lib/src/models/mastodon_media_attachment.dart
+++ b/lib/src/models/mastodon_media_attachment.dart
@@ -4,13 +4,7 @@ part 'mastodon_media_attachment.g.dart';
 
 /// Type of media.
 @JsonEnum(fieldRename: FieldRename.snake)
-enum MastodonMediaType {
-  unknown,
-  image,
-  gifv,
-  video,
-  audio,
-}
+enum MastodonMediaType { unknown, image, gifv, video, audio }
 
 /// Media attachment on Mastodon.
 @JsonSerializable(fieldRename: FieldRename.snake)

--- a/lib/src/models/mastodon_page.dart
+++ b/lib/src/models/mastodon_page.dart
@@ -5,11 +5,7 @@
 class MastodonPage<T> {
   /// Creates with [items] as the page contents, and [nextMaxId] and [prevMinId]
   /// as pagination cursors.
-  const MastodonPage({
-    required this.items,
-    this.nextMaxId,
-    this.prevMinId,
-  });
+  const MastodonPage({required this.items, this.nextMaxId, this.prevMinId});
 
   /// List of items in the page.
   final List<T> items;

--- a/lib/src/models/mastodon_poll.dart
+++ b/lib/src/models/mastodon_poll.dart
@@ -8,10 +8,7 @@ part 'mastodon_poll.g.dart';
 /// Poll option.
 @JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonPollOption {
-  const MastodonPollOption({
-    required this.title,
-    this.votesCount,
-  });
+  const MastodonPollOption({required this.title, this.votesCount});
 
   factory MastodonPollOption.fromJson(Map<String, dynamic> json) =>
       _$MastodonPollOptionFromJson(json);

--- a/lib/src/models/mastodon_privacy_policy.dart
+++ b/lib/src/models/mastodon_privacy_policy.dart
@@ -9,10 +9,7 @@ part 'mastodon_privacy_policy.g.dart';
 /// `GET /api/v1/instance/privacy_policy`
 @JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonPrivacyPolicy {
-  const MastodonPrivacyPolicy({
-    this.updatedAt,
-    required this.content,
-  });
+  const MastodonPrivacyPolicy({this.updatedAt, required this.content});
 
   factory MastodonPrivacyPolicy.fromJson(Map<String, dynamic> json) =>
       _$MastodonPrivacyPolicyFromJson(json);

--- a/lib/src/models/mastodon_proof.dart
+++ b/lib/src/models/mastodon_proof.dart
@@ -11,10 +11,7 @@ part 'mastodon_proof.g.dart';
 @JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonProof {
   /// Creates a [MastodonProof] with the given fields.
-  const MastodonProof({
-    required this.avatar,
-    required this.signatures,
-  });
+  const MastodonProof({required this.avatar, required this.signatures});
 
   /// Creates a [MastodonProof] from a JSON map.
   factory MastodonProof.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/models/mastodon_push_subscription_request.dart
+++ b/lib/src/models/mastodon_push_subscription_request.dart
@@ -108,19 +108,14 @@ class MastodonPushSubscriptionRequest {
     final json = <String, dynamic>{
       'subscription': <String, dynamic>{
         'endpoint': endpoint,
-        'keys': <String, dynamic>{
-          'p256dh': p256dh,
-          'auth': auth,
-        },
+        'keys': <String, dynamic>{'p256dh': p256dh, 'auth': auth},
       },
     };
     if (standard != null) {
       (json['subscription'] as Map<String, dynamic>)['standard'] = standard;
     }
     if (alerts != null) {
-      json['data'] = <String, dynamic>{
-        'alerts': alerts!.toJson(),
-      };
+      json['data'] = <String, dynamic>{'alerts': alerts!.toJson()};
     }
     if (policy != null) {
       final data = json['data'] as Map<String, dynamic>? ?? <String, dynamic>{};
@@ -137,10 +132,7 @@ class MastodonPushSubscriptionRequest {
 /// Updates only the `data` portion (alert settings and policy) of the
 /// subscription.
 class MastodonPushSubscriptionUpdateRequest {
-  const MastodonPushSubscriptionUpdateRequest({
-    this.alerts,
-    this.policy,
-  });
+  const MastodonPushSubscriptionUpdateRequest({this.alerts, this.policy});
 
   /// Settings per notification type.
   final MastodonPushAlertSettings? alerts;

--- a/lib/src/models/mastodon_status.dart
+++ b/lib/src/models/mastodon_status.dart
@@ -16,12 +16,7 @@ part 'mastodon_status.g.dart';
 
 /// Visibility of a status.
 @JsonEnum(fieldRename: FieldRename.snake)
-enum MastodonVisibility {
-  public,
-  unlisted,
-  private,
-  direct,
-}
+enum MastodonVisibility { public, unlisted, private, direct }
 
 /// Mention (the `@username` portion within a status).
 @JsonSerializable(fieldRename: FieldRename.snake)
@@ -242,10 +237,7 @@ class MastodonStatus {
 /// disclosed for other users' statuses.
 @JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonStatusApplication {
-  const MastodonStatusApplication({
-    required this.name,
-    this.website,
-  });
+  const MastodonStatusApplication({required this.name, this.website});
 
   factory MastodonStatusApplication.fromJson(Map<String, dynamic> json) =>
       _$MastodonStatusApplicationFromJson(json);

--- a/lib/src/models/mastodon_translation.dart
+++ b/lib/src/models/mastodon_translation.dart
@@ -76,10 +76,7 @@ class MastodonTranslationAttachment {
 /// Poll information within a translation result.
 @JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonTranslationPoll {
-  const MastodonTranslationPoll({
-    required this.id,
-    required this.options,
-  });
+  const MastodonTranslationPoll({required this.id, required this.options});
 
   factory MastodonTranslationPoll.fromJson(Map<String, dynamic> json) =>
       _$MastodonTranslationPollFromJson(json);

--- a/lib/src/models/mastodon_trends_link.dart
+++ b/lib/src/models/mastodon_trends_link.dart
@@ -78,10 +78,7 @@ class MastodonTrendsLink {
   final String description;
 
   /// Type of the preview card.
-  @JsonKey(
-    readValue: _readType,
-    unknownEnumValue: MastodonPreviewCardType.link,
-  )
+  @JsonKey(readValue: _readType, unknownEnumValue: MastodonPreviewCardType.link)
   final MastodonPreviewCardType type;
 
   /// Name of the content author.

--- a/lib/src/models/mastodon_unread_notification_count.dart
+++ b/lib/src/models/mastodon_unread_notification_count.dart
@@ -9,9 +9,8 @@ part 'mastodon_unread_notification_count.g.dart';
 class MastodonUnreadNotificationCount {
   const MastodonUnreadNotificationCount({required this.count});
 
-  factory MastodonUnreadNotificationCount.fromJson(
-    Map<String, dynamic> json,
-  ) => _$MastodonUnreadNotificationCountFromJson(json);
+  factory MastodonUnreadNotificationCount.fromJson(Map<String, dynamic> json) =>
+      _$MastodonUnreadNotificationCountFromJson(json);
 
   /// Serializes to JSON.
   Map<String, dynamic> toJson() =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,23 +2,21 @@ name: mastodon_client
 version: 1.0.0-beta.1
 documentation: https://librarylibrarian.github.io/mastodon_client/
 environment:
-  sdk: ^3.8.0
+  sdk: ">=3.9.0 <4.0.0"
 description: >-
   A pure Dart Mastodon API client. Covers accounts, statuses, timelines,
   notifications, media, filters, and admin APIs with OAuth, pagination,
   and typed error handling.
 dependencies:
   crypto: ^3.0.7
-  dio: ^5.9.2
-  json_annotation: ^4.11.0
-  logger: ^2.6.2
+  dio: ^5.11.0
+  json_annotation: ^4.12.0
+  logger: ^2.7.0
 dev_dependencies:
-  build_runner: ^2.12.2
-  json_serializable: ^6.13.0
-  lints: ^6.0.0
-  pedantic_mono: ^1.35.0
-  pubspec_dependency_sorter: ^1.0.5
-  test: ^1.25.0
+  build_runner: ^2.15.1
+  json_serializable: ^6.14.1
+  lints: ^6.1.0
+  test: ^1.31.0
 repository: https://github.com/LibraryLibrarian/mastodon_client
 topics:
   - mastodon

--- a/test/internal/dio_error_handler_test.dart
+++ b/test/internal/dio_error_handler_test.dart
@@ -122,24 +122,18 @@ void main() {
       expect((result as MastodonApiException).message, 'Not found');
     });
 
-    test(
-      'unmapped status codes fall back to the DioException message when '
-      'no server message is present',
-      () {
-        final options = RequestOptions(path: '/api/v1/statuses');
-        final exception = DioException(
-          requestOptions: options,
-          response: Response<dynamic>(
-            requestOptions: options,
-            statusCode: 418,
-          ),
-          type: DioExceptionType.badResponse,
-          message: "I'm a teapot",
-        );
-        final result = convertDioException(exception);
-        expect((result as MastodonApiException).message, "I'm a teapot");
-      },
-    );
+    test('unmapped status codes fall back to the DioException message when '
+        'no server message is present', () {
+      final options = RequestOptions(path: '/api/v1/statuses');
+      final exception = DioException(
+        requestOptions: options,
+        response: Response<dynamic>(requestOptions: options, statusCode: 418),
+        type: DioExceptionType.badResponse,
+        message: "I'm a teapot",
+      );
+      final result = convertDioException(exception);
+      expect((result as MastodonApiException).message, "I'm a teapot");
+    });
   });
 
   group('convertDioException - retry-after header (429)', () {

--- a/test/models/admin/mastodon_admin_dimension_test.dart
+++ b/test/models/admin/mastodon_admin_dimension_test.dart
@@ -10,9 +10,7 @@ void main() {
       final list = jsonDecode(file.readAsStringSync()) as List<dynamic>;
       final dimensions = list
           .map(
-            (e) => MastodonAdminDimension.fromJson(
-              e as Map<String, dynamic>,
-            ),
+            (e) => MastodonAdminDimension.fromJson(e as Map<String, dynamic>),
           )
           .toList();
 
@@ -24,9 +22,7 @@ void main() {
       final list = jsonDecode(file.readAsStringSync()) as List<dynamic>;
       final dimensions = list
           .map(
-            (e) => MastodonAdminDimension.fromJson(
-              e as Map<String, dynamic>,
-            ),
+            (e) => MastodonAdminDimension.fromJson(e as Map<String, dynamic>),
           )
           .toList();
 

--- a/test/models/admin/mastodon_admin_domain_allow_test.dart
+++ b/test/models/admin/mastodon_admin_domain_allow_test.dart
@@ -10,9 +10,7 @@ void main() {
       final list = jsonDecode(file.readAsStringSync()) as List<dynamic>;
       final allows = list
           .map(
-            (e) => MastodonAdminDomainAllow.fromJson(
-              e as Map<String, dynamic>,
-            ),
+            (e) => MastodonAdminDomainAllow.fromJson(e as Map<String, dynamic>),
           )
           .toList();
 
@@ -24,9 +22,7 @@ void main() {
       final list = jsonDecode(file.readAsStringSync()) as List<dynamic>;
       final allows = list
           .map(
-            (e) => MastodonAdminDomainAllow.fromJson(
-              e as Map<String, dynamic>,
-            ),
+            (e) => MastodonAdminDomainAllow.fromJson(e as Map<String, dynamic>),
           )
           .toList();
 

--- a/test/models/admin/mastodon_admin_domain_block_test.dart
+++ b/test/models/admin/mastodon_admin_domain_block_test.dart
@@ -30,9 +30,7 @@ void main() {
       final list = jsonDecode(file.readAsStringSync()) as List<dynamic>;
       final blocks = list
           .map(
-            (e) => MastodonAdminDomainBlock.fromJson(
-              e as Map<String, dynamic>,
-            ),
+            (e) => MastodonAdminDomainBlock.fromJson(e as Map<String, dynamic>),
           )
           .toList();
 

--- a/test/models/mastodon_custom_emoji_test.dart
+++ b/test/models/mastodon_custom_emoji_test.dart
@@ -9,9 +9,7 @@ void main() {
       final file = File('test/fixtures/custom_emojis.json');
       final list = jsonDecode(file.readAsStringSync()) as List<dynamic>;
       final emojis = list
-          .map(
-            (e) => MastodonCustomEmoji.fromJson(e as Map<String, dynamic>),
-          )
+          .map((e) => MastodonCustomEmoji.fromJson(e as Map<String, dynamic>))
           .toList();
 
       expect(emojis, hasLength(1));

--- a/test/models/mastodon_filter_test.dart
+++ b/test/models/mastodon_filter_test.dart
@@ -57,9 +57,7 @@ void main() {
       final file = File('test/fixtures/filter_keywords.json');
       final list = jsonDecode(file.readAsStringSync()) as List<dynamic>;
       final keywords = list
-          .map(
-            (e) => MastodonFilterKeyword.fromJson(e as Map<String, dynamic>),
-          )
+          .map((e) => MastodonFilterKeyword.fromJson(e as Map<String, dynamic>))
           .toList();
 
       expect(keywords, hasLength(1));

--- a/test/models/mastodon_instance_v1_test.dart
+++ b/test/models/mastodon_instance_v1_test.dart
@@ -20,9 +20,7 @@ void main() {
       expect(instance.version, equals('4.6.3'));
       expect(
         instance.thumbnail,
-        equals(
-          'https://mastodon.test/packs/assets/preview-vSUsFXid.png',
-        ),
+        equals('https://mastodon.test/packs/assets/preview-vSUsFXid.png'),
       );
       expect(instance.languages, equals(['en']));
       expect(instance.registrations, isFalse);

--- a/test/models/mastodon_oauth_server_metadata_test.dart
+++ b/test/models/mastodon_oauth_server_metadata_test.dart
@@ -17,18 +17,9 @@ void main() {
       );
       expect(obj.tokenEndpoint, 'https://localhost:3001/oauth/token');
       expect(obj.revocationEndpoint, 'https://localhost:3001/oauth/revoke');
-      expect(
-        obj.userinfoEndpoint,
-        'https://localhost:3001/oauth/userinfo',
-      );
-      expect(
-        obj.appRegistrationEndpoint,
-        'https://localhost:3001/api/v1/apps',
-      );
-      expect(
-        obj.serviceDocumentation,
-        'https://docs.joinmastodon.org/',
-      );
+      expect(obj.userinfoEndpoint, 'https://localhost:3001/oauth/userinfo');
+      expect(obj.appRegistrationEndpoint, 'https://localhost:3001/api/v1/apps');
+      expect(obj.serviceDocumentation, 'https://docs.joinmastodon.org/');
       expect(obj.scopesSupported, contains('read'));
       expect(obj.scopesSupported, contains('write'));
       expect(obj.scopesSupported, contains('push'));

--- a/test/models/mastodon_preview_card_test.dart
+++ b/test/models/mastodon_preview_card_test.dart
@@ -34,10 +34,7 @@ void main() {
         ),
       );
       expect(card.embedUrl, equals(''));
-      expect(
-        card.blurhash,
-        equals('U44UXbj_D~aus^fRayfRD#aw-rj{ajfQoffR'),
-      );
+      expect(card.blurhash, equals('U44UXbj_D~aus^fRayfRD#aw-rj{ajfQoffR'));
       expect(card.authors, isEmpty);
     });
 

--- a/test/models/mastodon_relationship_test.dart
+++ b/test/models/mastodon_relationship_test.dart
@@ -9,9 +9,7 @@ void main() {
       final file = File('test/fixtures/relationships.json');
       final list = jsonDecode(file.readAsStringSync()) as List<dynamic>;
       final relationships = list
-          .map(
-            (e) => MastodonRelationship.fromJson(e as Map<String, dynamic>),
-          )
+          .map((e) => MastodonRelationship.fromJson(e as Map<String, dynamic>))
           .toList();
 
       expect(relationships, hasLength(1));

--- a/test/models/mastodon_status_test.dart
+++ b/test/models/mastodon_status_test.dart
@@ -48,9 +48,7 @@ void main() {
       final file = File('test/fixtures/status.json');
       final json = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
       final collection =
-          jsonDecode(
-                File('test/fixtures/collection.json').readAsStringSync(),
-              )
+          jsonDecode(File('test/fixtures/collection.json').readAsStringSync())
               as Map<String, dynamic>;
 
       final status = MastodonStatus.fromJson({


### PR DESCRIPTION
## 概要

Issue #20 Phase 1のCI導入に先立ち、純DartのCIで依存解決できるようSDK・依存関係・lint構成を整理します。併せて、Issue #19の公開パッケージへの開発用ファイル混入を解消し、新しいlintセットとformatterが要求する機械的なコード移行を行います。

## 変更内容

- Dart SDK下限を3.8から3.9へ更新
- dio / json_annotation / logger / build_runner / json_serializable / lints / testを更新
- Flutter SDKへ推移依存するpedantic_monoを公式のpackage:lints/recommended.yamlへ置換
- 未使用かつFlutter SDKへ依存するpubspec_dependency_sorterを削除
- 現行Dart formatterでプロジェクト全体を整形
- .pubignoreへbuild / coverage / doc/api / test / 開発用設定ファイルの除外を追加
- 公開アーカイブを14 MBから112 KBへ削減
- CHANGELOGを更新

## 検証

Dart 3.9.2とDart 3.11.5の両方で以下を確認済みです。

- `dart format --output=none --set-exit-if-changed .`
- `dart analyze --fatal-infos`
- `dart run build_runner build`後の生成物差分なし
- `dart test --exclude-tags e2e`: 215件成功
- SDK間で生成コードが一致
- クリーンな一時クローンで`dart pub publish --dry-run`: 警告0件、112 KB

## 関連Issue

Closes #19
Relates to #20
