### PR TITLE
ci: Dartの品質チェックを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Dart ${{ matrix.sdk }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk: ['3.9.0', stable]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: ${{ matrix.sdk }}
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Check formatting
+        run: dart format --output=none --set-exit-if-changed .
+
+      - name: Analyze
+        run: dart analyze --fatal-infos
+
+      - name: Generate code
+        run: dart run build_runner build
+
+      - name: Check generated code
+        run: git diff --exit-code
+
+      - name: Run tests
+        run: dart test --exclude-tags e2e
+
+      - name: Validate package
+        run: dart pub publish --dry-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added CI checks for formatting, static analysis, generated code, unit tests, and package validation on the minimum and stable Dart SDKs (issue #20)
+
 ### Changed
 
 - **Breaking:** The minimum supported Dart SDK version is now 3.9.0


### PR DESCRIPTION
## 概要

Issue #20 Phase 1として、PRおよびmain/developへのpushでDartパッケージの品質チェックを自動実行するCIを追加します。

## CI内容

Dart 3.9.0（pubspecの下限）とstableのマトリクスで、以下を実行します。

- `dart pub get`
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze --fatal-infos`
- `dart run build_runner build`
- `git diff --exit-code`による生成コード差分検出
- `dart test --exclude-tags e2e`
- `dart pub publish --dry-run`

ワークフローの権限は`contents: read`のみに制限し、同一refの古い実行を自動キャンセルします。各ジョブには20分のタイムアウトを設定しています。

## ローカル検証

クリーンcheckout相当の環境で、Dart 3.9.0およびDart 3.11.5の双方について以下を確認済みです。

- format差分なし
- analyze 0件
- 生成コード差分なし
- 非E2Eテスト215件成功
- publish dry-run警告0件（112 KB）

Issue #20の全Phaseではなく、Phase 1のみの対応です。

Relates to #20
