### PR TITLE
ci: pub.devへの自動公開ワークフローを追加

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,14 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    # プレリリースを含むバージョンタグをpub.dev側のtag patternで検証する
+    tags: ['v*']
+
+jobs:
+  publish:
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      environment: pub.dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added CI checks for formatting, static analysis, generated code, unit tests, and package validation on the minimum and stable Dart SDKs (issue #20)
+- Added OIDC-based automated publishing to pub.dev for version tags (issue #20)
 
 ### Changed
 


### PR DESCRIPTION
## 概要

Issue #20 Phase 2として、pub.devへのOIDC自動公開ワークフローを追加します。

## 変更内容

- `v*`タグのpushを公開契機として設定
- `dart-lang/setup-dart`の公式reusable workflowを使用
- OIDC認証に必要な`id-token: write`を付与
- GitHub Environment `pub.dev`を指定
- プレリリースを含むタグの最終検証は、pub.dev側の`v{{version}}`パターンへ委譲
- CHANGELOGを更新

## 確認済みのGitHub設定

- GitHub Environment `pub.dev`が作成済み
- `LibraryLibrarian`がRequired reviewerとして設定済み

## pub.dev管理画面で必要な設定

- GitHub Actionsからの自動公開を有効化
- Repository: `LibraryLibrarian/mastodon_client`
- Tag pattern: `v{{version}}`
- Environment: `pub.dev`

## 検証

- YAML構文チェック
- 公式reusable workflowの`environment`入力とOIDC公開処理を確認
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze --fatal-infos`
- `dart test --exclude-tags e2e`（215件成功）

実際のOIDC公開は管理画面設定後、次回のリリースタグで確認します。このPRではタグ作成・パッケージ公開を行いません。

Relates to #20
