### PR TITLE
release: 1.0.0-beta.2 を develop へ戻す

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.2] - 2026-08-13
+
 ### Added
 
 - Added CI checks for formatting, static analysis, generated code, unit tests, and package validation on the minimum and stable Dart SDKs (issue #20)
@@ -97,4 +99,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions workflow for documentation deployment
 - README in 6 languages
 
+[1.0.0-beta.2]: https://github.com/LibraryLibrarian/mastodon_client/releases/tag/v1.0.0-beta.2
 [1.0.0-beta.1]: https://github.com/LibraryLibrarian/mastodon_client/releases/tag/v1.0.0-beta.1

--- a/README.de.md
+++ b/README.de.md
@@ -22,7 +22,7 @@ Fügen Sie das Paket zu Ihrer `pubspec.yaml` hinzu:
 
 ```yaml
 dependencies:
-  mastodon_client: ^1.0.0-beta.1
+  mastodon_client: ^1.0.0-beta.2
 ```
 
 Führen Sie dann aus:

--- a/README.fr.md
+++ b/README.fr.md
@@ -22,7 +22,7 @@ Ajoutez le paquet à votre `pubspec.yaml` :
 
 ```yaml
 dependencies:
-  mastodon_client: ^1.0.0-beta.1
+  mastodon_client: ^1.0.0-beta.2
 ```
 
 Puis exécutez :

--- a/README.ja.md
+++ b/README.ja.md
@@ -23,7 +23,7 @@ pure Dart で実装された [Mastodon](https://joinmastodon.org/) APIクライ�
 
 ```yaml
 dependencies:
-  mastodon_client: ^1.0.0-beta.1
+  mastodon_client: ^1.0.0-beta.2
 ```
 
 次のコマンドを実行してください:

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
 
 ```yaml
 dependencies:
-  mastodon_client: ^1.0.0-beta.1
+  mastodon_client: ^1.0.0-beta.2
 ```
 
 그런 다음 실행하세요:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add the package to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  mastodon_client: ^1.0.0-beta.1
+  mastodon_client: ^1.0.0-beta.2
 ```
 
 Then run:

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -22,7 +22,7 @@
 
 ```yaml
 dependencies:
-  mastodon_client: ^1.0.0-beta.1
+  mastodon_client: ^1.0.0-beta.2
 ```
 
 然后运行：

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -22,7 +22,7 @@ Add the dependency to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  mastodon_client: ^1.0.0-beta.1
+  mastodon_client: ^1.0.0-beta.2
 ```
 
 Then fetch it:

--- a/docs/i18n/de/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/de/docusaurus-plugin-content-docs/current/getting-started.md
@@ -22,7 +22,7 @@ Füge die Abhängigkeit in deine `pubspec.yaml` ein:
 
 ```yaml
 dependencies:
-  mastodon_client: ^1.0.0-beta.1
+  mastodon_client: ^1.0.0-beta.2
 ```
 
 Anschließend ausführen:

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/getting-started.md
@@ -22,7 +22,7 @@ Ajoutez la dépendance dans votre `pubspec.yaml` :
 
 ```yaml
 dependencies:
-  mastodon_client: ^1.0.0-beta.1
+  mastodon_client: ^1.0.0-beta.2
 ```
 
 Puis récupérez-la :

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/getting-started.md
@@ -22,7 +22,7 @@ Flutter・Dart サーバーサイド・CLI ツールなど、Dart が動作す�
 
 ```yaml
 dependencies:
-  mastodon_client: ^1.0.0-beta.1
+  mastodon_client: ^1.0.0-beta.2
 ```
 
 その後、依存関係を取得します。

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started.md
@@ -22,7 +22,7 @@ Flutter, 서버사이드 Dart, CLI 도구 등 Dart가 실행되는 모든 환경
 
 ```yaml
 dependencies:
-  mastodon_client: ^1.0.0-beta.1
+  mastodon_client: ^1.0.0-beta.2
 ```
 
 그런 다음 패키지를 가져옵니다:

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started.md
@@ -22,7 +22,7 @@ mastodon_client 是一个纯 Dart 编写的 Mastodon API 客户端库。
 
 ```yaml
 dependencies:
-  mastodon_client: ^1.0.0-beta.1
+  mastodon_client: ^1.0.0-beta.2
 ```
 
 然后拉取依赖：

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mastodon_client
-version: 1.0.0-beta.1
+version: 1.0.0-beta.2
 documentation: https://librarylibrarian.github.io/mastodon_client/
 environment:
   sdk: ">=3.9.0 <4.0.0"


### PR DESCRIPTION
## 概要

main向けPR #27で確定した1.0.0-beta.2のリリース情報をdevelopへ戻します。

## 反映内容

- pubspec.yamlを1.0.0-beta.2へ更新
- README 6言語とDocusaurus getting-started 6言語の依存例を更新
- CHANGELOGのUnreleasedを1.0.0-beta.2として確定
- GitHub Release参照リンクを追加

## 状況

- main向けPR #27: マージ済み（493c821）
- v1.0.0-beta.2タグ: 明示承認待ちのため未作成
- pub.dev自動公開: 未開始

タグpushと公開結果の確認後、Issue #19/#20の状態を更新します。