### PR TITLE
feat: Streaming API (WebSocket) を実装し client.streaming として公開

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added the Streaming API over WebSocket, exposed as `client.streaming`, with a single multiplexed connection, reference-counted subscriptions, and typed sealed events (issue #21)
+- Added `MastodonStream` covering all twelve official channels, plus `subscribeRaw` for channels this library does not model (issue #21)
+- Added automatic streaming endpoint discovery from instance metadata, with normalization of scheme, port, and path (issue #21)
+- Added three streaming authentication modes with fallback, close-code-aware reconnection with exponential backoff and jitter, and `suspend()` / `resume()` (issue #21)
+- Added `MastodonClient.dispose()` and `HealthApi.checkStreaming()` (issue #21)
+
+### Changed
+
+- `MastodonHttpClient` now retains and exposes `baseUrl`, `accessToken`, and `enableLog` (issue #21)
+
 ## [1.0.0-beta.2] - 2026-08-13
 
 ### Added

--- a/README.de.md
+++ b/README.de.md
@@ -13,6 +13,7 @@ Eine reine Dart-Clientbibliothek für die [Mastodon](https://joinmastodon.org/) 
 - Cursorbasierte Paginierung über `MastodonPage<T>`
 - Sealed-Ausnahmehierarchie für erschöpfende Fehlerbehandlung
 - Asynchroner Medien-Upload mit automatischem v2/v1-Fallback und Verarbeitungs-Polling
+- Streaming-API über WebSocket mit gemultiplexten Abonnements und automatischer Wiederverbindung
 - Konfigurierbares Logging über eine austauschbare `Logger`-Schnittstelle
 - Reines Dart — keine Flutter-Abhängigkeit erforderlich
 
@@ -102,6 +103,7 @@ void main() async {
 | `markers` | Timeline-Lesepositionsmarkierungen |
 | `scheduledStatuses` | Verwaltung geplanter Status |
 | `health` | Server-Gesundheitsprüfung |
+| `streaming` | Streaming-API über WebSocket (siehe [Streaming](#streaming)) |
 | `profile` | Avatar-/Header-Bildverwaltung |
 | `groupedNotifications` | Gruppierte Benachrichtigungen (v2) |
 | `adminAccounts` | Admin-Kontoverwaltung |
@@ -170,6 +172,56 @@ try {
   // Timeout, connection refused, etc.
 }
 ```
+
+## Streaming
+
+Echtzeit-Aktualisierungen über die Streaming-API (WebSocket). Eine einzelne Verbindung multiplext alle Abonnements, und der Endpunkt wird automatisch aus den Instanz-Metadaten ermittelt.
+
+```dart
+final client = MastodonClient(
+  baseUrl: 'https://mastodon.social',
+  accessToken: 'your_token',
+);
+
+await client.streaming.connect();
+
+final home = await client.streaming.subscribe(const MastodonStream.user());
+home.events.listen((event) {
+  switch (event) {
+    case MastodonUpdateEvent(:final status):
+      print(status.content);
+    case MastodonDeleteEvent(:final statusId):
+      print('gelöscht: $statusId');
+    case MastodonNotificationEvent(:final notification):
+      print(notification.type);
+    default:
+      break;
+  }
+});
+
+// Nur Status (`update` und `status.update`)
+home.statuses.listen((status) => print(status.id));
+
+final tag = await client.streaming.subscribe(
+  const MastodonStream.hashtag('dart'),
+);
+
+await tag.cancel();
+await client.dispose();
+```
+
+Kanäle werden über `MastodonStream` beschrieben: `user()`, `userNotification()`, `public()` (mit `local`, `remote`, `onlyMedia`), `hashtag()` (mit `local`), `list()` und `direct()`. Für Kanäle, die diese Bibliothek nicht abbildet, steht `subscribeRaw` zur Verfügung.
+
+Abonnements werden referenzgezählt, sodass ein doppeltes Abonnement desselben Kanals nur einen `subscribe`-Frame sendet. Die Wiederverbindung erfolgt automatisch mit exponentiellem Backoff und Jitter, danach wird jedes aktive Abonnement erneut gesendet. Nutze `suspend()` und `resume()` bei Lebenszyklus-Wechseln der Anwendung und beobachte `stateChanges` sowie `errors`, um die Verbindung zu überwachen.
+
+### Wissenswertes
+
+- Streaming erfordert immer ein Zugriffstoken, auch für öffentliche Kanäle.
+- Ein Token mit nur `read:statuses` empfängt Home-Status über `user`, erhält aber stillschweigend keine Benachrichtigungen. Verwende `read` oder `read:notifications`, wenn Benachrichtigungen benötigt werden.
+- `only_media` wird über WebSocket ignoriert. Wähle stattdessen den Kanalnamen, etwa über `MastodonStream.public(onlyMedia: true)`.
+- Wer `user` und `userNotification` gleichzeitig abonniert, erhält jede Benachrichtigung doppelt. `user` allein genügt.
+- Öffentliche und Hashtag-Aktualisierungen können durch Spracheinstellungen, Feed-Zugriffseinstellungen, Blockierungen oder Stummschaltungen stillschweigend verworfen werden. Ein stiller Stream ist nicht zwangsläufig ein Fehler.
+- Während einer Trennung erzeugte Ereignisse werden nicht nachgeliefert. Schließe die Lücke über REST-Endpunkte mit `since_id` oder `min_id`.
 
 ## Logging
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -13,6 +13,7 @@ Une bibliothèque cliente pure Dart pour l'API [Mastodon](https://joinmastodon.o
 - Pagination par curseur via `MastodonPage<T>`
 - Hiérarchie d'exceptions sealed pour une gestion exhaustive des erreurs
 - Téléversement de médias asynchrone avec basculement automatique v2/v1 et scrutation du traitement
+- API de diffusion via WebSocket avec abonnements multiplexés et reconnexion automatique
 - Journalisation configurable via une interface `Logger` interchangeable
 - Pure Dart — aucune dépendance Flutter requise
 
@@ -102,6 +103,7 @@ void main() async {
 | `markers` | Marqueurs de position de lecture dans les fils |
 | `scheduledStatuses` | Gestion des statuts planifiés |
 | `health` | Vérification de l'état du serveur |
+| `streaming` | API de diffusion via WebSocket (voir [Diffusion](#diffusion)) |
 | `profile` | Gestion des images d'avatar et d'en-tête |
 | `groupedNotifications` | Notifications groupées (v2) |
 | `adminAccounts` | Gestion des comptes (admin) |
@@ -170,6 +172,56 @@ try {
   // Timeout, connection refused, etc.
 }
 ```
+
+## Diffusion
+
+Mises à jour en temps réel via l'API de diffusion (WebSocket). Une seule connexion multiplexe tous les abonnements, et le point de terminaison est résolu automatiquement à partir des métadonnées de l'instance.
+
+```dart
+final client = MastodonClient(
+  baseUrl: 'https://mastodon.social',
+  accessToken: 'your_token',
+);
+
+await client.streaming.connect();
+
+final home = await client.streaming.subscribe(const MastodonStream.user());
+home.events.listen((event) {
+  switch (event) {
+    case MastodonUpdateEvent(:final status):
+      print(status.content);
+    case MastodonDeleteEvent(:final statusId):
+      print('supprimé : $statusId');
+    case MastodonNotificationEvent(:final notification):
+      print(notification.type);
+    default:
+      break;
+  }
+});
+
+// Statuts uniquement (`update` et `status.update`)
+home.statuses.listen((status) => print(status.id));
+
+final tag = await client.streaming.subscribe(
+  const MastodonStream.hashtag('dart'),
+);
+
+await tag.cancel();
+await client.dispose();
+```
+
+Les canaux sont décrits par `MastodonStream` : `user()`, `userNotification()`, `public()` (avec `local`, `remote`, `onlyMedia`), `hashtag()` (avec `local`), `list()` et `direct()`. Utilisez `subscribeRaw` pour les canaux que cette bibliothèque ne modélise pas.
+
+Les abonnements sont comptés par référence : s'abonner deux fois au même canal n'envoie qu'une seule trame `subscribe`. La reconnexion est automatique avec un repli exponentiel et de la gigue, et chaque abonnement actif est renvoyé ensuite. Utilisez `suspend()` et `resume()` lors des changements de cycle de vie de l'application, et observez `stateChanges` et `errors` pour surveiller la connexion.
+
+### À savoir
+
+- La diffusion exige toujours un jeton d'accès, y compris pour les canaux publics.
+- Un jeton limité à `read:statuses` reçoit les statuts du fil principal sur `user`, mais ne reçoit silencieusement aucune notification. Utilisez `read` ou `read:notifications` si les notifications sont nécessaires.
+- `only_media` est ignoré via WebSocket. Sélectionnez plutôt le nom du canal, via `MastodonStream.public(onlyMedia: true)`.
+- S'abonner à la fois à `user` et à `userNotification` livre chaque notification en double. `user` seul suffit.
+- Les mises à jour publiques et de mots-clics peuvent être silencieusement écartées par les préférences de langue, les réglages d'accès aux fils, les blocages ou les masquages. Un flux inactif n'est pas nécessairement une erreur.
+- Les événements produits pendant une déconnexion ne sont pas rejoués. Comblez le manque via les points de terminaison REST avec `since_id` ou `min_id`.
 
 ## Journalisation
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -14,6 +14,7 @@ pure Dart で実装された [Mastodon](https://joinmastodon.org/) APIクライ�
 - `MastodonPage<T>` によるカーソルベースのページネーション
 - 網羅的なエラーハンドリングのための sealed 例外階層
 - 自動的な v2/v1 フォールバックと処理ポーリングを備えた非同期メディアアップロード
+- 多重化された購読と自動再接続を備えた WebSocket による Streaming API
 - 交換可能な `Logger` インターフェースによる設定可能なロギング
 - pure Dart — Flutter への依存は不要
 
@@ -103,6 +104,7 @@ void main() async {
 | `markers` | タイムラインの既読位置マーカー |
 | `scheduledStatuses` | 予約投稿の管理 |
 | `health` | サーバーのヘルスチェック |
+| `streaming` | WebSocket による Streaming API（[ストリーミング](#ストリーミング)を参照） |
 | `profile` | アバター・ヘッダー画像の管理 |
 | `groupedNotifications` | グループ化された通知（v2） |
 | `adminAccounts` | 管理者用アカウント管理 |
@@ -171,6 +173,56 @@ try {
   // Timeout, connection refused, etc.
 }
 ```
+
+## ストリーミング
+
+Streaming API（WebSocket）によるリアルタイム更新です。単一の接続にすべての購読を多重化し、接続先はインスタンス情報から自動的に解決されます。
+
+```dart
+final client = MastodonClient(
+  baseUrl: 'https://mastodon.social',
+  accessToken: 'your_token',
+);
+
+await client.streaming.connect();
+
+final home = await client.streaming.subscribe(const MastodonStream.user());
+home.events.listen((event) {
+  switch (event) {
+    case MastodonUpdateEvent(:final status):
+      print(status.content);
+    case MastodonDeleteEvent(:final statusId):
+      print('削除: $statusId');
+    case MastodonNotificationEvent(:final notification):
+      print(notification.type);
+    default:
+      break;
+  }
+});
+
+// 投稿だけを受け取る（`update` と `status.update`）
+home.statuses.listen((status) => print(status.id));
+
+final tag = await client.streaming.subscribe(
+  const MastodonStream.hashtag('dart'),
+);
+
+await tag.cancel();
+await client.dispose();
+```
+
+チャンネルは `MastodonStream` で表現します。`user()` / `userNotification()` / `public()`（`local`、`remote`、`onlyMedia` を指定可能）/ `hashtag()`（`local` を指定可能）/ `list()` / `direct()` が利用できます。本ライブラリが型として持たないチャンネルには `subscribeRaw` を使います。
+
+購読は参照カウントで管理されるため、同一チャンネルを二重に購読しても `subscribe` フレームは 1 回しか送られません。再接続は指数バックオフとジッタで自動的に行われ、再接続後はすべての購読が自動的に再送されます。アプリのライフサイクルに合わせて `suspend()` と `resume()` を使い、接続の監視には `stateChanges` と `errors` を利用してください。
+
+### 注意点
+
+- パブリックなチャンネルを含め、ストリーミングには例外なくアクセストークンが必要です。
+- `read:statuses` のみのトークンで `user` に繋ぐと、ホームタイムラインは流れますが通知は一切届きません（エラーも出ません）。通知が必要な場合は `read` または `read:notifications` を使ってください。
+- `only_media` は WebSocket では無視されます。`MastodonStream.public(onlyMedia: true)` のようにチャンネル名で指定してください。
+- `user` と `userNotification` を同時に購読すると、同じ通知が 2 回届きます。`user` だけで十分です。
+- パブリックおよびハッシュタグの更新は、言語設定・フィード公開設定・ブロック・ミュートによってサイレントに破棄されることがあります。何も流れてこないことが必ずしも異常とは限りません。
+- 切断中に発生したイベントは再接続後も届きません。REST の `since_id` や `min_id` で穴埋めしてください。
 
 ## ロギング
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,6 +13,7 @@
 - `MastodonPage<T>`를 통한 커서 기반 페이지네이션
 - 완전한 오류 처리를 위한 sealed 예외 계층
 - 자동 v2/v1 폴백 및 처리 폴링을 지원하는 비동기 미디어 업로드
+- 다중화된 구독과 자동 재연결을 지원하는 WebSocket 기반 스트리밍 API
 - 교체 가능한 `Logger` 인터페이스를 통한 설정 가능한 로깅
 - 순수 Dart — Flutter 의존성 불필요
 
@@ -102,6 +103,7 @@ void main() async {
 | `markers` | 타임라인 읽기 위치 마커 |
 | `scheduledStatuses` | 예약 포스트 관리 |
 | `health` | 서버 상태 확인 |
+| `streaming` | WebSocket 기반 스트리밍 API ([스트리밍](#스트리밍) 참조) |
 | `profile` | 아바타/헤더 이미지 관리 |
 | `groupedNotifications` | 그룹화된 알림 (v2) |
 | `adminAccounts` | 관리자 계정 관리 |
@@ -170,6 +172,56 @@ try {
   // Timeout, connection refused, etc.
 }
 ```
+
+## 스트리밍
+
+스트리밍 API(WebSocket)를 통한 실시간 업데이트입니다. 단일 연결에 모든 구독을 다중화하며, 엔드포인트는 인스턴스 메타데이터에서 자동으로 확인됩니다.
+
+```dart
+final client = MastodonClient(
+  baseUrl: 'https://mastodon.social',
+  accessToken: 'your_token',
+);
+
+await client.streaming.connect();
+
+final home = await client.streaming.subscribe(const MastodonStream.user());
+home.events.listen((event) {
+  switch (event) {
+    case MastodonUpdateEvent(:final status):
+      print(status.content);
+    case MastodonDeleteEvent(:final statusId):
+      print('삭제됨: $statusId');
+    case MastodonNotificationEvent(:final notification):
+      print(notification.type);
+    default:
+      break;
+  }
+});
+
+// 포스트만 수신 (`update` 및 `status.update`)
+home.statuses.listen((status) => print(status.id));
+
+final tag = await client.streaming.subscribe(
+  const MastodonStream.hashtag('dart'),
+);
+
+await tag.cancel();
+await client.dispose();
+```
+
+채널은 `MastodonStream`으로 표현합니다. `user()`, `userNotification()`, `public()`(`local`, `remote`, `onlyMedia` 지정 가능), `hashtag()`(`local` 지정 가능), `list()`, `direct()`를 사용할 수 있습니다. 이 라이브러리가 타입으로 제공하지 않는 채널에는 `subscribeRaw`를 사용하세요.
+
+구독은 참조 카운트로 관리되므로 같은 채널을 두 번 구독해도 `subscribe` 프레임은 한 번만 전송됩니다. 재연결은 지수 백오프와 지터를 사용해 자동으로 이루어지며, 재연결 후에는 활성 구독이 모두 다시 전송됩니다. 애플리케이션 생명주기 변화에 맞춰 `suspend()`와 `resume()`을 사용하고, 연결 상태는 `stateChanges`와 `errors`로 관찰하세요.
+
+### 유의 사항
+
+- 공개 채널을 포함해 스트리밍에는 항상 액세스 토큰이 필요합니다.
+- `read:statuses`만 가진 토큰으로 `user`에 연결하면 홈 타임라인은 수신되지만 알림은 전혀 오지 않습니다(오류도 발생하지 않습니다). 알림이 필요하면 `read` 또는 `read:notifications`를 사용하세요.
+- `only_media`는 WebSocket에서 무시됩니다. `MastodonStream.public(onlyMedia: true)`처럼 채널 이름으로 지정하세요.
+- `user`와 `userNotification`을 함께 구독하면 같은 알림이 두 번 전달됩니다. `user`만으로 충분합니다.
+- 공개 및 해시태그 업데이트는 언어 설정, 피드 공개 설정, 차단, 뮤트에 의해 조용히 삭제될 수 있습니다. 아무것도 흐르지 않는 것이 반드시 오류는 아닙니다.
+- 연결이 끊긴 동안 발생한 이벤트는 다시 전달되지 않습니다. REST의 `since_id` 또는 `min_id`로 공백을 메우세요.
 
 ## 로깅
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A pure Dart client library for the [Mastodon](https://joinmastodon.org/) API. Pr
 - Cursor-based pagination via `MastodonPage<T>`
 - Sealed exception hierarchy for exhaustive error handling
 - Async media upload with automatic v2/v1 fallback and processing polling
+- Streaming API over WebSocket with multiplexed subscriptions and automatic reconnection
 - Configurable logging through a swappable `Logger` interface
 - Pure Dart — no Flutter dependency required
 
@@ -102,6 +103,7 @@ void main() async {
 | `markers` | Timeline read position markers |
 | `scheduledStatuses` | Scheduled status management |
 | `health` | Server health check |
+| `streaming` | Streaming API over WebSocket (see [Streaming](#streaming)) |
 | `profile` | Avatar/header image management |
 | `groupedNotifications` | Grouped notifications (v2) |
 | `adminAccounts` | Admin account management |
@@ -170,6 +172,56 @@ try {
   // Timeout, connection refused, etc.
 }
 ```
+
+## Streaming
+
+Real-time updates over the Streaming API (WebSocket). A single connection multiplexes every subscription, and the endpoint is discovered from instance metadata automatically.
+
+```dart
+final client = MastodonClient(
+  baseUrl: 'https://mastodon.social',
+  accessToken: 'your_token',
+);
+
+await client.streaming.connect();
+
+final home = await client.streaming.subscribe(const MastodonStream.user());
+home.events.listen((event) {
+  switch (event) {
+    case MastodonUpdateEvent(:final status):
+      print(status.content);
+    case MastodonDeleteEvent(:final statusId):
+      print('deleted: $statusId');
+    case MastodonNotificationEvent(:final notification):
+      print(notification.type);
+    default:
+      break;
+  }
+});
+
+// Statuses only (`update` and `status.update`)
+home.statuses.listen((status) => print(status.id));
+
+final tag = await client.streaming.subscribe(
+  const MastodonStream.hashtag('dart'),
+);
+
+await tag.cancel();
+await client.dispose();
+```
+
+Channels are described by `MastodonStream`: `user()`, `userNotification()`, `public()` (with `local`, `remote`, `onlyMedia`), `hashtag()` (with `local`), `list()`, and `direct()`. Use `subscribeRaw` for channels this library does not model.
+
+Subscriptions are reference counted, so subscribing twice to the same channel sends a single `subscribe` frame. Reconnection is automatic with exponential backoff and jitter, and every active subscription is resent afterwards. Use `suspend()` and `resume()` around application lifecycle changes, and observe `stateChanges` and `errors` to monitor the connection.
+
+### Things to know
+
+- Streaming always requires an access token, including public channels.
+- A `read:statuses` token receives home statuses on `user`, but silently receives no notifications. Use `read` or `read:notifications` when notifications are needed.
+- `only_media` is ignored over WebSocket. Select the channel name instead, via `MastodonStream.public(onlyMedia: true)`.
+- Subscribing to both `user` and `userNotification` delivers every notification twice. `user` alone is enough.
+- Public and hashtag updates may be silently dropped by language preferences, feed access settings, blocks, or mutes. An idle stream is not necessarily an error.
+- Events produced while disconnected are not replayed. Fill the gap through REST endpoints using `since_id` or `min_id`.
 
 ## Logging
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -13,6 +13,7 @@
 - 通过 `MastodonPage<T>` 实现基于游标的分页
 - 用于穷举式错误处理的 sealed 异常层级
 - 支持自动 v2/v1 降级和处理轮询的异步媒体上传
+- 基于 WebSocket 的流式 API，支持多路复用订阅与自动重连
 - 通过可替换的 `Logger` 接口实现可配置的日志记录
 - 纯 Dart 实现 — 不依赖 Flutter
 
@@ -102,6 +103,7 @@ void main() async {
 | `markers` | 时间线已读位置标记 |
 | `scheduledStatuses` | 定时嘟文管理 |
 | `health` | 服务器健康检查 |
+| `streaming` | 基于 WebSocket 的流式 API（参见[流式传输](#流式传输)） |
 | `profile` | 头像/头图管理 |
 | `groupedNotifications` | 分组通知（v2） |
 | `adminAccounts` | 管理员账户管理 |
@@ -170,6 +172,56 @@ try {
   // Timeout, connection refused, etc.
 }
 ```
+
+## 流式传输
+
+通过流式 API（WebSocket）获取实时更新。所有订阅都多路复用到单个连接上，端点会自动从实例元数据中解析。
+
+```dart
+final client = MastodonClient(
+  baseUrl: 'https://mastodon.social',
+  accessToken: 'your_token',
+);
+
+await client.streaming.connect();
+
+final home = await client.streaming.subscribe(const MastodonStream.user());
+home.events.listen((event) {
+  switch (event) {
+    case MastodonUpdateEvent(:final status):
+      print(status.content);
+    case MastodonDeleteEvent(:final statusId):
+      print('已删除: $statusId');
+    case MastodonNotificationEvent(:final notification):
+      print(notification.type);
+    default:
+      break;
+  }
+});
+
+// 仅接收嘟文（`update` 和 `status.update`）
+home.statuses.listen((status) => print(status.id));
+
+final tag = await client.streaming.subscribe(
+  const MastodonStream.hashtag('dart'),
+);
+
+await tag.cancel();
+await client.dispose();
+```
+
+频道通过 `MastodonStream` 描述：`user()`、`userNotification()`、`public()`（可指定 `local`、`remote`、`onlyMedia`）、`hashtag()`（可指定 `local`）、`list()` 和 `direct()`。对于本库未建模的频道，请使用 `subscribeRaw`。
+
+订阅采用引用计数，因此重复订阅同一频道只会发送一次 `subscribe` 帧。重连使用指数退避加抖动自动进行，重连后会重新发送所有活动订阅。请在应用生命周期变化时使用 `suspend()` 和 `resume()`，并通过 `stateChanges` 和 `errors` 监控连接。
+
+### 注意事项
+
+- 包括公共频道在内，流式传输始终需要访问令牌。
+- 仅具有 `read:statuses` 的令牌可以在 `user` 上接收主页嘟文，但不会收到任何通知（也不会报错）。需要通知时请使用 `read` 或 `read:notifications`。
+- `only_media` 在 WebSocket 上会被忽略。请改用频道名指定，例如 `MastodonStream.public(onlyMedia: true)`。
+- 同时订阅 `user` 和 `userNotification` 会导致每条通知收到两次。仅订阅 `user` 即可。
+- 公共和话题标签的更新可能因语言偏好、信息流访问设置、屏蔽或静音而被静默丢弃。没有事件流入未必是错误。
+- 断开期间产生的事件不会被补发。请通过 REST 的 `since_id` 或 `min_id` 补齐缺口。
 
 ## 日志记录
 

--- a/docs/docs/api/streaming.md
+++ b/docs/docs/api/streaming.md
@@ -1,0 +1,177 @@
+---
+sidebar_position: 15
+---
+
+# Streaming
+
+The `client.streaming` API delivers real-time updates over the Mastodon Streaming API (WebSocket). A single connection multiplexes every subscription, so subscribing to several channels does not open several sockets.
+
+Accessing `client.streaming` does not open a connection. The socket is opened only when `connect()` is called, so REST-only applications never touch the network through this API.
+
+## Connecting
+
+```dart
+final client = MastodonClient(
+  baseUrl: 'https://mastodon.social',
+  accessToken: 'your_token',
+);
+
+await client.streaming.connect();
+```
+
+The endpoint is discovered automatically. The client reads `configuration.urls.streaming` from `GET /api/v2/instance`, falls back to `urls.streaming_api` from `GET /api/v1/instance`, and finally reuses the REST host. The resolved value is normalized: `http` becomes `ws`, `https` becomes `wss`, the port is preserved, and `/api/v1/streaming` is appended when missing.
+
+Streaming requires an access token in every case, including public channels. Anonymous access was removed in Mastodon v4.2.0.
+
+## Subscribing
+
+```dart
+final home = await client.streaming.subscribe(const MastodonStream.user());
+
+home.events.listen((event) {
+  switch (event) {
+    case MastodonUpdateEvent(:final status):
+      print(status.content);
+    case MastodonStatusUpdateEvent(:final status):
+      print('edited: ${status.id}');
+    case MastodonDeleteEvent(:final statusId):
+      print('deleted: $statusId');
+    case MastodonNotificationEvent(:final notification):
+      print(notification.type);
+    case MastodonUnknownStreamEvent(:final event):
+      print('unknown event: $event');
+    default:
+      break;
+  }
+});
+
+await home.cancel();
+```
+
+Each subscription handle exposes three layers:
+
+| Property | Type | Contents |
+|---|---|---|
+| `events` | `Stream<MastodonStreamEvent>` | Typed, sealed events |
+| `statuses` | `Stream<MastodonStatus>` | Statuses from `update` and `status.update` |
+| `messages` | `Stream<MastodonStreamingMessage>` | Raw envelopes with an undecoded payload |
+
+## Channels
+
+Channels are described by the sealed `MastodonStream` type.
+
+| Factory | Wire name |
+|---|---|
+| `MastodonStream.user()` | `user` |
+| `MastodonStream.userNotification()` | `user:notification` |
+| `MastodonStream.public()` | `public` |
+| `MastodonStream.public(local: true)` | `public:local` |
+| `MastodonStream.public(remote: true)` | `public:remote` |
+| `MastodonStream.public(onlyMedia: true)` | `public:media` |
+| `MastodonStream.public(local: true, onlyMedia: true)` | `public:local:media` |
+| `MastodonStream.public(remote: true, onlyMedia: true)` | `public:remote:media` |
+| `MastodonStream.hashtag('dart')` | `hashtag` |
+| `MastodonStream.hashtag('dart', local: true)` | `hashtag:local` |
+| `MastodonStream.list('42')` | `list` |
+| `MastodonStream.direct()` | `direct` |
+
+`local` and `remote` cannot both be true — no such channel exists on the server, and the combination is rejected by an assertion.
+
+For channels this library does not model, such as those added by Mastodon forks, use `subscribeRaw`:
+
+```dart
+final raw = await client.streaming.subscribeRaw('someCustomStream');
+raw.messages.listen((message) => print(message.payload));
+```
+
+## Reference counting
+
+Mastodon silently ignores a second `subscribe` for a channel that is already active, so the client keeps a reference count. The `subscribe` frame is sent when the count goes from zero to one, and `unsubscribe` when it returns to zero.
+
+Hashtag keys are normalized to lower case for this purpose. Subscribing to `Dart` and `dart` without normalization would collide on the server side and leave the second subscriber without events.
+
+```dart
+final a = await client.streaming.subscribe(const MastodonStream.hashtag('Dart'));
+final b = await client.streaming.subscribe(const MastodonStream.hashtag('dart'));
+
+await a.cancel(); // No unsubscribe yet — b is still active.
+await b.cancel(); // Now unsubscribe is sent.
+```
+
+## Errors
+
+A successful subscription produces no acknowledgement, and server errors carry no channel name or correlation ID. Subscription frames are therefore serialized, and an error arriving during the quiet window that follows is attributed to the most recent request.
+
+```dart
+try {
+  await client.streaming.subscribe(const MastodonStream.list('999'));
+} on MastodonStreamingSubscriptionException catch (e) {
+  print('${e.message} (${e.status})');
+}
+```
+
+`MastodonStreamingSubscriptionException.status` is nullable because the server omits `status` from `unsubscribe` errors.
+
+Connection-level failures surface as `MastodonStreamingConnectionException`, and unexpected closures as `MastodonStreamingClosedException`. Both are also emitted on `client.streaming.errors` for applications that prefer to observe rather than catch.
+
+## Reconnection and lifecycle
+
+Reconnection is automatic, with exponential backoff and jitter capped by `MastodonStreamingConfig.reconnectMaxDelay`. Every active subscription is resent once the replacement connection is usable, because subscription state lives on the connection.
+
+Close codes are treated differently:
+
+| Close code | Behavior |
+|---|---|
+| `1000` | Normal closure. No reconnection. |
+| `1003` | The server rejected a binary frame. Reported as an error without retrying. |
+| `1005` | No close frame. May indicate a revoked token, so the client does not retry blindly. |
+| Others | Reconnect with backoff. |
+
+An HTTP 401 during the handshake is raised immediately instead of entering the retry loop, since retrying an invalid token cannot succeed.
+
+Use `suspend()` and `resume()` when the application moves to and from the background, and release everything with `dispose()`:
+
+```dart
+await client.streaming.suspend();
+await client.streaming.resume();
+
+await client.dispose();
+```
+
+`MastodonClient.dispose()` closes the streaming connection and the HTTP transport. It does not create a streaming client if one was never used.
+
+## Configuration
+
+```dart
+final client = MastodonClient(
+  baseUrl: 'https://mastodon.social',
+  accessToken: 'your_token',
+  streamingConfig: MastodonStreamingConfig(
+    authMode: MastodonStreamingAuthMode.subprotocol,
+    pingInterval: Duration(seconds: 30),
+    reconnectMaxDelay: Duration(seconds: 30),
+    reconnectJitter: 0.2,
+  ),
+);
+```
+
+Three authentication modes are supported. The default, `subprotocol`, sends the token as the only WebSocket subprotocol; it works on every platform including the web and keeps the token out of access logs. `header` requires `dart:io`, and `queryParameter` is a legacy mode that exposes the token in the URL. When `enableAuthFallback` is left enabled, the remaining modes are tried after a failure and the successful mode is preferred on later reconnections. Tokens are always redacted from log output.
+
+## Things to know
+
+These behaviors come from the Mastodon streaming server itself and regularly look like client bugs.
+
+- A token limited to `read:statuses` receives home statuses on `user`, but receives no notifications at all — without any error. Notifications require `read` or `read:notifications`.
+- `only_media` is ignored over WebSocket. Media-only behavior must be selected through the channel name.
+- Subscribing to both `user` and `user:notification` delivers every notification twice, because the server treats them as distinct channel sets. `user` alone is enough.
+- `update` and `status.update` on public and hashtag channels can be dropped silently by language preferences, feed access settings (Mastodon v4.5 and later), blocks, mutes, and domain blocks. A public stream that stays quiet is not necessarily broken.
+- `filters_changed` is defined as an event type but is not delivered to clients on Mastodon v4.3 and later, because the server discards payload-free messages.
+- Events produced while the socket is disconnected are not replayed after reconnection. Fill the gap through REST endpoints using `since_id` or `min_id`.
+
+## Health check
+
+The streaming process exposes its own health endpoint, which returns plain text rather than JSON:
+
+```dart
+final healthy = await client.health.checkStreaming();
+```

--- a/docs/i18n/de/docusaurus-plugin-content-docs/current/api/streaming.md
+++ b/docs/i18n/de/docusaurus-plugin-content-docs/current/api/streaming.md
@@ -1,0 +1,177 @@
+---
+sidebar_position: 15
+---
+
+# Streaming
+
+Die `client.streaming`-API liefert Echtzeit-Aktualisierungen über die Mastodon-Streaming-API (WebSocket). Eine einzelne Verbindung multiplext alle Abonnements, sodass das Abonnieren mehrerer Kanäle nicht mehrere Sockets öffnet.
+
+Der Zugriff auf `client.streaming` öffnet noch keine Verbindung. Der Socket wird erst bei `connect()` geöffnet, sodass rein REST-basierte Anwendungen über diese API nie das Netzwerk berühren.
+
+## Verbinden
+
+```dart
+final client = MastodonClient(
+  baseUrl: 'https://mastodon.social',
+  accessToken: 'your_token',
+);
+
+await client.streaming.connect();
+```
+
+Der Endpunkt wird automatisch ermittelt. Der Client liest `configuration.urls.streaming` aus `GET /api/v2/instance`, weicht auf `urls.streaming_api` aus `GET /api/v1/instance` aus und verwendet schließlich den REST-Host. Der ermittelte Wert wird normalisiert: `http` wird zu `ws`, `https` zu `wss`, der Port bleibt erhalten, und `/api/v1/streaming` wird angehängt, falls es fehlt.
+
+Streaming erfordert in jedem Fall ein Zugriffstoken, auch für öffentliche Kanäle. Anonymer Zugriff wurde in Mastodon v4.2.0 entfernt.
+
+## Abonnieren
+
+```dart
+final home = await client.streaming.subscribe(const MastodonStream.user());
+
+home.events.listen((event) {
+  switch (event) {
+    case MastodonUpdateEvent(:final status):
+      print(status.content);
+    case MastodonStatusUpdateEvent(:final status):
+      print('bearbeitet: ${status.id}');
+    case MastodonDeleteEvent(:final statusId):
+      print('gelöscht: $statusId');
+    case MastodonNotificationEvent(:final notification):
+      print(notification.type);
+    case MastodonUnknownStreamEvent(:final event):
+      print('unbekanntes Ereignis: $event');
+    default:
+      break;
+  }
+});
+
+await home.cancel();
+```
+
+Jedes Abonnement-Handle stellt drei Ebenen bereit:
+
+| Eigenschaft | Typ | Inhalt |
+|---|---|---|
+| `events` | `Stream<MastodonStreamEvent>` | Typisierte, sealed Ereignisse |
+| `statuses` | `Stream<MastodonStatus>` | Status aus `update` und `status.update` |
+| `messages` | `Stream<MastodonStreamingMessage>` | Rohe Envelopes mit undekodierter Payload |
+
+## Kanäle
+
+Kanäle werden über den sealed Typ `MastodonStream` beschrieben.
+
+| Factory | Protokollname |
+|---|---|
+| `MastodonStream.user()` | `user` |
+| `MastodonStream.userNotification()` | `user:notification` |
+| `MastodonStream.public()` | `public` |
+| `MastodonStream.public(local: true)` | `public:local` |
+| `MastodonStream.public(remote: true)` | `public:remote` |
+| `MastodonStream.public(onlyMedia: true)` | `public:media` |
+| `MastodonStream.public(local: true, onlyMedia: true)` | `public:local:media` |
+| `MastodonStream.public(remote: true, onlyMedia: true)` | `public:remote:media` |
+| `MastodonStream.hashtag('dart')` | `hashtag` |
+| `MastodonStream.hashtag('dart', local: true)` | `hashtag:local` |
+| `MastodonStream.list('42')` | `list` |
+| `MastodonStream.direct()` | `direct` |
+
+`local` und `remote` können nicht beide true sein — einen solchen Kanal gibt es auf dem Server nicht, und die Kombination wird durch eine Assertion abgelehnt.
+
+Für Kanäle, die diese Bibliothek nicht abbildet, etwa solche aus Mastodon-Forks, steht `subscribeRaw` zur Verfügung:
+
+```dart
+final raw = await client.streaming.subscribeRaw('someCustomStream');
+raw.messages.listen((message) => print(message.payload));
+```
+
+## Referenzzählung
+
+Mastodon ignoriert ein zweites `subscribe` für einen bereits aktiven Kanal stillschweigend, deshalb führt der Client eine Referenzzählung. Der `subscribe`-Frame wird gesendet, wenn der Zähler von null auf eins steigt, `unsubscribe`, wenn er wieder null erreicht.
+
+Hashtag-Schlüssel werden dafür in Kleinbuchstaben normalisiert. Ohne Normalisierung würden `Dart` und `dart` serverseitig kollidieren und das zweite Abonnement ohne Ereignisse zurücklassen.
+
+```dart
+final a = await client.streaming.subscribe(const MastodonStream.hashtag('Dart'));
+final b = await client.streaming.subscribe(const MastodonStream.hashtag('dart'));
+
+await a.cancel(); // Noch kein unsubscribe — b ist weiterhin aktiv.
+await b.cancel(); // Jetzt wird unsubscribe gesendet.
+```
+
+## Fehler
+
+Ein erfolgreiches Abonnement erzeugt keine Bestätigung, und Serverfehler enthalten weder Kanalnamen noch Korrelations-ID. Abonnement-Frames werden daher serialisiert, und ein Fehler, der im anschließenden Ruhefenster eintrifft, wird der letzten Anfrage zugeordnet.
+
+```dart
+try {
+  await client.streaming.subscribe(const MastodonStream.list('999'));
+} on MastodonStreamingSubscriptionException catch (e) {
+  print('${e.message} (${e.status})');
+}
+```
+
+`MastodonStreamingSubscriptionException.status` ist nullable, weil der Server `status` bei `unsubscribe`-Fehlern weglässt.
+
+Fehler auf Verbindungsebene erscheinen als `MastodonStreamingConnectionException`, unerwartete Trennungen als `MastodonStreamingClosedException`. Beide werden zusätzlich über `client.streaming.errors` ausgegeben, falls Beobachten dem Abfangen vorgezogen wird.
+
+## Wiederverbindung und Lebenszyklus
+
+Die Wiederverbindung erfolgt automatisch mit exponentiellem Backoff und Jitter, begrenzt durch `MastodonStreamingConfig.reconnectMaxDelay`. Da der Abonnementzustand an der Verbindung hängt, wird jedes aktive Abonnement erneut gesendet, sobald die Ersatzverbindung nutzbar ist.
+
+Close-Codes werden unterschiedlich behandelt:
+
+| Close-Code | Verhalten |
+|---|---|
+| `1000` | Normaler Abschluss. Keine Wiederverbindung. |
+| `1003` | Der Server hat einen Binär-Frame abgelehnt. Wird als Fehler gemeldet, ohne erneut zu versuchen. |
+| `1005` | Kein Close-Frame. Kann ein widerrufenes Token bedeuten, daher kein blindes Wiederholen. |
+| Andere | Wiederverbindung mit Backoff. |
+
+Ein HTTP 401 während des Handshakes wird sofort ausgelöst, statt in die Wiederholungsschleife zu gehen, da ein ungültiges Token durch Wiederholen nicht gültig wird.
+
+Verwende `suspend()` und `resume()`, wenn die Anwendung in den Hintergrund wechselt und zurückkehrt, und gib alles mit `dispose()` frei:
+
+```dart
+await client.streaming.suspend();
+await client.streaming.resume();
+
+await client.dispose();
+```
+
+`MastodonClient.dispose()` schließt die Streaming-Verbindung und den HTTP-Transport. Ein Streaming-Client wird dabei nicht erzeugt, wenn nie einer verwendet wurde.
+
+## Konfiguration
+
+```dart
+final client = MastodonClient(
+  baseUrl: 'https://mastodon.social',
+  accessToken: 'your_token',
+  streamingConfig: MastodonStreamingConfig(
+    authMode: MastodonStreamingAuthMode.subprotocol,
+    pingInterval: Duration(seconds: 30),
+    reconnectMaxDelay: Duration(seconds: 30),
+    reconnectJitter: 0.2,
+  ),
+);
+```
+
+Drei Authentifizierungsmodi werden unterstützt. Der Standard `subprotocol` sendet das Token als einziges WebSocket-Subprotokoll; er funktioniert auf allen Plattformen einschließlich Web und hält das Token aus Zugriffsprotokollen heraus. `header` benötigt `dart:io`, und `queryParameter` ist ein Alt-Modus, der das Token in der URL offenlegt. Bleibt `enableAuthFallback` aktiviert, werden nach einem Fehlschlag die übrigen Modi versucht, und der erfolgreiche Modus wird bei späteren Wiederverbindungen bevorzugt. Tokens werden in der Log-Ausgabe stets maskiert.
+
+## Wissenswertes
+
+Die folgenden Verhaltensweisen stammen vom Mastodon-Streaming-Server selbst und wirken regelmäßig wie Client-Fehler.
+
+- Ein Token mit nur `read:statuses` empfängt Home-Status über `user`, erhält aber überhaupt keine Benachrichtigungen — ohne jede Fehlermeldung. Benachrichtigungen erfordern `read` oder `read:notifications`.
+- `only_media` wird über WebSocket ignoriert. Nur-Medien-Verhalten muss über den Kanalnamen gewählt werden.
+- Wer `user` und `user:notification` gleichzeitig abonniert, erhält jede Benachrichtigung doppelt, weil der Server sie als getrennte Kanalmengen behandelt. `user` allein genügt.
+- `update` und `status.update` auf öffentlichen und Hashtag-Kanälen können durch Spracheinstellungen, Feed-Zugriffseinstellungen (ab Mastodon v4.5), Blockierungen, Stummschaltungen und Domain-Blockaden stillschweigend verworfen werden. Ein öffentlicher Stream, der still bleibt, ist nicht zwangsläufig defekt.
+- `filters_changed` ist als Ereignistyp definiert, wird ab Mastodon v4.3 jedoch nicht an Clients ausgeliefert, weil der Server Nachrichten ohne Payload verwirft.
+- Ereignisse, die während einer Trennung entstehen, werden nach der Wiederverbindung nicht nachgeliefert. Schließe die Lücke über REST-Endpunkte mit `since_id` oder `min_id`.
+
+## Gesundheitsprüfung
+
+Der Streaming-Prozess besitzt einen eigenen Health-Endpunkt, der reinen Text statt JSON zurückgibt:
+
+```dart
+final healthy = await client.health.checkStreaming();
+```

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/api/streaming.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/api/streaming.md
@@ -1,0 +1,177 @@
+---
+sidebar_position: 15
+---
+
+# Diffusion
+
+L'API `client.streaming` fournit des mises à jour en temps réel via l'API de diffusion de Mastodon (WebSocket). Une seule connexion multiplexe tous les abonnements : s'abonner à plusieurs canaux n'ouvre donc pas plusieurs sockets.
+
+Accéder à `client.streaming` n'ouvre pas de connexion. Le socket n'est ouvert qu'à l'appel de `connect()`, si bien qu'une application purement REST ne touche jamais au réseau via cette API.
+
+## Connexion
+
+```dart
+final client = MastodonClient(
+  baseUrl: 'https://mastodon.social',
+  accessToken: 'your_token',
+);
+
+await client.streaming.connect();
+```
+
+Le point de terminaison est résolu automatiquement. Le client lit `configuration.urls.streaming` depuis `GET /api/v2/instance`, se rabat sur `urls.streaming_api` de `GET /api/v1/instance`, puis réutilise l'hôte REST. La valeur obtenue est normalisée : `http` devient `ws`, `https` devient `wss`, le port est conservé, et `/api/v1/streaming` est ajouté s'il manque.
+
+La diffusion exige un jeton d'accès dans tous les cas, y compris pour les canaux publics. L'accès anonyme a été supprimé dans Mastodon v4.2.0.
+
+## Abonnement
+
+```dart
+final home = await client.streaming.subscribe(const MastodonStream.user());
+
+home.events.listen((event) {
+  switch (event) {
+    case MastodonUpdateEvent(:final status):
+      print(status.content);
+    case MastodonStatusUpdateEvent(:final status):
+      print('modifié : ${status.id}');
+    case MastodonDeleteEvent(:final statusId):
+      print('supprimé : $statusId');
+    case MastodonNotificationEvent(:final notification):
+      print(notification.type);
+    case MastodonUnknownStreamEvent(:final event):
+      print('événement inconnu : $event');
+    default:
+      break;
+  }
+});
+
+await home.cancel();
+```
+
+Chaque descripteur d'abonnement expose trois couches :
+
+| Propriété | Type | Contenu |
+|---|---|---|
+| `events` | `Stream<MastodonStreamEvent>` | Événements typés et sealed |
+| `statuses` | `Stream<MastodonStatus>` | Statuts issus de `update` et `status.update` |
+| `messages` | `Stream<MastodonStreamingMessage>` | Enveloppes brutes à charge utile non décodée |
+
+## Canaux
+
+Les canaux sont décrits par le type sealed `MastodonStream`.
+
+| Fabrique | Nom protocolaire |
+|---|---|
+| `MastodonStream.user()` | `user` |
+| `MastodonStream.userNotification()` | `user:notification` |
+| `MastodonStream.public()` | `public` |
+| `MastodonStream.public(local: true)` | `public:local` |
+| `MastodonStream.public(remote: true)` | `public:remote` |
+| `MastodonStream.public(onlyMedia: true)` | `public:media` |
+| `MastodonStream.public(local: true, onlyMedia: true)` | `public:local:media` |
+| `MastodonStream.public(remote: true, onlyMedia: true)` | `public:remote:media` |
+| `MastodonStream.hashtag('dart')` | `hashtag` |
+| `MastodonStream.hashtag('dart', local: true)` | `hashtag:local` |
+| `MastodonStream.list('42')` | `list` |
+| `MastodonStream.direct()` | `direct` |
+
+`local` et `remote` ne peuvent pas être vrais simultanément : aucun canal de ce type n'existe côté serveur, et la combinaison est rejetée par une assertion.
+
+Pour les canaux que cette bibliothèque ne modélise pas, comme ceux ajoutés par les forks de Mastodon, utilisez `subscribeRaw` :
+
+```dart
+final raw = await client.streaming.subscribeRaw('someCustomStream');
+raw.messages.listen((message) => print(message.payload));
+```
+
+## Comptage de références
+
+Mastodon ignore silencieusement un second `subscribe` pour un canal déjà actif ; le client tient donc un compteur de références. La trame `subscribe` est envoyée lorsque le compteur passe de zéro à un, et `unsubscribe` lorsqu'il revient à zéro.
+
+Les clés de mots-clics sont normalisées en minuscules à cette fin. Sans normalisation, `Dart` et `dart` entreraient en collision côté serveur et le second abonné ne recevrait aucun événement.
+
+```dart
+final a = await client.streaming.subscribe(const MastodonStream.hashtag('Dart'));
+final b = await client.streaming.subscribe(const MastodonStream.hashtag('dart'));
+
+await a.cancel(); // Pas encore d'unsubscribe : b reste actif.
+await b.cancel(); // L'unsubscribe est envoyé maintenant.
+```
+
+## Erreurs
+
+Un abonnement réussi ne produit aucun accusé de réception, et les erreurs du serveur ne portent ni nom de canal ni identifiant de corrélation. Les trames d'abonnement sont donc sérialisées, et une erreur reçue pendant la fenêtre de silence qui suit est attribuée à la dernière requête.
+
+```dart
+try {
+  await client.streaming.subscribe(const MastodonStream.list('999'));
+} on MastodonStreamingSubscriptionException catch (e) {
+  print('${e.message} (${e.status})');
+}
+```
+
+`MastodonStreamingSubscriptionException.status` est nullable car le serveur omet `status` dans les erreurs d'`unsubscribe`.
+
+Les échecs au niveau de la connexion apparaissent comme `MastodonStreamingConnectionException`, et les fermetures inattendues comme `MastodonStreamingClosedException`. Les deux sont également émis sur `client.streaming.errors` pour les applications qui préfèrent observer plutôt que capturer.
+
+## Reconnexion et cycle de vie
+
+La reconnexion est automatique, avec un repli exponentiel et de la gigue, plafonnée par `MastodonStreamingConfig.reconnectMaxDelay`. L'état des abonnements étant lié à la connexion, chaque abonnement actif est renvoyé dès que la connexion de remplacement est utilisable.
+
+Les codes de fermeture sont traités différemment :
+
+| Code de fermeture | Comportement |
+|---|---|
+| `1000` | Fermeture normale. Pas de reconnexion. |
+| `1003` | Le serveur a rejeté une trame binaire. Signalé comme erreur sans nouvelle tentative. |
+| `1005` | Aucune trame de fermeture. Peut indiquer un jeton révoqué ; pas de nouvelle tentative aveugle. |
+| Autres | Reconnexion avec repli. |
+
+Un HTTP 401 pendant la poignée de main est levé immédiatement au lieu d'entrer dans la boucle de reprise, car réessayer avec un jeton invalide ne peut pas aboutir.
+
+Utilisez `suspend()` et `resume()` lorsque l'application passe en arrière-plan et en revient, puis libérez tout avec `dispose()` :
+
+```dart
+await client.streaming.suspend();
+await client.streaming.resume();
+
+await client.dispose();
+```
+
+`MastodonClient.dispose()` ferme la connexion de diffusion et le transport HTTP. Il ne crée pas de client de diffusion si aucun n'a jamais été utilisé.
+
+## Configuration
+
+```dart
+final client = MastodonClient(
+  baseUrl: 'https://mastodon.social',
+  accessToken: 'your_token',
+  streamingConfig: MastodonStreamingConfig(
+    authMode: MastodonStreamingAuthMode.subprotocol,
+    pingInterval: Duration(seconds: 30),
+    reconnectMaxDelay: Duration(seconds: 30),
+    reconnectJitter: 0.2,
+  ),
+);
+```
+
+Trois modes d'authentification sont pris en charge. Le mode par défaut, `subprotocol`, envoie le jeton comme unique sous-protocole WebSocket ; il fonctionne sur toutes les plateformes, y compris le web, et évite que le jeton apparaisse dans les journaux d'accès. `header` nécessite `dart:io`, et `queryParameter` est un mode hérité qui expose le jeton dans l'URL. Si `enableAuthFallback` reste activé, les modes restants sont essayés après un échec, et le mode ayant réussi est privilégié lors des reconnexions suivantes. Les jetons sont toujours masqués dans les journaux.
+
+## À savoir
+
+Les comportements suivants proviennent du serveur de diffusion de Mastodon lui-même et ressemblent souvent à des bogues du client.
+
+- Un jeton limité à `read:statuses` reçoit les statuts du fil principal sur `user`, mais ne reçoit aucune notification — sans aucune erreur. Les notifications exigent `read` ou `read:notifications`.
+- `only_media` est ignoré via WebSocket. Le comportement « médias uniquement » doit être choisi par le nom du canal.
+- S'abonner à la fois à `user` et à `user:notification` livre chaque notification en double, car le serveur les traite comme des ensembles de canaux distincts. `user` seul suffit.
+- `update` et `status.update` sur les canaux publics et de mots-clics peuvent être écartés silencieusement par les préférences de langue, les réglages d'accès aux fils (Mastodon v4.5 et ultérieur), les blocages, les masquages et les blocages de domaine. Un flux public silencieux n'est pas nécessairement défaillant.
+- `filters_changed` est défini comme type d'événement mais n'est pas livré aux clients à partir de Mastodon v4.3, car le serveur écarte les messages sans charge utile.
+- Les événements produits pendant une déconnexion ne sont pas rejoués après la reconnexion. Comblez le manque via les points de terminaison REST avec `since_id` ou `min_id`.
+
+## Vérification de l'état
+
+Le processus de diffusion expose son propre point de terminaison d'état, qui renvoie du texte brut plutôt que du JSON :
+
+```dart
+final healthy = await client.health.checkStreaming();
+```

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/api/streaming.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/api/streaming.md
@@ -1,0 +1,177 @@
+---
+sidebar_position: 15
+---
+
+# ストリーミング
+
+`client.streaming` API は Mastodon の Streaming API（WebSocket）を通じてリアルタイム更新を配信します。単一の接続にすべての購読を多重化するため、複数のチャンネルを購読しても接続が複数開かれることはありません。
+
+`client.streaming` にアクセスしただけでは接続は開きません。ソケットが開くのは `connect()` を呼んだときだけなので、REST しか使わないアプリケーションがこの API 経由で通信を発生させることはありません。
+
+## 接続
+
+```dart
+final client = MastodonClient(
+  baseUrl: 'https://mastodon.social',
+  accessToken: 'your_token',
+);
+
+await client.streaming.connect();
+```
+
+接続先は自動的に解決されます。まず `GET /api/v2/instance` の `configuration.urls.streaming` を読み、無ければ `GET /api/v1/instance` の `urls.streaming_api` にフォールバックし、それも無ければ REST のホストを流用します。解決した値は正規化されます。`http` は `ws` に、`https` は `wss` に変換され、ポートは保持され、`/api/v1/streaming` が無ければ付与されます。
+
+パブリックなチャンネルを含め、ストリーミングには例外なくアクセストークンが必要です。無認証アクセスは Mastodon v4.2.0 で廃止されました。
+
+## 購読
+
+```dart
+final home = await client.streaming.subscribe(const MastodonStream.user());
+
+home.events.listen((event) {
+  switch (event) {
+    case MastodonUpdateEvent(:final status):
+      print(status.content);
+    case MastodonStatusUpdateEvent(:final status):
+      print('編集: ${status.id}');
+    case MastodonDeleteEvent(:final statusId):
+      print('削除: $statusId');
+    case MastodonNotificationEvent(:final notification):
+      print(notification.type);
+    case MastodonUnknownStreamEvent(:final event):
+      print('未知のイベント: $event');
+    default:
+      break;
+  }
+});
+
+await home.cancel();
+```
+
+購読ハンドルは 3 層を提供します。
+
+| プロパティ | 型 | 内容 |
+|---|---|---|
+| `events` | `Stream<MastodonStreamEvent>` | 型付きの sealed イベント |
+| `statuses` | `Stream<MastodonStatus>` | `update` と `status.update` の投稿 |
+| `messages` | `Stream<MastodonStreamingMessage>` | payload 未デコードの生エンベロープ |
+
+## チャンネル
+
+チャンネルは sealed な `MastodonStream` 型で表現します。
+
+| ファクトリ | ワイヤ上の名前 |
+|---|---|
+| `MastodonStream.user()` | `user` |
+| `MastodonStream.userNotification()` | `user:notification` |
+| `MastodonStream.public()` | `public` |
+| `MastodonStream.public(local: true)` | `public:local` |
+| `MastodonStream.public(remote: true)` | `public:remote` |
+| `MastodonStream.public(onlyMedia: true)` | `public:media` |
+| `MastodonStream.public(local: true, onlyMedia: true)` | `public:local:media` |
+| `MastodonStream.public(remote: true, onlyMedia: true)` | `public:remote:media` |
+| `MastodonStream.hashtag('dart')` | `hashtag` |
+| `MastodonStream.hashtag('dart', local: true)` | `hashtag:local` |
+| `MastodonStream.list('42')` | `list` |
+| `MastodonStream.direct()` | `direct` |
+
+`local` と `remote` を同時に true にすることはできません。サーバー側に該当するチャンネルが存在しないため、この組み合わせは `assert` で弾かれます。
+
+Mastodon のフォークが追加したチャンネルなど、本ライブラリが型として持たないチャンネルには `subscribeRaw` を使います。
+
+```dart
+final raw = await client.streaming.subscribeRaw('someCustomStream');
+raw.messages.listen((message) => print(message.payload));
+```
+
+## 参照カウント
+
+Mastodon は既に購読済みのチャンネルに対する 2 回目の `subscribe` をサイレントに無視するため、クライアント側で参照カウントを保持しています。カウントが 0 から 1 になったときに `subscribe` を送り、0 に戻ったときに `unsubscribe` を送ります。
+
+このときハッシュタグのキーは小文字に正規化されます。正規化しないまま `Dart` と `dart` を購読すると、サーバー側で衝突して 2 つ目の購読者にイベントが届かなくなります。
+
+```dart
+final a = await client.streaming.subscribe(const MastodonStream.hashtag('Dart'));
+final b = await client.streaming.subscribe(const MastodonStream.hashtag('dart'));
+
+await a.cancel(); // b がまだ有効なので unsubscribe は送られない
+await b.cancel(); // ここで unsubscribe が送られる
+```
+
+## エラー
+
+購読が成功しても ack は返らず、サーバーのエラーにはチャンネル名も相関 ID も含まれません。そのため購読フレームは逐次送信され、直後の待機時間内に届いたエラーは直近のリクエストに紐づけられます。
+
+```dart
+try {
+  await client.streaming.subscribe(const MastodonStream.list('999'));
+} on MastodonStreamingSubscriptionException catch (e) {
+  print('${e.message} (${e.status})');
+}
+```
+
+`MastodonStreamingSubscriptionException.status` が nullable なのは、`unsubscribe` のエラーにサーバーが `status` を付けないためです。
+
+接続レベルの失敗は `MastodonStreamingConnectionException`、予期しない切断は `MastodonStreamingClosedException` として表現されます。catch する代わりに観測したい場合のために、いずれも `client.streaming.errors` にも流れます。
+
+## 再接続とライフサイクル
+
+再接続は指数バックオフとジッタで自動的に行われ、上限は `MastodonStreamingConfig.reconnectMaxDelay` でキャップされます。購読の状態は接続に紐づくため、代わりの接続が使えるようになった時点ですべての購読が再送されます。
+
+close code によって扱いが異なります。
+
+| close code | 挙動 |
+|---|---|
+| `1000` | 正常終了。再接続しない。 |
+| `1003` | サーバーがバイナリフレームを拒否した。再試行せずエラーとして報告する。 |
+| `1005` | クローズフレーム無し。トークン失効の可能性があるため、無条件には再試行しない。 |
+| その他 | バックオフを挟んで再接続する。 |
+
+ハンドシェイク時の HTTP 401 はリトライループに入らず即座に送出されます。無効なトークンで再試行しても成功しないためです。
+
+アプリのバックグラウンド遷移には `suspend()` と `resume()` を使い、後片付けには `dispose()` を使ってください。
+
+```dart
+await client.streaming.suspend();
+await client.streaming.resume();
+
+await client.dispose();
+```
+
+`MastodonClient.dispose()` はストリーミング接続と HTTP トランスポートを閉じます。ストリーミングを一度も使っていない場合、そのために新しくクライアントを生成することはありません。
+
+## 設定
+
+```dart
+final client = MastodonClient(
+  baseUrl: 'https://mastodon.social',
+  accessToken: 'your_token',
+  streamingConfig: MastodonStreamingConfig(
+    authMode: MastodonStreamingAuthMode.subprotocol,
+    pingInterval: Duration(seconds: 30),
+    reconnectMaxDelay: Duration(seconds: 30),
+    reconnectJitter: 0.2,
+  ),
+);
+```
+
+認証方式は 3 種類あります。既定の `subprotocol` はトークンを唯一の WebSocket サブプロトコルとして送る方式で、Web を含む全プラットフォームで動作し、アクセスログにトークンが残りません。`header` は `dart:io` を必要とし、`queryParameter` は URL にトークンが露出するレガシーな方式です。`enableAuthFallback` を有効にしたままにしておくと、失敗時に残りの方式が順に試され、成功した方式が以降の再接続で優先されます。ログ出力からは常にトークンがマスクされます。
+
+## 注意点
+
+以下は Mastodon の streaming サーバー自体の挙動で、しばしばクライアントのバグに見えるものです。
+
+- `read:statuses` のみのトークンで `user` に繋ぐと、ホームタイムラインは流れますが通知は一切届きません。エラーも出ません。通知には `read` または `read:notifications` が必要です。
+- `only_media` は WebSocket では無視されます。メディアのみに絞るにはチャンネル名で指定する必要があります。
+- `user` と `user:notification` を同時に購読すると、サーバーが両者を別のチャンネル集合として扱うため、同じ通知が 2 回届きます。`user` だけで十分です。
+- パブリックおよびハッシュタグのチャンネルにおける `update` と `status.update` は、言語設定・フィード公開設定（Mastodon v4.5 以降）・ブロック・ミュート・ドメインブロックによってサイレントに破棄されることがあります。パブリックのストリームが静かなままでも、必ずしも壊れているわけではありません。
+- `filters_changed` はイベント型として定義されていますが、Mastodon v4.3 以降ではクライアントに配送されません。payload の無いメッセージをサーバーが破棄するためです。
+- ソケットが切断されている間に発生したイベントは、再接続後も再配送されません。REST の `since_id` や `min_id` で穴埋めしてください。
+
+## ヘルスチェック
+
+streaming プロセスは独自のヘルスチェックエンドポイントを持ち、JSON ではなくプレーンテキストを返します。
+
+```dart
+final healthy = await client.health.checkStreaming();
+```

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/streaming.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/streaming.md
@@ -1,0 +1,177 @@
+---
+sidebar_position: 15
+---
+
+# 스트리밍
+
+`client.streaming` API는 Mastodon 스트리밍 API(WebSocket)를 통해 실시간 업데이트를 전달합니다. 단일 연결에 모든 구독을 다중화하므로 여러 채널을 구독해도 소켓이 여러 개 열리지 않습니다.
+
+`client.streaming`에 접근하는 것만으로는 연결이 열리지 않습니다. 소켓은 `connect()`를 호출할 때만 열리므로, REST만 사용하는 애플리케이션은 이 API를 통해 네트워크에 접근하지 않습니다.
+
+## 연결
+
+```dart
+final client = MastodonClient(
+  baseUrl: 'https://mastodon.social',
+  accessToken: 'your_token',
+);
+
+await client.streaming.connect();
+```
+
+엔드포인트는 자동으로 확인됩니다. 클라이언트는 `GET /api/v2/instance`의 `configuration.urls.streaming`을 먼저 읽고, 없으면 `GET /api/v1/instance`의 `urls.streaming_api`로 폴백하며, 그것도 없으면 REST 호스트를 재사용합니다. 확인된 값은 정규화됩니다. `http`는 `ws`로, `https`는 `wss`로 변환되고, 포트는 유지되며, `/api/v1/streaming`이 없으면 추가됩니다.
+
+공개 채널을 포함해 스트리밍에는 항상 액세스 토큰이 필요합니다. 익명 접근은 Mastodon v4.2.0에서 제거되었습니다.
+
+## 구독
+
+```dart
+final home = await client.streaming.subscribe(const MastodonStream.user());
+
+home.events.listen((event) {
+  switch (event) {
+    case MastodonUpdateEvent(:final status):
+      print(status.content);
+    case MastodonStatusUpdateEvent(:final status):
+      print('편집됨: ${status.id}');
+    case MastodonDeleteEvent(:final statusId):
+      print('삭제됨: $statusId');
+    case MastodonNotificationEvent(:final notification):
+      print(notification.type);
+    case MastodonUnknownStreamEvent(:final event):
+      print('알 수 없는 이벤트: $event');
+    default:
+      break;
+  }
+});
+
+await home.cancel();
+```
+
+각 구독 핸들은 세 개의 계층을 제공합니다.
+
+| 속성 | 타입 | 내용 |
+|---|---|---|
+| `events` | `Stream<MastodonStreamEvent>` | 타입이 지정된 sealed 이벤트 |
+| `statuses` | `Stream<MastodonStatus>` | `update` 및 `status.update`의 포스트 |
+| `messages` | `Stream<MastodonStreamingMessage>` | payload가 디코딩되지 않은 원시 봉투 |
+
+## 채널
+
+채널은 sealed 타입인 `MastodonStream`으로 표현합니다.
+
+| 팩토리 | 프로토콜상의 이름 |
+|---|---|
+| `MastodonStream.user()` | `user` |
+| `MastodonStream.userNotification()` | `user:notification` |
+| `MastodonStream.public()` | `public` |
+| `MastodonStream.public(local: true)` | `public:local` |
+| `MastodonStream.public(remote: true)` | `public:remote` |
+| `MastodonStream.public(onlyMedia: true)` | `public:media` |
+| `MastodonStream.public(local: true, onlyMedia: true)` | `public:local:media` |
+| `MastodonStream.public(remote: true, onlyMedia: true)` | `public:remote:media` |
+| `MastodonStream.hashtag('dart')` | `hashtag` |
+| `MastodonStream.hashtag('dart', local: true)` | `hashtag:local` |
+| `MastodonStream.list('42')` | `list` |
+| `MastodonStream.direct()` | `direct` |
+
+`local`과 `remote`를 동시에 true로 지정할 수는 없습니다. 서버에 해당하는 채널이 존재하지 않으므로 이 조합은 assertion으로 거부됩니다.
+
+Mastodon 포크가 추가한 채널처럼 이 라이브러리가 타입으로 제공하지 않는 채널에는 `subscribeRaw`를 사용하세요.
+
+```dart
+final raw = await client.streaming.subscribeRaw('someCustomStream');
+raw.messages.listen((message) => print(message.payload));
+```
+
+## 참조 카운트
+
+Mastodon은 이미 활성화된 채널에 대한 두 번째 `subscribe`를 조용히 무시하므로, 클라이언트가 참조 카운트를 유지합니다. 카운트가 0에서 1이 될 때 `subscribe` 프레임을 보내고, 다시 0이 될 때 `unsubscribe`를 보냅니다.
+
+이를 위해 해시태그 키는 소문자로 정규화됩니다. 정규화하지 않으면 `Dart`와 `dart`가 서버 측에서 충돌하여 두 번째 구독자가 이벤트를 받지 못합니다.
+
+```dart
+final a = await client.streaming.subscribe(const MastodonStream.hashtag('Dart'));
+final b = await client.streaming.subscribe(const MastodonStream.hashtag('dart'));
+
+await a.cancel(); // b가 아직 활성이므로 unsubscribe는 보내지 않음
+await b.cancel(); // 이제 unsubscribe가 전송됨
+```
+
+## 오류
+
+구독에 성공해도 확인 응답은 오지 않으며, 서버 오류에는 채널 이름도 상관 ID도 포함되지 않습니다. 따라서 구독 프레임은 순차적으로 전송되고, 그 뒤의 대기 구간에 도착한 오류는 가장 최근 요청에 연결됩니다.
+
+```dart
+try {
+  await client.streaming.subscribe(const MastodonStream.list('999'));
+} on MastodonStreamingSubscriptionException catch (e) {
+  print('${e.message} (${e.status})');
+}
+```
+
+`MastodonStreamingSubscriptionException.status`가 nullable인 이유는 서버가 `unsubscribe` 오류에서 `status`를 생략하기 때문입니다.
+
+연결 수준의 실패는 `MastodonStreamingConnectionException`으로, 예기치 않은 종료는 `MastodonStreamingClosedException`으로 표현됩니다. 잡는 대신 관찰하고 싶은 경우를 위해 두 가지 모두 `client.streaming.errors`로도 전달됩니다.
+
+## 재연결과 생명주기
+
+재연결은 지수 백오프와 지터를 사용해 자동으로 이루어지며, 상한은 `MastodonStreamingConfig.reconnectMaxDelay`로 제한됩니다. 구독 상태는 연결에 종속되므로, 대체 연결을 사용할 수 있게 되면 활성 구독이 모두 다시 전송됩니다.
+
+종료 코드에 따라 처리가 다릅니다.
+
+| 종료 코드 | 동작 |
+|---|---|
+| `1000` | 정상 종료. 재연결하지 않음. |
+| `1003` | 서버가 바이너리 프레임을 거부함. 재시도 없이 오류로 보고. |
+| `1005` | 종료 프레임 없음. 토큰이 취소되었을 수 있으므로 무작정 재시도하지 않음. |
+| 그 외 | 백오프 후 재연결. |
+
+핸드셰이크 중의 HTTP 401은 재시도 루프에 들어가지 않고 즉시 던져집니다. 유효하지 않은 토큰으로 재시도해도 성공할 수 없기 때문입니다.
+
+애플리케이션이 백그라운드로 전환되거나 돌아올 때는 `suspend()`와 `resume()`을 사용하고, 정리에는 `dispose()`를 사용하세요.
+
+```dart
+await client.streaming.suspend();
+await client.streaming.resume();
+
+await client.dispose();
+```
+
+`MastodonClient.dispose()`는 스트리밍 연결과 HTTP 전송을 닫습니다. 스트리밍을 한 번도 사용하지 않았다면 이를 위해 스트리밍 클라이언트를 새로 만들지 않습니다.
+
+## 설정
+
+```dart
+final client = MastodonClient(
+  baseUrl: 'https://mastodon.social',
+  accessToken: 'your_token',
+  streamingConfig: MastodonStreamingConfig(
+    authMode: MastodonStreamingAuthMode.subprotocol,
+    pingInterval: Duration(seconds: 30),
+    reconnectMaxDelay: Duration(seconds: 30),
+    reconnectJitter: 0.2,
+  ),
+);
+```
+
+세 가지 인증 방식을 지원합니다. 기본값인 `subprotocol`은 토큰을 유일한 WebSocket 하위 프로토콜로 전송하며, 웹을 포함한 모든 플랫폼에서 동작하고 액세스 로그에 토큰을 남기지 않습니다. `header`는 `dart:io`가 필요하고, `queryParameter`는 URL에 토큰이 노출되는 레거시 방식입니다. `enableAuthFallback`을 켜 둔 상태에서는 실패 후 나머지 방식을 차례로 시도하며, 성공한 방식이 이후 재연결에서 우선 사용됩니다. 로그 출력에서 토큰은 항상 마스킹됩니다.
+
+## 유의 사항
+
+다음 동작은 Mastodon 스트리밍 서버 자체에서 비롯된 것으로, 흔히 클라이언트 버그처럼 보입니다.
+
+- `read:statuses`로 제한된 토큰은 `user`에서 홈 포스트는 받지만 알림은 전혀 받지 못하며, 오류도 발생하지 않습니다. 알림에는 `read` 또는 `read:notifications`가 필요합니다.
+- `only_media`는 WebSocket에서 무시됩니다. 미디어만 받으려면 채널 이름으로 선택해야 합니다.
+- `user`와 `user:notification`을 함께 구독하면 서버가 둘을 서로 다른 채널 집합으로 취급하므로 모든 알림이 두 번 전달됩니다. `user`만으로 충분합니다.
+- 공개 및 해시태그 채널의 `update`와 `status.update`는 언어 설정, 피드 접근 설정(Mastodon v4.5 이상), 차단, 뮤트, 도메인 차단에 의해 조용히 삭제될 수 있습니다. 공개 스트림이 조용하다고 해서 반드시 고장 난 것은 아닙니다.
+- `filters_changed`는 이벤트 타입으로 정의되어 있지만 Mastodon v4.3 이상에서는 클라이언트에 전달되지 않습니다. 서버가 payload 없는 메시지를 버리기 때문입니다.
+- 소켓이 끊긴 동안 발생한 이벤트는 재연결 후에도 다시 전달되지 않습니다. REST의 `since_id` 또는 `min_id`로 공백을 메우세요.
+
+## 상태 확인
+
+스트리밍 프로세스는 자체 상태 확인 엔드포인트를 가지며, JSON이 아닌 일반 텍스트를 반환합니다.
+
+```dart
+final healthy = await client.health.checkStreaming();
+```

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/api/streaming.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/api/streaming.md
@@ -1,0 +1,177 @@
+---
+sidebar_position: 15
+---
+
+# 流式传输
+
+`client.streaming` API 通过 Mastodon 的流式 API（WebSocket）提供实时更新。所有订阅都多路复用到单个连接上，因此订阅多个频道不会打开多个套接字。
+
+访问 `client.streaming` 本身不会建立连接。只有调用 `connect()` 时才会打开套接字，所以仅使用 REST 的应用不会通过此 API 产生任何网络通信。
+
+## 建立连接
+
+```dart
+final client = MastodonClient(
+  baseUrl: 'https://mastodon.social',
+  accessToken: 'your_token',
+);
+
+await client.streaming.connect();
+```
+
+端点会自动解析。客户端先读取 `GET /api/v2/instance` 的 `configuration.urls.streaming`，若不存在则回退到 `GET /api/v1/instance` 的 `urls.streaming_api`，最后复用 REST 主机。解析出的值会被规范化：`http` 转为 `ws`，`https` 转为 `wss`，端口保留，缺少 `/api/v1/streaming` 时会自动补全。
+
+包括公共频道在内，流式传输始终需要访问令牌。匿名访问已在 Mastodon v4.2.0 中移除。
+
+## 订阅
+
+```dart
+final home = await client.streaming.subscribe(const MastodonStream.user());
+
+home.events.listen((event) {
+  switch (event) {
+    case MastodonUpdateEvent(:final status):
+      print(status.content);
+    case MastodonStatusUpdateEvent(:final status):
+      print('已编辑: ${status.id}');
+    case MastodonDeleteEvent(:final statusId):
+      print('已删除: $statusId');
+    case MastodonNotificationEvent(:final notification):
+      print(notification.type);
+    case MastodonUnknownStreamEvent(:final event):
+      print('未知事件: $event');
+    default:
+      break;
+  }
+});
+
+await home.cancel();
+```
+
+每个订阅句柄提供三个层次：
+
+| 属性 | 类型 | 内容 |
+|---|---|---|
+| `events` | `Stream<MastodonStreamEvent>` | 类型化的 sealed 事件 |
+| `statuses` | `Stream<MastodonStatus>` | 来自 `update` 和 `status.update` 的嘟文 |
+| `messages` | `Stream<MastodonStreamingMessage>` | payload 未解码的原始信封 |
+
+## 频道
+
+频道由 sealed 的 `MastodonStream` 类型描述。
+
+| 工厂方法 | 协议名称 |
+|---|---|
+| `MastodonStream.user()` | `user` |
+| `MastodonStream.userNotification()` | `user:notification` |
+| `MastodonStream.public()` | `public` |
+| `MastodonStream.public(local: true)` | `public:local` |
+| `MastodonStream.public(remote: true)` | `public:remote` |
+| `MastodonStream.public(onlyMedia: true)` | `public:media` |
+| `MastodonStream.public(local: true, onlyMedia: true)` | `public:local:media` |
+| `MastodonStream.public(remote: true, onlyMedia: true)` | `public:remote:media` |
+| `MastodonStream.hashtag('dart')` | `hashtag` |
+| `MastodonStream.hashtag('dart', local: true)` | `hashtag:local` |
+| `MastodonStream.list('42')` | `list` |
+| `MastodonStream.direct()` | `direct` |
+
+`local` 和 `remote` 不能同时为 true。服务器上不存在这样的频道，因此该组合会被断言拒绝。
+
+对于本库未建模的频道（例如 Mastodon 分支新增的频道），请使用 `subscribeRaw`：
+
+```dart
+final raw = await client.streaming.subscribeRaw('someCustomStream');
+raw.messages.listen((message) => print(message.payload));
+```
+
+## 引用计数
+
+Mastodon 会静默忽略对已订阅频道的第二次 `subscribe`，因此客户端维护了引用计数。计数从 0 变为 1 时发送 `subscribe`，回到 0 时发送 `unsubscribe`。
+
+为此话题标签的键会被规范化为小写。若不规范化，同时订阅 `Dart` 和 `dart` 会在服务器端发生冲突，导致第二个订阅者收不到事件。
+
+```dart
+final a = await client.streaming.subscribe(const MastodonStream.hashtag('Dart'));
+final b = await client.streaming.subscribe(const MastodonStream.hashtag('dart'));
+
+await a.cancel(); // b 仍然有效，暂不发送 unsubscribe
+await b.cancel(); // 此时才发送 unsubscribe
+```
+
+## 错误
+
+订阅成功不会返回确认，而服务器的错误既不含频道名也不含关联 ID。因此订阅帧会串行发送，并将随后静默窗口内到达的错误归因于最近一次请求。
+
+```dart
+try {
+  await client.streaming.subscribe(const MastodonStream.list('999'));
+} on MastodonStreamingSubscriptionException catch (e) {
+  print('${e.message} (${e.status})');
+}
+```
+
+`MastodonStreamingSubscriptionException.status` 可为空，因为服务器在 `unsubscribe` 的错误中不包含 `status`。
+
+连接级别的失败表现为 `MastodonStreamingConnectionException`，意外断开表现为 `MastodonStreamingClosedException`。若倾向于观察而非捕获，二者也会发送到 `client.streaming.errors`。
+
+## 重连与生命周期
+
+重连会自动进行，采用指数退避加抖动，上限由 `MastodonStreamingConfig.reconnectMaxDelay` 限制。由于订阅状态依附于连接，替代连接可用后会重新发送所有活动订阅。
+
+不同的关闭码处理方式不同：
+
+| 关闭码 | 行为 |
+|---|---|
+| `1000` | 正常关闭。不重连。 |
+| `1003` | 服务器拒绝了二进制帧。报告为错误且不重试。 |
+| `1005` | 没有关闭帧。可能意味着令牌已失效，因此不会盲目重试。 |
+| 其他 | 退避后重连。 |
+
+握手期间的 HTTP 401 会立即抛出而不进入重试循环，因为使用无效令牌重试不可能成功。
+
+应用进入或离开后台时请使用 `suspend()` 和 `resume()`，并用 `dispose()` 释放资源：
+
+```dart
+await client.streaming.suspend();
+await client.streaming.resume();
+
+await client.dispose();
+```
+
+`MastodonClient.dispose()` 会关闭流式连接和 HTTP 传输。如果从未使用过流式功能，它不会为此创建流式客户端。
+
+## 配置
+
+```dart
+final client = MastodonClient(
+  baseUrl: 'https://mastodon.social',
+  accessToken: 'your_token',
+  streamingConfig: MastodonStreamingConfig(
+    authMode: MastodonStreamingAuthMode.subprotocol,
+    pingInterval: Duration(seconds: 30),
+    reconnectMaxDelay: Duration(seconds: 30),
+    reconnectJitter: 0.2,
+  ),
+);
+```
+
+支持三种认证方式。默认的 `subprotocol` 将令牌作为唯一的 WebSocket 子协议发送；它在包括 Web 在内的所有平台上都可用，并且不会把令牌留在访问日志中。`header` 需要 `dart:io`，而 `queryParameter` 是会在 URL 中暴露令牌的旧方式。保持 `enableAuthFallback` 启用时，失败后会依次尝试其余方式，并在后续重连中优先使用成功的方式。日志输出中的令牌始终会被脱敏。
+
+## 注意事项
+
+以下行为源自 Mastodon 流式服务器本身，经常被误认为是客户端缺陷。
+
+- 仅具有 `read:statuses` 的令牌可以在 `user` 上接收主页嘟文，但完全收不到通知，而且不会报错。通知需要 `read` 或 `read:notifications`。
+- `only_media` 在 WebSocket 上会被忽略。只看媒体必须通过频道名来选择。
+- 同时订阅 `user` 和 `user:notification` 会使每条通知收到两次，因为服务器将二者视为不同的频道集合。仅订阅 `user` 即可。
+- 公共和话题标签频道上的 `update` 与 `status.update` 可能因语言偏好、信息流访问设置（Mastodon v4.5 及以后）、屏蔽、静音和域名屏蔽而被静默丢弃。公共流保持安静未必意味着出错。
+- `filters_changed` 虽然定义为事件类型，但在 Mastodon v4.3 及以后不会送达客户端，因为服务器会丢弃没有 payload 的消息。
+- 套接字断开期间产生的事件在重连后不会重放。请通过 REST 的 `since_id` 或 `min_id` 补齐缺口。
+
+## 健康检查
+
+流式进程有自己的健康检查端点，返回纯文本而非 JSON：
+
+```dart
+final healthy = await client.health.checkStreaming();
+```

--- a/lib/mastodon_client.dart
+++ b/lib/mastodon_client.dart
@@ -88,4 +88,8 @@ export 'src/models/mastodon_weekly_activity.dart';
 export 'src/streaming/mastodon_streaming.dart';
 export 'src/streaming/streaming_config.dart';
 export 'src/streaming/streaming_connection_state.dart';
+export 'src/streaming/streaming_event.dart';
+export 'src/streaming/streaming_message.dart';
+export 'src/streaming/streaming_stream.dart';
+export 'src/streaming/streaming_subscription.dart';
 export 'src/streaming/websocket_connector.dart';

--- a/lib/mastodon_client.dart
+++ b/lib/mastodon_client.dart
@@ -85,3 +85,7 @@ export 'src/models/mastodon_trends_link.dart';
 export 'src/models/mastodon_unread_notification_count.dart';
 export 'src/models/mastodon_web_push_subscription.dart';
 export 'src/models/mastodon_weekly_activity.dart';
+export 'src/streaming/mastodon_streaming.dart';
+export 'src/streaming/streaming_config.dart';
+export 'src/streaming/streaming_connection_state.dart';
+export 'src/streaming/websocket_connector.dart';

--- a/lib/mastodon_client.dart
+++ b/lib/mastodon_client.dart
@@ -76,6 +76,7 @@ export 'src/models/mastodon_status_create_result.dart';
 export 'src/models/mastodon_status_edit.dart';
 export 'src/models/mastodon_status_edit_request.dart';
 export 'src/models/mastodon_status_source.dart';
+export 'src/models/mastodon_streaming_announcement_reaction.dart';
 export 'src/models/mastodon_suggestion.dart';
 export 'src/models/mastodon_terms_of_service.dart';
 export 'src/models/mastodon_token.dart';

--- a/lib/src/api/health_api.dart
+++ b/lib/src/api/health_api.dart
@@ -21,4 +21,17 @@ class HealthApi {
     await _http.send<dynamic>('/health');
     return true;
   }
+
+  /// Checks whether the streaming process is healthy.
+  ///
+  /// `GET /api/v1/streaming/health`
+  ///
+  /// No authentication is required. The endpoint returns a plain-text `OK`
+  /// response rather than JSON.
+  ///
+  /// Throws a `MastodonException` on failure.
+  Future<bool> checkStreaming() async {
+    final data = await _http.send<String>('/api/v1/streaming/health');
+    return data == 'OK';
+  }
 }

--- a/lib/src/api/health_api.dart
+++ b/lib/src/api/health_api.dart
@@ -32,6 +32,6 @@ class HealthApi {
   /// Throws a `MastodonException` on failure.
   Future<bool> checkStreaming() async {
     final data = await _http.send<String>('/api/v1/streaming/health');
-    return data == 'OK';
+    return data?.trim() == 'OK';
   }
 }

--- a/lib/src/client/mastodon_client.dart
+++ b/lib/src/client/mastodon_client.dart
@@ -124,7 +124,17 @@ class MastodonClient {
       logger: _http.logger,
       enableLog: _http.enableLog,
       metadataProvider: _resolveStreamingMetadata,
+      tokenValidator: _validateStreamingToken,
     );
+  }
+
+  Future<bool> _validateStreamingToken() async {
+    try {
+      await AccountsApi(_http).verifyCredentials();
+      return true;
+    } on MastodonUnauthorizedException {
+      return false;
+    }
   }
 
   Future<({MastodonInstance? instance, MastodonInstanceV1? instanceV1})>

--- a/lib/src/client/mastodon_client.dart
+++ b/lib/src/client/mastodon_client.dart
@@ -52,7 +52,12 @@ import '../api/suggestions_api.dart';
 import '../api/tags_api.dart';
 import '../api/timelines_api.dart';
 import '../api/trends_api.dart';
+import '../exception/mastodon_exception.dart';
 import '../logging/logger.dart';
+import '../models/mastodon_instance.dart';
+import '../models/mastodon_instance_v1.dart';
+import '../streaming/mastodon_streaming.dart';
+import '../streaming/streaming_config.dart';
 import 'mastodon_http_client.dart';
 
 /// Main entry point for the Mastodon API client.
@@ -83,7 +88,9 @@ class MastodonClient {
     bool enableLog = true,
     Logger? logger,
     HttpClientAdapter? httpClientAdapter,
-  }) : _http = MastodonHttpClient(
+    MastodonStreamingConfig? streamingConfig,
+  }) : streamingConfig = streamingConfig ?? MastodonStreamingConfig(),
+       _http = MastodonHttpClient(
          baseUrl: baseUrl,
          accessToken: accessToken,
          enableLog: enableLog,
@@ -92,6 +99,56 @@ class MastodonClient {
        );
 
   final MastodonHttpClient _http;
+  MastodonStreaming? _streaming;
+  Future<void>? _disposeFuture;
+
+  /// Connection and reconnection settings used by [streaming].
+  final MastodonStreamingConfig streamingConfig;
+
+  /// Lazily created and cached Streaming API client.
+  ///
+  /// Accessing this property does not open a WebSocket. Call
+  /// [MastodonStreaming.connect] explicitly when streaming is needed.
+  MastodonStreaming get streaming {
+    if (_disposeFuture != null) {
+      throw StateError('MastodonClient has been disposed');
+    }
+    final accessToken = _http.accessToken;
+    if (accessToken == null || accessToken.isEmpty) {
+      throw StateError('Mastodon Streaming API requires an access token');
+    }
+    return _streaming ??= MastodonStreaming(
+      baseUrl: _http.baseUrl,
+      accessToken: accessToken,
+      config: streamingConfig,
+      logger: _http.logger,
+      enableLog: _http.enableLog,
+      metadataProvider: _resolveStreamingMetadata,
+    );
+  }
+
+  Future<({MastodonInstance? instance, MastodonInstanceV1? instanceV1})>
+  _resolveStreamingMetadata() async {
+    MastodonInstance? instance;
+    try {
+      instance = await InstanceApi(_http).fetch();
+    } on MastodonException {
+      // v2 非対応サーバでは v1 の取得へフォールバックする。
+    }
+    final v2Url = instance?.configuration.urls.streaming?.trim();
+    if (v2Url != null && v2Url.isNotEmpty) {
+      return (instance: instance, instanceV1: null);
+    }
+
+    MastodonInstanceV1? instanceV1;
+    try {
+      // ignore: deprecated_member_use_from_same_package
+      instanceV1 = await InstanceApi(_http).fetchV1();
+    } on MastodonException {
+      // メタデータが取れなければ StreamingUrlResolver が REST host を使う。
+    }
+    return (instance: instance, instanceV1: instanceV1);
+  }
 
   /// Account information API.
   AccountsApi get accounts => AccountsApi(_http);
@@ -256,4 +313,18 @@ class MastodonClient {
 
   /// Trends (tags, statuses, and links) API.
   TrendsApi get trends => TrendsApi(_http);
+
+  /// Releases the optional streaming connection and the HTTP transport.
+  ///
+  /// If [streaming] was never accessed, this method does not create it or open
+  /// a WebSocket. Calling this method repeatedly is safe.
+  Future<void> dispose() => _disposeFuture ??= _performDispose();
+
+  Future<void> _performDispose() async {
+    try {
+      await _streaming?.dispose();
+    } finally {
+      _http.dio.close(force: true);
+    }
+  }
 }

--- a/lib/src/client/mastodon_http_client.dart
+++ b/lib/src/client/mastodon_http_client.dart
@@ -13,12 +13,12 @@ import 'constants.dart';
 /// to all requests.
 class MastodonHttpClient {
   MastodonHttpClient({
-    required String baseUrl,
-    String? accessToken,
+    required this.baseUrl,
+    this.accessToken,
     Duration connectTimeout = const Duration(seconds: 10),
     Duration receiveTimeout = const Duration(seconds: 10),
     Duration sendTimeout = const Duration(seconds: 10),
-    bool enableLog = true,
+    this.enableLog = true,
     Logger? logger,
     HttpClientAdapter? httpClientAdapter,
   }) : logger = logger ?? const StdoutLogger(),
@@ -44,6 +44,15 @@ class MastodonHttpClient {
 
   final Dio dio;
   final Logger logger;
+
+  /// Base URL used for REST API requests.
+  final String baseUrl;
+
+  /// Access token used to authenticate requests, if provided.
+  final String? accessToken;
+
+  /// Whether client logging is enabled.
+  final bool enableLog;
 
   /// Executes an HTTP request and returns the response body.
   ///

--- a/lib/src/exception/mastodon_exception.dart
+++ b/lib/src/exception/mastodon_exception.dart
@@ -164,3 +164,69 @@ class MastodonMediaProcessingTimeoutException extends MastodonException {
   /// ID of the media that was awaiting processing.
   final String mediaId;
 }
+
+/// Base class for errors from the Mastodon Streaming API.
+sealed class MastodonStreamingException extends MastodonException {
+  const MastodonStreamingException(super.message);
+}
+
+/// A failure while establishing or restoring a streaming connection.
+class MastodonStreamingConnectionException extends MastodonStreamingException {
+  /// Creates a streaming connection failure.
+  const MastodonStreamingConnectionException({
+    String message = 'Streaming connection failed',
+    this.statusCode,
+    this.endpoint,
+    this.raw,
+  }) : super(message);
+
+  /// HTTP status returned by the WebSocket handshake, when available.
+  final int? statusCode;
+
+  /// Credential-free Streaming API endpoint.
+  final String? endpoint;
+
+  /// Original exception or error object, when safe to expose.
+  final Object? raw;
+}
+
+/// A server-reported subscription or unsubscription failure.
+class MastodonStreamingSubscriptionException
+    extends MastodonStreamingException {
+  /// Creates a streaming subscription failure.
+  const MastodonStreamingSubscriptionException({
+    String message = 'Streaming subscription failed',
+    this.status,
+    this.endpoint,
+    this.raw,
+  }) : super(message);
+
+  /// Status value returned by a subscription response, when present.
+  final int? status;
+
+  /// Credential-free Streaming API endpoint.
+  final String? endpoint;
+
+  /// Original response or error object.
+  final Object? raw;
+}
+
+/// An unexpected or non-recoverable streaming connection closure.
+class MastodonStreamingClosedException extends MastodonStreamingException {
+  /// Creates a streaming closure failure.
+  const MastodonStreamingClosedException({
+    required this.closeCode,
+    this.closeReason,
+    this.endpoint,
+    String message = 'Streaming connection closed',
+  }) : super(message);
+
+  /// WebSocket close code. A value of 1005 means no status was received.
+  final int closeCode;
+
+  /// WebSocket close reason, when supplied by the server.
+  final String? closeReason;
+
+  /// Credential-free Streaming API endpoint.
+  final String? endpoint;
+}

--- a/lib/src/models/mastodon_streaming_announcement_reaction.dart
+++ b/lib/src/models/mastodon_streaming_announcement_reaction.dart
@@ -1,0 +1,30 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'mastodon_streaming_announcement_reaction.g.dart';
+
+/// Reaction update delivered by the `announcement.reaction` streaming event.
+@JsonSerializable(fieldRename: FieldRename.snake)
+class MastodonStreamingAnnouncementReaction {
+  const MastodonStreamingAnnouncementReaction({
+    required this.name,
+    required this.count,
+    required this.announcementId,
+  });
+
+  factory MastodonStreamingAnnouncementReaction.fromJson(
+    Map<String, dynamic> json,
+  ) => _$MastodonStreamingAnnouncementReactionFromJson(json);
+
+  /// Serializes to JSON.
+  Map<String, dynamic> toJson() =>
+      _$MastodonStreamingAnnouncementReactionToJson(this);
+
+  /// Emoji name (Unicode emoji or custom emoji shortcode).
+  final String name;
+
+  /// Total count of this reaction.
+  final int count;
+
+  /// ID of the announcement whose reaction count changed.
+  final String announcementId;
+}

--- a/lib/src/models/mastodon_streaming_announcement_reaction.g.dart
+++ b/lib/src/models/mastodon_streaming_announcement_reaction.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: deprecated_member_use_from_same_package
+
+part of 'mastodon_streaming_announcement_reaction.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+MastodonStreamingAnnouncementReaction
+_$MastodonStreamingAnnouncementReactionFromJson(Map<String, dynamic> json) =>
+    MastodonStreamingAnnouncementReaction(
+      name: json['name'] as String,
+      count: (json['count'] as num).toInt(),
+      announcementId: json['announcement_id'] as String,
+    );
+
+Map<String, dynamic> _$MastodonStreamingAnnouncementReactionToJson(
+  MastodonStreamingAnnouncementReaction instance,
+) => <String, dynamic>{
+  'name': instance.name,
+  'count': instance.count,
+  'announcement_id': instance.announcementId,
+};

--- a/lib/src/streaming/internal/streaming_event_decoder.dart
+++ b/lib/src/streaming/internal/streaming_event_decoder.dart
@@ -1,0 +1,88 @@
+import 'dart:convert';
+
+import '../../models/mastodon_announcement.dart';
+import '../../models/mastodon_conversation.dart';
+import '../../models/mastodon_notification.dart';
+import '../../models/mastodon_status.dart';
+import '../../models/mastodon_streaming_announcement_reaction.dart';
+import '../streaming_event.dart';
+import '../streaming_message.dart';
+
+/// Decodes one raw Streaming API message into a typed event.
+MastodonStreamEvent decodeMastodonStreamEvent(
+  MastodonStreamingMessage message,
+) {
+  try {
+    return switch (message.event) {
+      'update' => MastodonUpdateEvent(
+        stream: message.stream,
+        status: MastodonStatus.fromJson(_decodeObject(message.payload)),
+      ),
+      'status.update' => MastodonStatusUpdateEvent(
+        stream: message.stream,
+        status: MastodonStatus.fromJson(_decodeObject(message.payload)),
+      ),
+      'delete' => MastodonDeleteEvent(
+        stream: message.stream,
+        statusId: _requirePayload(message.payload),
+      ),
+      'notification' => MastodonNotificationEvent(
+        stream: message.stream,
+        notification: MastodonNotification.fromJson(
+          _decodeObject(message.payload),
+        ),
+      ),
+      'conversation' => MastodonConversationEvent(
+        stream: message.stream,
+        conversation: MastodonConversation.fromJson(
+          _decodeObject(message.payload),
+        ),
+      ),
+      'announcement' => MastodonAnnouncementEvent(
+        stream: message.stream,
+        announcement: MastodonAnnouncement.fromJson(
+          _decodeObject(message.payload),
+        ),
+      ),
+      'announcement.reaction' => MastodonAnnouncementReactionEvent(
+        stream: message.stream,
+        reaction: MastodonStreamingAnnouncementReaction.fromJson(
+          _decodeObject(message.payload),
+        ),
+      ),
+      'announcement.delete' => MastodonAnnouncementDeleteEvent(
+        stream: message.stream,
+        announcementId: _requirePayload(message.payload),
+      ),
+      'notifications_merged' => MastodonNotificationsMergedEvent(
+        stream: message.stream,
+      ),
+      'filters_changed' => MastodonFiltersChangedEvent(stream: message.stream),
+      _ => _unknown(message),
+    };
+  } on Object {
+    return _unknown(message);
+  }
+}
+
+MastodonUnknownStreamEvent _unknown(MastodonStreamingMessage message) =>
+    MastodonUnknownStreamEvent(
+      stream: message.stream,
+      event: message.event,
+      rawPayload: message.payload,
+    );
+
+Map<String, dynamic> _decodeObject(String? rawPayload) {
+  final decoded = jsonDecode(_requirePayload(rawPayload));
+  if (decoded is! Map<String, dynamic>) {
+    throw const FormatException('Streaming event payload must be an object');
+  }
+  return decoded;
+}
+
+String _requirePayload(String? rawPayload) {
+  if (rawPayload == null) {
+    throw const FormatException('Streaming event payload is required');
+  }
+  return rawPayload;
+}

--- a/lib/src/streaming/internal/websocket_channel_connection.dart
+++ b/lib/src/streaming/internal/websocket_channel_connection.dart
@@ -1,0 +1,29 @@
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import 'websocket_types.dart';
+
+/// Adapts a [WebSocketChannel] to [WebSocketConnection].
+final class WebSocketChannelConnection implements WebSocketConnection {
+  /// Creates an adapter around [channel].
+  WebSocketChannelConnection(this.channel);
+
+  /// Wrapped channel.
+  final WebSocketChannel channel;
+
+  @override
+  Stream<Object?> get messages => channel.stream.cast<Object?>();
+
+  @override
+  int? get closeCode => channel.closeCode;
+
+  @override
+  String? get closeReason => channel.closeReason;
+
+  @override
+  void sendText(String data) => channel.sink.add(data);
+
+  @override
+  Future<void> close([int? closeCode, String? closeReason]) async {
+    await channel.sink.close(closeCode, closeReason);
+  }
+}

--- a/lib/src/streaming/internal/websocket_connector_factory.dart
+++ b/lib/src/streaming/internal/websocket_connector_factory.dart
@@ -4,6 +4,12 @@ import 'websocket_channel_connection.dart';
 import 'websocket_types.dart';
 
 /// Creates the platform-default connector.
+///
+/// Browsers do not expose WebSocket handshake HTTP status codes. Consequently,
+/// [WebSocketConnectorException.statusCode] remains `null` on Web even for a
+/// 401 response. Web applications should set a finite
+/// `MastodonStreamingConfig.maxReconnectAttempts` value to avoid unlimited
+/// retries with an invalid token.
 WebSocketConnector createDefaultWebSocketConnector() =>
     _DefaultWebSocketConnector();
 

--- a/lib/src/streaming/internal/websocket_connector_factory.dart
+++ b/lib/src/streaming/internal/websocket_connector_factory.dart
@@ -1,0 +1,43 @@
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import 'websocket_channel_connection.dart';
+import 'websocket_types.dart';
+
+/// Creates the platform-default connector.
+WebSocketConnector createDefaultWebSocketConnector() =>
+    _DefaultWebSocketConnector();
+
+final class _DefaultWebSocketConnector implements WebSocketConnector {
+  @override
+  Future<WebSocketConnection> connect(WebSocketConnectOptions options) async {
+    if (options.headers.isNotEmpty) {
+      throw const WebSocketConnectorException(
+        message: 'WebSocket handshake headers are unsupported on this platform',
+      );
+    }
+
+    final channel = WebSocketChannel.connect(
+      options.uri,
+      protocols: options.protocols.isEmpty ? null : options.protocols,
+    );
+    try {
+      final ready = channel.ready;
+      if (options.connectTimeout case final timeout?) {
+        await ready.timeout(timeout);
+      } else {
+        await ready;
+      }
+      return WebSocketChannelConnection(channel);
+    } catch (error) {
+      try {
+        await channel.sink.close();
+      } catch (_) {
+        // 接続失敗の原因を close 側の例外で上書きしない。
+      }
+      throw WebSocketConnectorException(
+        message: 'WebSocket handshake failed',
+        cause: error,
+      );
+    }
+  }
+}

--- a/lib/src/streaming/internal/websocket_connector_factory_io.dart
+++ b/lib/src/streaming/internal/websocket_connector_factory_io.dart
@@ -1,0 +1,43 @@
+import 'dart:io';
+
+import 'package:web_socket_channel/io.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import 'websocket_channel_connection.dart';
+import 'websocket_types.dart';
+
+/// Creates the dart:io WebSocket connector.
+WebSocketConnector createDefaultWebSocketConnector() => _IoWebSocketConnector();
+
+final class _IoWebSocketConnector implements WebSocketConnector {
+  @override
+  Future<WebSocketConnection> connect(WebSocketConnectOptions options) async {
+    final channel = IOWebSocketChannel.connect(
+      options.uri,
+      protocols: options.protocols.isEmpty ? null : options.protocols,
+      headers: options.headers.isEmpty ? null : options.headers,
+      pingInterval: options.pingInterval,
+      connectTimeout: options.connectTimeout,
+    );
+    try {
+      await channel.ready;
+      return WebSocketChannelConnection(channel);
+    } catch (error) {
+      try {
+        await channel.sink.close();
+      } catch (_) {
+        // 接続失敗の原因を close 側の例外で上書きしない。
+      }
+      throw WebSocketConnectorException(
+        message: 'WebSocket handshake failed',
+        statusCode: _statusCodeOf(error),
+        cause: error,
+      );
+    }
+  }
+
+  int? _statusCodeOf(Object error) {
+    final inner = error is WebSocketChannelException ? error.inner : error;
+    return inner is WebSocketException ? inner.httpStatusCode : null;
+  }
+}

--- a/lib/src/streaming/internal/websocket_types.dart
+++ b/lib/src/streaming/internal/websocket_types.dart
@@ -1,0 +1,72 @@
+/// Options used when opening a Streaming API WebSocket.
+class WebSocketConnectOptions {
+  /// Creates WebSocket connection options.
+  const WebSocketConnectOptions({
+    required this.uri,
+    this.protocols = const [],
+    this.headers = const {},
+    this.pingInterval,
+    this.connectTimeout,
+  });
+
+  /// WebSocket endpoint.
+  final Uri uri;
+
+  /// Requested WebSocket subprotocols.
+  final List<String> protocols;
+
+  /// HTTP headers sent during the WebSocket handshake.
+  final Map<String, String> headers;
+
+  /// Interval used for transport-level ping frames.
+  final Duration? pingInterval;
+
+  /// Maximum time allowed for the WebSocket handshake.
+  final Duration? connectTimeout;
+}
+
+/// A minimal WebSocket connection used by the streaming transport.
+abstract interface class WebSocketConnection {
+  /// Messages and transport errors received from the server.
+  Stream<Object?> get messages;
+
+  /// Close code received from the server, when available.
+  int? get closeCode;
+
+  /// Close reason received from the server, when available.
+  String? get closeReason;
+
+  /// Sends a text frame.
+  void sendText(String data);
+
+  /// Starts closing the WebSocket.
+  Future<void> close([int? closeCode, String? closeReason]);
+}
+
+/// Opens a WebSocket connection.
+abstract interface class WebSocketConnector {
+  /// Connects using [options] and completes after the handshake succeeds.
+  Future<WebSocketConnection> connect(WebSocketConnectOptions options);
+}
+
+/// A transport-level WebSocket connection failure.
+class WebSocketConnectorException implements Exception {
+  /// Creates a connector failure.
+  const WebSocketConnectorException({
+    required this.message,
+    this.statusCode,
+    this.cause,
+  });
+
+  /// Human-readable description that must not contain credentials.
+  final String message;
+
+  /// HTTP status returned by the WebSocket handshake, when available.
+  final int? statusCode;
+
+  /// Original transport error.
+  final Object? cause;
+
+  @override
+  String toString() => 'WebSocketConnectorException: $message';
+}

--- a/lib/src/streaming/mastodon_streaming.dart
+++ b/lib/src/streaming/mastodon_streaming.dart
@@ -1,22 +1,36 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:math';
 
 import '../exception/mastodon_exception.dart';
 import '../logging/logger.dart';
 import '../models/mastodon_instance.dart';
 import '../models/mastodon_instance_v1.dart';
+import 'internal/streaming_event_decoder.dart';
 import 'streaming_config.dart';
 import 'streaming_connection_state.dart';
+import 'streaming_event.dart';
+import 'streaming_message.dart';
+import 'streaming_stream.dart';
+import 'streaming_subscription.dart';
 import 'streaming_url_resolver.dart';
 import 'websocket_connector.dart';
 
 /// Called immediately after an automatic streaming reconnection succeeds.
 typedef MastodonStreamingReconnectCallback = FutureOr<void> Function();
 
+/// Resolves instance metadata used to discover the streaming endpoint.
+typedef MastodonStreamingMetadataProvider =
+    Future<({MastodonInstance? instance, MastodonInstanceV1? instanceV1})>
+    Function();
+
 /// Maintains a WebSocket connection to the Mastodon Streaming API.
 ///
-/// This transport exposes raw text frames. Subscription management and event
-/// decoding are layered on top of it by the higher-level streaming API.
+/// A single connection multiplexes every active subscription.
+///
+/// Events produced while the socket is disconnected are not replayed after
+/// reconnection. Applications are responsible for filling gaps through REST
+/// endpoints using `since_id` or `min_id`.
 class MastodonStreaming {
   /// Creates a Mastodon Streaming API transport.
   factory MastodonStreaming({
@@ -26,6 +40,7 @@ class MastodonStreaming {
     Logger? logger,
     bool enableLog = false,
     MastodonStreamingReconnectCallback? onReconnect,
+    MastodonStreamingMetadataProvider? metadataProvider,
   }) => MastodonStreaming.withConnector(
     baseUrl: baseUrl,
     accessToken: accessToken,
@@ -34,6 +49,7 @@ class MastodonStreaming {
     logger: logger,
     enableLog: enableLog,
     onReconnect: onReconnect,
+    metadataProvider: metadataProvider,
   );
 
   /// Creates a transport with an injectable WebSocket connector.
@@ -48,7 +64,9 @@ class MastodonStreaming {
     Logger? logger,
     bool enableLog = false,
     this.onReconnect,
+    MastodonStreamingMetadataProvider? metadataProvider,
     Future<void> Function(Duration duration)? delay,
+    Future<void> Function(Duration duration)? subscriptionDelay,
     double Function()? jitterSource,
     StreamingUrlResolver urlResolver = const StreamingUrlResolver(),
   }) : _baseUrl = baseUrl,
@@ -57,7 +75,9 @@ class MastodonStreaming {
        config = config ?? MastodonStreamingConfig(),
        _logger = logger ?? const StdoutLogger(),
        _enableLog = enableLog,
+       _metadataProvider = metadataProvider,
        _delay = delay ?? Future<void>.delayed,
+       _subscriptionDelay = subscriptionDelay ?? Future<void>.delayed,
        _jitterSource = jitterSource ?? Random().nextDouble,
        _urlResolver = urlResolver;
 
@@ -66,7 +86,9 @@ class MastodonStreaming {
   final WebSocketConnector _connector;
   final Logger _logger;
   final bool _enableLog;
+  final MastodonStreamingMetadataProvider? _metadataProvider;
   final Future<void> Function(Duration duration) _delay;
+  final Future<void> Function(Duration duration) _subscriptionDelay;
   final double Function() _jitterSource;
   final StreamingUrlResolver _urlResolver;
 
@@ -85,6 +107,9 @@ class MastodonStreaming {
       StreamController<MastodonStreamingException>.broadcast();
   final StreamController<String> _frameController =
       StreamController<String>.broadcast();
+  final StreamController<MastodonStreamingMessage> _messageController =
+      StreamController<MastodonStreamingMessage>.broadcast();
+  final Map<String, _SubscriptionEntry> _subscriptions = {};
 
   MastodonStreamingConnectionState _state =
       MastodonStreamingConnectionState.disconnected;
@@ -99,6 +124,8 @@ class MastodonStreaming {
   bool _isSuspended = false;
   bool _isDisposed = false;
   bool _reconnectScheduled = false;
+  Future<void> _subscriptionQueue = Future<void>.value();
+  _PendingSubscriptionOperation? _pendingSubscriptionOperation;
 
   /// Current connection state.
   MastodonStreamingConnectionState get state => _state;
@@ -112,6 +139,9 @@ class MastodonStreaming {
 
   /// Raw text frames received from the server.
   Stream<String> get rawFrames => _frameController.stream;
+
+  /// Decoded raw message envelopes from all subscribed channels.
+  Stream<MastodonStreamingMessage> get messages => _messageController.stream;
 
   /// Authentication mode that most recently connected successfully.
   MastodonStreamingAuthMode? get successfulAuthMode => _successfulAuthMode;
@@ -144,7 +174,79 @@ class MastodonStreaming {
     _wantsConnection = true;
     _reconnectAttempts = 0;
     _reconnectScheduled = false;
+    if (instance == null && instanceV1 == null && _metadataProvider != null) {
+      return _resolveMetadataAndConnect();
+    }
     return _beginConnection(reconnecting: false, automaticAttempt: false);
+  }
+
+  Future<void> _resolveMetadataAndConnect() {
+    final generation = ++_generation;
+    _setState(MastodonStreamingConnectionState.connecting);
+    late final Future<void> future;
+    future = _loadMetadataAndConnect(generation).whenComplete(() {
+      if (identical(_connectFuture, future)) {
+        _connectFuture = null;
+      }
+    });
+    _connectFuture = future;
+    return future;
+  }
+
+  Future<void> _loadMetadataAndConnect(int generation) async {
+    try {
+      final metadata = await _metadataProvider!.call();
+      if (!_isCurrentIntent(generation)) {
+        return;
+      }
+      _instance = metadata.instance;
+      _instanceV1 = metadata.instanceV1;
+    } on Object {
+      if (!_isCurrentIntent(generation)) {
+        return;
+      }
+      _logWarn(
+        'Could not discover the Streaming API endpoint; using the REST host',
+      );
+    }
+    if (_isCurrentIntent(generation)) {
+      await _beginConnection(reconnecting: false, automaticAttempt: false);
+    }
+  }
+
+  /// Subscribes to an official Mastodon Streaming API channel.
+  ///
+  /// Repeated subscriptions with the same normalized key share one server
+  /// subscription. Each returned handle receives the routed messages until
+  /// its own [MastodonStreamingSubscription.cancel] method is called.
+  Future<MastodonStreamingSubscription> subscribe(MastodonStream stream) =>
+      _subscribeTarget(
+        _SubscriptionTarget(
+          name: stream.name,
+          params: stream.params,
+          key: stream.key,
+        ),
+      );
+
+  /// Subscribes to an unknown or server-specific streaming channel.
+  Future<MastodonStreamingSubscription> subscribeRaw(
+    String streamName, {
+    Map<String, String> params = const {},
+  }) {
+    final trimmedName = streamName.trim();
+    if (trimmedName.isEmpty) {
+      throw const MastodonStreamingSubscriptionException(
+        message: 'Streaming channel name must not be empty',
+      );
+    }
+    return _subscribeTarget(
+      _SubscriptionTarget(
+        name: trimmedName,
+        params: params,
+        key: _rawSubscriptionKey(trimmedName, params),
+        isRaw: true,
+      ),
+    );
   }
 
   /// Sends one text frame on the active WebSocket.
@@ -214,9 +316,12 @@ class MastodonStreaming {
     _connectFuture = null;
     final connection = _takeConnection();
     _setState(MastodonStreamingConnectionState.disposed);
+    final subscriptionHandles = _takeSubscriptionHandles();
     try {
       await _releaseConnection(connection);
     } finally {
+      await Future.wait(subscriptionHandles.map((handle) => handle.close()));
+      await _messageController.close();
       await _frameController.close();
       await _errorController.close();
       await _stateController.close();
@@ -282,6 +387,7 @@ class MastodonStreaming {
       _reconnectAttempts = 0;
       _setState(MastodonStreamingConnectionState.connected);
       _logInfo('Connected to Mastodon Streaming API');
+      await _restoreSubscriptions();
 
       if (reconnecting) {
         try {
@@ -385,12 +491,295 @@ class MastodonStreaming {
     ),
   };
 
+  Future<MastodonStreamingSubscription> _subscribeTarget(
+    _SubscriptionTarget target,
+  ) async {
+    _ensureNotDisposed();
+    var entry = _subscriptions[target.key];
+    final isNewEntry = entry == null;
+    entry ??= _SubscriptionEntry(target);
+    _subscriptions[target.key] = entry;
+
+    final handle = _createSubscriptionHandle(entry);
+    entry.handles.add(handle);
+
+    final existingSend = entry.initialSendFuture;
+    if (!isNewEntry) {
+      if (existingSend != null) {
+        await existingSend;
+      }
+      return handle.subscription;
+    }
+    if (!isConnected) {
+      return handle.subscription;
+    }
+
+    final send = _sendSubscriptionOperation('subscribe', target);
+    entry.initialSendFuture = send;
+    try {
+      await send;
+      return handle.subscription;
+    } on MastodonStreamingSubscriptionException catch (error) {
+      if (identical(_subscriptions[target.key], entry)) {
+        _subscriptions.remove(target.key);
+      }
+      final handles = List<_SubscriptionHandle>.of(entry.handles);
+      entry.handles.clear();
+      await Future.wait(handles.map((item) => item.close()));
+      _emitError(error);
+      rethrow;
+    } finally {
+      if (identical(entry.initialSendFuture, send)) {
+        entry.initialSendFuture = null;
+      }
+    }
+  }
+
+  _SubscriptionHandle _createSubscriptionHandle(_SubscriptionEntry entry) {
+    late final _SubscriptionHandle handle;
+    handle = _SubscriptionHandle(
+      target: entry.target,
+      onCancel: () => _cancelSubscriptionHandle(entry, handle),
+      onIsActive: () => entry.handles.contains(handle),
+    );
+    return handle;
+  }
+
+  Future<void> _cancelSubscriptionHandle(
+    _SubscriptionEntry entry,
+    _SubscriptionHandle handle,
+  ) async {
+    if (!entry.handles.remove(handle)) {
+      return;
+    }
+    await handle.close();
+    if (entry.handles.isNotEmpty) {
+      return;
+    }
+
+    if (identical(_subscriptions[entry.target.key], entry)) {
+      _subscriptions.remove(entry.target.key);
+    }
+    if (!isConnected) {
+      return;
+    }
+    try {
+      await _sendSubscriptionOperation('unsubscribe', entry.target);
+    } on MastodonStreamingSubscriptionException catch (error) {
+      _emitError(error);
+      rethrow;
+    }
+  }
+
+  Future<void> _restoreSubscriptions() async {
+    for (final entry in List<_SubscriptionEntry>.of(_subscriptions.values)) {
+      if (!identical(_subscriptions[entry.target.key], entry) ||
+          entry.handles.isEmpty) {
+        continue;
+      }
+      try {
+        await _sendSubscriptionOperation('subscribe', entry.target);
+      } on MastodonStreamingSubscriptionException catch (error) {
+        _emitError(error);
+      }
+    }
+  }
+
+  Future<void> _sendSubscriptionOperation(
+    String type,
+    _SubscriptionTarget target,
+  ) {
+    final operation = _subscriptionQueue.then(
+      (_) => _performSubscriptionOperation(type, target),
+    );
+    _subscriptionQueue = operation.catchError((Object _) {});
+    return operation;
+  }
+
+  Future<void> _performSubscriptionOperation(
+    String type,
+    _SubscriptionTarget target,
+  ) async {
+    if (!isConnected) {
+      return;
+    }
+
+    final pending = _PendingSubscriptionOperation(type: type, target: target);
+    _pendingSubscriptionOperation = pending;
+    try {
+      try {
+        sendText(
+          jsonEncode({'type': type, 'stream': target.name, ...target.params}),
+        );
+      } catch (error) {
+        throw MastodonStreamingSubscriptionException(
+          message: 'Could not send Streaming $type request',
+          raw: error,
+        );
+      }
+
+      final error = await Future.any<MastodonStreamingSubscriptionException?>([
+        _subscriptionDelay(
+          config.subscriptionErrorWindow,
+        ).then<MastodonStreamingSubscriptionException?>((_) => null),
+        pending.error.future,
+      ]);
+      if (error != null) {
+        throw error;
+      }
+    } finally {
+      if (identical(_pendingSubscriptionOperation, pending)) {
+        _pendingSubscriptionOperation = null;
+      }
+    }
+  }
+
+  void _handleProtocolFrame(String raw) {
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is Map<String, dynamic> && decoded['error'] is String) {
+        _handleSubscriptionError(decoded);
+        return;
+      }
+
+      final message = MastodonStreamingMessage.fromRaw(raw);
+      _messageController.add(message);
+      _routeMessage(message, decodeMastodonStreamEvent(message));
+    } on Object {
+      _routeMalformedEnvelope(raw);
+    }
+  }
+
+  void _routeMalformedEnvelope(String raw) {
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map<String, dynamic>) {
+        return;
+      }
+      final streamValue = decoded['stream'];
+      final eventValue = decoded['event'];
+      if (streamValue is! List<dynamic> ||
+          streamValue.isEmpty ||
+          streamValue.length > 2 ||
+          streamValue.any((value) => value is! String) ||
+          eventValue is! String ||
+          eventValue.isEmpty) {
+        return;
+      }
+      final payloadValue = decoded['payload'];
+      final rawPayload = payloadValue == null
+          ? null
+          : payloadValue is String
+          ? payloadValue
+          : jsonEncode(payloadValue);
+      final message = MastodonStreamingMessage(
+        stream: streamValue.cast<String>(),
+        event: eventValue,
+        payload: rawPayload,
+        raw: raw,
+      );
+      final event = MastodonUnknownStreamEvent(
+        stream: message.stream,
+        event: message.event,
+        rawPayload: message.payload,
+      );
+      _messageController.add(message);
+      _routeMessage(message, event);
+    } on Object {
+      // ストリームを特定できない不正フレームは次のフレームを待つ。
+    }
+  }
+
+  void _handleSubscriptionError(Map<String, dynamic> decoded) {
+    final pending = _pendingSubscriptionOperation;
+    final error = MastodonStreamingSubscriptionException(
+      message: decoded['error'] as String,
+      status: decoded['status'] is int ? decoded['status'] as int : null,
+      raw: pending == null
+          ? decoded
+          : {
+              ...decoded,
+              'operation': pending.type,
+              'stream': pending.target.name,
+            },
+    );
+    if (pending != null && !pending.error.isCompleted) {
+      pending.error.complete(error);
+    } else {
+      _emitError(error);
+    }
+  }
+
+  void _routeMessage(
+    MastodonStreamingMessage message,
+    MastodonStreamEvent event,
+  ) {
+    for (final entry in List<_SubscriptionEntry>.of(_subscriptions.values)) {
+      if (!_matchesStream(entry.target, message.stream)) {
+        continue;
+      }
+      for (final handle in List<_SubscriptionHandle>.of(entry.handles)) {
+        handle.add(message, event);
+      }
+    }
+  }
+
+  bool _matchesStream(_SubscriptionTarget target, List<String> stream) {
+    if (stream.isEmpty || stream.first != target.name) {
+      return false;
+    }
+    if (target.isRaw && target.params.isEmpty) {
+      return true;
+    }
+    final tag = target.params['tag'];
+    if (tag != null) {
+      return stream.length == 2 && stream[1].toLowerCase() == tag.toLowerCase();
+    }
+    final list = target.params['list'];
+    if (list != null) {
+      return stream.length == 2 && stream[1] == list;
+    }
+    return stream.length == 1;
+  }
+
+  static String _rawSubscriptionKey(
+    String streamName,
+    Map<String, String> params,
+  ) {
+    final tag = params['tag'];
+    if (tag != null) {
+      return '$streamName:${tag.toLowerCase()}';
+    }
+    final list = params['list'];
+    if (list != null) {
+      return '$streamName:$list';
+    }
+    if (params.isEmpty) {
+      return streamName;
+    }
+    final entries = params.entries.toList()
+      ..sort((left, right) => left.key.compareTo(right.key));
+    return '$streamName?${entries.map((entry) => '${entry.key}=${entry.value}').join('&')}';
+  }
+
+  List<_SubscriptionHandle> _takeSubscriptionHandles() {
+    final handles = [
+      for (final entry in _subscriptions.values) ...entry.handles,
+    ];
+    for (final entry in _subscriptions.values) {
+      entry.handles.clear();
+    }
+    _subscriptions.clear();
+    return handles;
+  }
+
   void _handleFrame(_ActiveConnection connection, Object? data) {
     if (!_isCurrentConnection(connection) || connection.terminationHandled) {
       return;
     }
     if (data is String) {
       _frameController.add(data);
+      _handleProtocolFrame(data);
       return;
     }
 
@@ -646,4 +1035,73 @@ final class _ActiveConnection {
   final WebSocketConnection socket;
   StreamSubscription<Object?>? subscription;
   bool terminationHandled = false;
+}
+
+final class _SubscriptionTarget {
+  _SubscriptionTarget({
+    required this.name,
+    required Map<String, String> params,
+    required this.key,
+    this.isRaw = false,
+  }) : params = Map.unmodifiable(params);
+
+  final String name;
+  final Map<String, String> params;
+  final String key;
+  final bool isRaw;
+}
+
+final class _SubscriptionEntry {
+  _SubscriptionEntry(this.target);
+
+  final _SubscriptionTarget target;
+  final Set<_SubscriptionHandle> handles = {};
+  Future<void>? initialSendFuture;
+}
+
+final class _SubscriptionHandle {
+  _SubscriptionHandle({
+    required this.target,
+    required Future<void> Function() onCancel,
+    required bool Function() onIsActive,
+  }) {
+    subscription = MastodonStreamingSubscription.managed(
+      streamName: target.name,
+      params: target.params,
+      messages: _messageController.stream,
+      events: _eventController.stream,
+      onCancel: onCancel,
+      onIsActive: onIsActive,
+    );
+  }
+
+  final _SubscriptionTarget target;
+  final StreamController<MastodonStreamingMessage> _messageController =
+      StreamController<MastodonStreamingMessage>.broadcast();
+  final StreamController<MastodonStreamEvent> _eventController =
+      StreamController<MastodonStreamEvent>.broadcast();
+  late final MastodonStreamingSubscription subscription;
+  Future<void>? _closeFuture;
+
+  void add(MastodonStreamingMessage message, MastodonStreamEvent event) {
+    if (_messageController.isClosed || _eventController.isClosed) {
+      return;
+    }
+    _messageController.add(message);
+    _eventController.add(event);
+  }
+
+  Future<void> close() => _closeFuture ??= Future.wait<void>([
+    _messageController.close(),
+    _eventController.close(),
+  ]);
+}
+
+final class _PendingSubscriptionOperation {
+  _PendingSubscriptionOperation({required this.type, required this.target});
+
+  final String type;
+  final _SubscriptionTarget target;
+  final Completer<MastodonStreamingSubscriptionException?> error =
+      Completer<MastodonStreamingSubscriptionException?>();
 }

--- a/lib/src/streaming/mastodon_streaming.dart
+++ b/lib/src/streaming/mastodon_streaming.dart
@@ -24,6 +24,9 @@ typedef MastodonStreamingMetadataProvider =
     Future<({MastodonInstance? instance, MastodonInstanceV1? instanceV1})>
     Function();
 
+/// Verifies whether the access token used by the streaming connection is valid.
+typedef MastodonStreamingTokenValidator = Future<bool> Function();
+
 /// Maintains a WebSocket connection to the Mastodon Streaming API.
 ///
 /// A single connection multiplexes every active subscription.
@@ -41,6 +44,7 @@ class MastodonStreaming {
     bool enableLog = false,
     MastodonStreamingReconnectCallback? onReconnect,
     MastodonStreamingMetadataProvider? metadataProvider,
+    MastodonStreamingTokenValidator? tokenValidator,
   }) => MastodonStreaming.withConnector(
     baseUrl: baseUrl,
     accessToken: accessToken,
@@ -50,6 +54,7 @@ class MastodonStreaming {
     enableLog: enableLog,
     onReconnect: onReconnect,
     metadataProvider: metadataProvider,
+    tokenValidator: tokenValidator,
   );
 
   /// Creates a transport with an injectable WebSocket connector.
@@ -65,6 +70,7 @@ class MastodonStreaming {
     bool enableLog = false,
     this.onReconnect,
     MastodonStreamingMetadataProvider? metadataProvider,
+    MastodonStreamingTokenValidator? tokenValidator,
     Future<void> Function(Duration duration)? delay,
     Future<void> Function(Duration duration)? subscriptionDelay,
     double Function()? jitterSource,
@@ -76,6 +82,7 @@ class MastodonStreaming {
        _logger = logger ?? const StdoutLogger(),
        _enableLog = enableLog,
        _metadataProvider = metadataProvider,
+       _tokenValidator = tokenValidator,
        _delay = delay ?? Future<void>.delayed,
        _subscriptionDelay = subscriptionDelay ?? Future<void>.delayed,
        _jitterSource = jitterSource ?? Random().nextDouble,
@@ -87,6 +94,7 @@ class MastodonStreaming {
   final Logger _logger;
   final bool _enableLog;
   final MastodonStreamingMetadataProvider? _metadataProvider;
+  final MastodonStreamingTokenValidator? _tokenValidator;
   final Future<void> Function(Duration duration) _delay;
   final Future<void> Function(Duration duration) _subscriptionDelay;
   final double Function() _jitterSource;
@@ -126,6 +134,8 @@ class MastodonStreaming {
   bool _reconnectScheduled = false;
   Future<void> _subscriptionQueue = Future<void>.value();
   _PendingSubscriptionOperation? _pendingSubscriptionOperation;
+  int _activeSubscriptionCalls = 0;
+  Completer<void>? _subscriptionCallsDrained;
 
   /// Current connection state.
   MastodonStreamingConnectionState get state => _state;
@@ -243,7 +253,7 @@ class MastodonStreaming {
       _SubscriptionTarget(
         name: trimmedName,
         params: params,
-        key: _rawSubscriptionKey(trimmedName, params),
+        key: MastodonStream.keyFor(trimmedName, params),
         isRaw: true,
       ),
     );
@@ -317,8 +327,11 @@ class MastodonStreaming {
     final connection = _takeConnection();
     _setState(MastodonStreamingConnectionState.disposed);
     final subscriptionHandles = _takeSubscriptionHandles();
+    _pendingSubscriptionOperation?.interrupt();
     try {
       await _releaseConnection(connection);
+      await _subscriptionQueue;
+      await _waitForSubscriptionCalls();
     } finally {
       await Future.wait(subscriptionHandles.map((handle) => handle.close()));
       await _messageController.close();
@@ -495,6 +508,23 @@ class MastodonStreaming {
     _SubscriptionTarget target,
   ) async {
     _ensureNotDisposed();
+    _activeSubscriptionCalls++;
+    try {
+      return await _performSubscribeTarget(target);
+    } finally {
+      _activeSubscriptionCalls--;
+      if (_activeSubscriptionCalls == 0) {
+        _subscriptionCallsDrained?.complete();
+        _subscriptionCallsDrained = null;
+      }
+    }
+  }
+
+  Future<MastodonStreamingSubscription> _performSubscribeTarget(
+    _SubscriptionTarget target,
+  ) async {
+    final generation = _generation;
+    final connection = _connection;
     var entry = _subscriptions[target.key];
     final isNewEntry = entry == null;
     entry ??= _SubscriptionEntry(target);
@@ -506,7 +536,13 @@ class MastodonStreaming {
     final existingSend = entry.initialSendFuture;
     if (!isNewEntry) {
       if (existingSend != null) {
-        await existingSend;
+        try {
+          await existingSend;
+          _ensureSubscriptionCallIsCurrent(generation, connection);
+        } on StateError {
+          await _discardSubscriptionEntry(entry);
+          rethrow;
+        }
       }
       return handle.subscription;
     }
@@ -518,14 +554,13 @@ class MastodonStreaming {
     entry.initialSendFuture = send;
     try {
       await send;
+      _ensureSubscriptionCallIsCurrent(generation, connection);
       return handle.subscription;
+    } on StateError {
+      await _discardSubscriptionEntry(entry);
+      rethrow;
     } on MastodonStreamingSubscriptionException catch (error) {
-      if (identical(_subscriptions[target.key], entry)) {
-        _subscriptions.remove(target.key);
-      }
-      final handles = List<_SubscriptionHandle>.of(entry.handles);
-      entry.handles.clear();
-      await Future.wait(handles.map((item) => item.close()));
+      await _discardSubscriptionEntry(entry);
       _emitError(error);
       rethrow;
     } finally {
@@ -533,6 +568,36 @@ class MastodonStreaming {
         entry.initialSendFuture = null;
       }
     }
+  }
+
+  void _ensureSubscriptionCallIsCurrent(
+    int generation,
+    _ActiveConnection? connection,
+  ) {
+    _ensureNotDisposed();
+    if (_generation != generation ||
+        !isConnected ||
+        !identical(_connection, connection)) {
+      throw StateError(
+        'MastodonStreaming connection changed during subscription',
+      );
+    }
+  }
+
+  Future<void> _discardSubscriptionEntry(_SubscriptionEntry entry) async {
+    if (identical(_subscriptions[entry.target.key], entry)) {
+      _subscriptions.remove(entry.target.key);
+    }
+    final handles = List<_SubscriptionHandle>.of(entry.handles);
+    entry.handles.clear();
+    await Future.wait(handles.map((item) => item.close()));
+  }
+
+  Future<void> _waitForSubscriptionCalls() {
+    if (_activeSubscriptionCalls == 0) {
+      return Future<void>.value();
+    }
+    return (_subscriptionCallsDrained ??= Completer<void>()).future;
   }
 
   _SubscriptionHandle _createSubscriptionHandle(_SubscriptionEntry entry) {
@@ -623,6 +688,7 @@ class MastodonStreaming {
           config.subscriptionErrorWindow,
         ).then<MastodonStreamingSubscriptionException?>((_) => null),
         pending.error.future,
+        pending.interrupted.future.then((_) => null),
       ]);
       if (error != null) {
         throw error;
@@ -742,26 +808,6 @@ class MastodonStreaming {
     return stream.length == 1;
   }
 
-  static String _rawSubscriptionKey(
-    String streamName,
-    Map<String, String> params,
-  ) {
-    final tag = params['tag'];
-    if (tag != null) {
-      return '$streamName:${tag.toLowerCase()}';
-    }
-    final list = params['list'];
-    if (list != null) {
-      return '$streamName:$list';
-    }
-    if (params.isEmpty) {
-      return streamName;
-    }
-    final entries = params.entries.toList()
-      ..sort((left, right) => left.key.compareTo(right.key));
-    return '$streamName?${entries.map((entry) => '${entry.key}=${entry.value}').join('&')}';
-  }
-
   List<_SubscriptionHandle> _takeSubscriptionHandles() {
     final handles = [
       for (final entry in _subscriptions.values) ...entry.handles,
@@ -826,8 +872,62 @@ class MastodonStreaming {
       closeReason: connection.socket.closeReason,
       endpoint: _safeEndpoint,
     );
+    if (code == 1005 && _tokenValidator != null) {
+      connection.terminationHandled = true;
+      _connection = null;
+      _setState(MastodonStreamingConnectionState.disconnected);
+      unawaited(_releaseConnection(connection));
+      unawaited(_validateTokenAfterMissingCloseStatus(connection, exception));
+      return;
+    }
+
     final reconnect = code != 1003 && code != 1005;
     _terminateConnection(connection, exception, reconnect: reconnect);
+  }
+
+  Future<void> _validateTokenAfterMissingCloseStatus(
+    _ActiveConnection connection,
+    MastodonStreamingClosedException exception,
+  ) async {
+    bool isValid;
+    try {
+      isValid = await _tokenValidator!.call();
+    } catch (_) {
+      if (!_isCurrentIntent(connection.generation)) {
+        return;
+      }
+      _wantsConnection = false;
+      _emitError(
+        MastodonStreamingClosedException(
+          closeCode: exception.closeCode,
+          closeReason: exception.closeReason,
+          endpoint: exception.endpoint,
+          message:
+              'Streaming connection closed and access token validation failed',
+        ),
+      );
+      return;
+    }
+
+    if (!_isCurrentIntent(connection.generation)) {
+      return;
+    }
+    if (!isValid) {
+      _wantsConnection = false;
+      _emitError(
+        MastodonStreamingClosedException(
+          closeCode: exception.closeCode,
+          closeReason: exception.closeReason,
+          endpoint: exception.endpoint,
+          message:
+              'Streaming connection closed because the access token is invalid',
+        ),
+      );
+      return;
+    }
+
+    _emitError(exception);
+    _scheduleReconnect();
   }
 
   void _terminateConnection(
@@ -1104,4 +1204,11 @@ final class _PendingSubscriptionOperation {
   final _SubscriptionTarget target;
   final Completer<MastodonStreamingSubscriptionException?> error =
       Completer<MastodonStreamingSubscriptionException?>();
+  final Completer<void> interrupted = Completer<void>();
+
+  void interrupt() {
+    if (!interrupted.isCompleted) {
+      interrupted.complete();
+    }
+  }
 }

--- a/lib/src/streaming/mastodon_streaming.dart
+++ b/lib/src/streaming/mastodon_streaming.dart
@@ -1,0 +1,649 @@
+import 'dart:async';
+import 'dart:math';
+
+import '../exception/mastodon_exception.dart';
+import '../logging/logger.dart';
+import '../models/mastodon_instance.dart';
+import '../models/mastodon_instance_v1.dart';
+import 'streaming_config.dart';
+import 'streaming_connection_state.dart';
+import 'streaming_url_resolver.dart';
+import 'websocket_connector.dart';
+
+/// Called immediately after an automatic streaming reconnection succeeds.
+typedef MastodonStreamingReconnectCallback = FutureOr<void> Function();
+
+/// Maintains a WebSocket connection to the Mastodon Streaming API.
+///
+/// This transport exposes raw text frames. Subscription management and event
+/// decoding are layered on top of it by the higher-level streaming API.
+class MastodonStreaming {
+  /// Creates a Mastodon Streaming API transport.
+  factory MastodonStreaming({
+    required String baseUrl,
+    required String accessToken,
+    MastodonStreamingConfig? config,
+    Logger? logger,
+    bool enableLog = false,
+    MastodonStreamingReconnectCallback? onReconnect,
+  }) => MastodonStreaming.withConnector(
+    baseUrl: baseUrl,
+    accessToken: accessToken,
+    connector: createDefaultWebSocketConnector(),
+    config: config,
+    logger: logger,
+    enableLog: enableLog,
+    onReconnect: onReconnect,
+  );
+
+  /// Creates a transport with an injectable WebSocket connector.
+  ///
+  /// Package tests can also inject [delay] and [jitterSource] to observe
+  /// reconnection timing without waiting for wall-clock timers.
+  MastodonStreaming.withConnector({
+    required String baseUrl,
+    required String accessToken,
+    required WebSocketConnector connector,
+    MastodonStreamingConfig? config,
+    Logger? logger,
+    bool enableLog = false,
+    this.onReconnect,
+    Future<void> Function(Duration duration)? delay,
+    double Function()? jitterSource,
+    StreamingUrlResolver urlResolver = const StreamingUrlResolver(),
+  }) : _baseUrl = baseUrl,
+       _accessToken = accessToken,
+       _connector = connector,
+       config = config ?? MastodonStreamingConfig(),
+       _logger = logger ?? const StdoutLogger(),
+       _enableLog = enableLog,
+       _delay = delay ?? Future<void>.delayed,
+       _jitterSource = jitterSource ?? Random().nextDouble,
+       _urlResolver = urlResolver;
+
+  final String _baseUrl;
+  final String _accessToken;
+  final WebSocketConnector _connector;
+  final Logger _logger;
+  final bool _enableLog;
+  final Future<void> Function(Duration duration) _delay;
+  final double Function() _jitterSource;
+  final StreamingUrlResolver _urlResolver;
+
+  /// Connection and reconnection settings.
+  final MastodonStreamingConfig config;
+
+  /// Hook invoked after an automatic reconnection becomes usable.
+  ///
+  /// A subscription layer can replace this callback and resend every active
+  /// subscription because server-side subscription state is connection-bound.
+  MastodonStreamingReconnectCallback? onReconnect;
+
+  final StreamController<MastodonStreamingConnectionState> _stateController =
+      StreamController<MastodonStreamingConnectionState>.broadcast();
+  final StreamController<MastodonStreamingException> _errorController =
+      StreamController<MastodonStreamingException>.broadcast();
+  final StreamController<String> _frameController =
+      StreamController<String>.broadcast();
+
+  MastodonStreamingConnectionState _state =
+      MastodonStreamingConnectionState.disconnected;
+  MastodonStreamingAuthMode? _successfulAuthMode;
+  MastodonInstance? _instance;
+  MastodonInstanceV1? _instanceV1;
+  _ActiveConnection? _connection;
+  Future<void>? _connectFuture;
+  int _generation = 0;
+  int _reconnectAttempts = 0;
+  bool _wantsConnection = false;
+  bool _isSuspended = false;
+  bool _isDisposed = false;
+  bool _reconnectScheduled = false;
+
+  /// Current connection state.
+  MastodonStreamingConnectionState get state => _state;
+
+  /// State changes that occur after listening.
+  Stream<MastodonStreamingConnectionState> get stateChanges =>
+      _stateController.stream;
+
+  /// Connection and closure errors.
+  Stream<MastodonStreamingException> get errors => _errorController.stream;
+
+  /// Raw text frames received from the server.
+  Stream<String> get rawFrames => _frameController.stream;
+
+  /// Authentication mode that most recently connected successfully.
+  MastodonStreamingAuthMode? get successfulAuthMode => _successfulAuthMode;
+
+  /// Whether the WebSocket is open and ready to send text frames.
+  bool get isConnected => _state == MastodonStreamingConnectionState.connected;
+
+  /// Establishes a WebSocket connection.
+  ///
+  /// The optional instance metadata is used by [StreamingUrlResolver]. A failed
+  /// explicit connection is reported to the caller and is not auto-retried.
+  Future<void> connect({
+    MastodonInstance? instance,
+    MastodonInstanceV1? instanceV1,
+  }) {
+    _ensureNotDisposed();
+    if (isConnected) {
+      return Future<void>.value();
+    }
+    final current = _connectFuture;
+    if (current != null &&
+        (_state == MastodonStreamingConnectionState.connecting ||
+            _state == MastodonStreamingConnectionState.reconnecting)) {
+      return current;
+    }
+
+    _instance = instance;
+    _instanceV1 = instanceV1;
+    _isSuspended = false;
+    _wantsConnection = true;
+    _reconnectAttempts = 0;
+    _reconnectScheduled = false;
+    return _beginConnection(reconnecting: false, automaticAttempt: false);
+  }
+
+  /// Sends one text frame on the active WebSocket.
+  void sendText(String frame) {
+    _ensureNotDisposed();
+    final connection = _connection;
+    if (!isConnected || connection == null) {
+      throw StateError('MastodonStreaming is not connected');
+    }
+    connection.socket.sendText(frame);
+  }
+
+  /// Stops the connection until [connect] is called again.
+  Future<void> disconnect() async {
+    if (_isDisposed) {
+      return;
+    }
+    _wantsConnection = false;
+    _isSuspended = false;
+    _reconnectScheduled = false;
+    _generation++;
+    _connectFuture = null;
+    final connection = _takeConnection();
+    _setState(MastodonStreamingConnectionState.disconnected);
+    await _releaseConnection(connection);
+  }
+
+  /// Pauses the socket while preserving the intent to reconnect on [resume].
+  Future<void> suspend() async {
+    _ensureNotDisposed();
+    if (_isSuspended) {
+      return;
+    }
+    _isSuspended = true;
+    _reconnectScheduled = false;
+    _generation++;
+    _connectFuture = null;
+    final connection = _takeConnection();
+    _setState(MastodonStreamingConnectionState.suspended);
+    await _releaseConnection(connection);
+  }
+
+  /// Restores a socket that was paused by [suspend].
+  Future<void> resume() {
+    _ensureNotDisposed();
+    if (!_isSuspended) {
+      return Future<void>.value();
+    }
+    _isSuspended = false;
+    if (!_wantsConnection) {
+      _setState(MastodonStreamingConnectionState.disconnected);
+      return Future<void>.value();
+    }
+    return _beginConnection(reconnecting: true, automaticAttempt: true);
+  }
+
+  /// Permanently releases the socket and stream controllers.
+  Future<void> dispose() async {
+    if (_isDisposed) {
+      return;
+    }
+    _isDisposed = true;
+    _wantsConnection = false;
+    _isSuspended = false;
+    _reconnectScheduled = false;
+    _generation++;
+    _connectFuture = null;
+    final connection = _takeConnection();
+    _setState(MastodonStreamingConnectionState.disposed);
+    try {
+      await _releaseConnection(connection);
+    } finally {
+      await _frameController.close();
+      await _errorController.close();
+      await _stateController.close();
+    }
+  }
+
+  Future<void> _beginConnection({
+    required bool reconnecting,
+    required bool automaticAttempt,
+  }) {
+    final generation = ++_generation;
+    _setState(
+      reconnecting
+          ? MastodonStreamingConnectionState.reconnecting
+          : MastodonStreamingConnectionState.connecting,
+    );
+    late final Future<void> future;
+    future =
+        _openConnection(
+          generation,
+          reconnecting: reconnecting,
+          automaticAttempt: automaticAttempt,
+        ).whenComplete(() {
+          if (identical(_connectFuture, future)) {
+            _connectFuture = null;
+          }
+        });
+    _connectFuture = future;
+    return future;
+  }
+
+  Future<void> _openConnection(
+    int generation, {
+    required bool reconnecting,
+    required bool automaticAttempt,
+  }) async {
+    final endpoint = _urlResolver.resolve(
+      baseUrl: _baseUrl,
+      instance: _instance,
+      instanceV1: _instanceV1,
+    );
+    try {
+      final result = await _connectWithFallback(endpoint);
+      if (!_isCurrentIntent(generation)) {
+        await result.connection.close(1000, 'Connection superseded');
+        return;
+      }
+
+      final active = _ActiveConnection(
+        generation: generation,
+        socket: result.connection,
+      );
+      _connection = active;
+      active.subscription = result.connection.messages.listen(
+        (data) => _handleFrame(active, data),
+        onError: (Object error, StackTrace stackTrace) {
+          _handleSocketError(active, error, stackTrace);
+        },
+        onDone: () => _handleSocketDone(active),
+        cancelOnError: false,
+      );
+      _successfulAuthMode = result.authMode;
+      _reconnectAttempts = 0;
+      _setState(MastodonStreamingConnectionState.connected);
+      _logInfo('Connected to Mastodon Streaming API');
+
+      if (reconnecting) {
+        try {
+          await onReconnect?.call();
+        } catch (error) {
+          _emitError(
+            MastodonStreamingConnectionException(
+              message: 'Streaming reconnect hook failed',
+              endpoint: _safeUri(endpoint).toString(),
+              raw: error,
+            ),
+          );
+        }
+      }
+    } catch (error) {
+      if (!_isCurrentIntent(generation)) {
+        return;
+      }
+      final exception = _toConnectionException(error, endpoint);
+      _setState(MastodonStreamingConnectionState.disconnected);
+      _emitError(exception);
+
+      if (exception.statusCode == 401) {
+        _wantsConnection = false;
+        throw exception;
+      }
+      if (automaticAttempt) {
+        _scheduleReconnect();
+      } else {
+        _wantsConnection = false;
+      }
+      throw exception;
+    }
+  }
+
+  Future<_ConnectionResult> _connectWithFallback(Uri endpoint) async {
+    Object? lastError;
+    for (final mode in _authenticationOrder()) {
+      final options = _connectOptions(endpoint, mode);
+      _logInfo(
+        'Connecting to Mastodon Streaming API at '
+        '${_safeUri(options.uri)} using ${mode.name} authentication',
+      );
+      try {
+        final connection = await _connector.connect(options);
+        return _ConnectionResult(connection: connection, authMode: mode);
+      } on WebSocketConnectorException catch (error) {
+        lastError = error;
+        if (error.statusCode == 401) {
+          rethrow;
+        }
+        _logWarn('Mastodon Streaming API ${mode.name} authentication failed');
+      } catch (error) {
+        lastError = error;
+        _logWarn('Mastodon Streaming API ${mode.name} authentication failed');
+      }
+    }
+    throw WebSocketConnectorException(
+      message: 'All Streaming API authentication modes failed',
+      cause: lastError,
+    );
+  }
+
+  List<MastodonStreamingAuthMode> _authenticationOrder() {
+    final preferred = _successfulAuthMode ?? config.authMode;
+    if (!config.enableAuthFallback) {
+      return [preferred];
+    }
+    return [
+      preferred,
+      for (final mode in MastodonStreamingAuthMode.values)
+        if (mode != preferred) mode,
+    ];
+  }
+
+  WebSocketConnectOptions _connectOptions(
+    Uri endpoint,
+    MastodonStreamingAuthMode mode,
+  ) => switch (mode) {
+    MastodonStreamingAuthMode.subprotocol => WebSocketConnectOptions(
+      uri: endpoint,
+      protocols: [_accessToken],
+      pingInterval: config.pingInterval,
+      connectTimeout: config.connectTimeout,
+    ),
+    MastodonStreamingAuthMode.header => WebSocketConnectOptions(
+      uri: endpoint,
+      headers: {'Authorization': 'Bearer $_accessToken'},
+      pingInterval: config.pingInterval,
+      connectTimeout: config.connectTimeout,
+    ),
+    MastodonStreamingAuthMode.queryParameter => WebSocketConnectOptions(
+      uri: endpoint.replace(
+        queryParameters: {
+          ...endpoint.queryParameters,
+          'access_token': _accessToken,
+        },
+      ),
+      pingInterval: config.pingInterval,
+      connectTimeout: config.connectTimeout,
+    ),
+  };
+
+  void _handleFrame(_ActiveConnection connection, Object? data) {
+    if (!_isCurrentConnection(connection) || connection.terminationHandled) {
+      return;
+    }
+    if (data is String) {
+      _frameController.add(data);
+      return;
+    }
+
+    final exception = MastodonStreamingClosedException(
+      closeCode: 1003,
+      endpoint: _safeEndpoint,
+      message: 'Streaming API sent a non-text frame',
+    );
+    _terminateConnection(connection, exception, reconnect: false);
+  }
+
+  void _handleSocketError(
+    _ActiveConnection connection,
+    Object error,
+    StackTrace stackTrace,
+  ) {
+    if (!_isCurrentConnection(connection) || connection.terminationHandled) {
+      return;
+    }
+    final exception = MastodonStreamingConnectionException(
+      message: 'Streaming transport failed',
+      endpoint: _safeEndpoint,
+      raw: error,
+    );
+    _terminateConnection(connection, exception, reconnect: true);
+  }
+
+  void _handleSocketDone(_ActiveConnection connection) {
+    if (!_isCurrentConnection(connection) || connection.terminationHandled) {
+      return;
+    }
+    final code = connection.socket.closeCode ?? 1005;
+    if (code == 1000) {
+      connection.terminationHandled = true;
+      _connection = null;
+      _wantsConnection = false;
+      _setState(MastodonStreamingConnectionState.disconnected);
+      unawaited(_releaseConnection(connection));
+      return;
+    }
+
+    final exception = MastodonStreamingClosedException(
+      closeCode: code,
+      closeReason: connection.socket.closeReason,
+      endpoint: _safeEndpoint,
+    );
+    final reconnect = code != 1003 && code != 1005;
+    _terminateConnection(connection, exception, reconnect: reconnect);
+  }
+
+  void _terminateConnection(
+    _ActiveConnection connection,
+    MastodonStreamingException exception, {
+    required bool reconnect,
+  }) {
+    if (!_isCurrentConnection(connection) || connection.terminationHandled) {
+      return;
+    }
+    connection.terminationHandled = true;
+    _connection = null;
+    _setState(MastodonStreamingConnectionState.disconnected);
+    _emitError(exception);
+    unawaited(_releaseConnection(connection));
+
+    if (reconnect) {
+      _scheduleReconnect();
+    } else {
+      _wantsConnection = false;
+    }
+  }
+
+  void _scheduleReconnect() {
+    if (_isDisposed ||
+        _isSuspended ||
+        !_wantsConnection ||
+        !config.enableAutoReconnect ||
+        _reconnectScheduled) {
+      return;
+    }
+
+    final attempt = _reconnectAttempts + 1;
+    final maximum = config.maxReconnectAttempts;
+    if (maximum != null && attempt > maximum) {
+      _wantsConnection = false;
+      _emitError(
+        MastodonStreamingConnectionException(
+          message: 'Streaming reconnect limit reached',
+          endpoint: _safeEndpoint,
+        ),
+      );
+      return;
+    }
+
+    _reconnectAttempts = attempt;
+    _reconnectScheduled = true;
+    final delay = _computeReconnectDelay(attempt);
+    final generation = _generation;
+    _setState(MastodonStreamingConnectionState.reconnecting);
+    _logInfo(
+      'Reconnecting to Mastodon Streaming API in '
+      '${delay.inMilliseconds}ms (attempt $attempt)',
+    );
+    unawaited(
+      _delay(delay).then((_) {
+        _reconnectScheduled = false;
+        if (_isDisposed ||
+            _isSuspended ||
+            !_wantsConnection ||
+            _generation != generation) {
+          return;
+        }
+        final future = _beginConnection(
+          reconnecting: true,
+          automaticAttempt: true,
+        );
+        unawaited(future.catchError((Object _) {}));
+      }),
+    );
+  }
+
+  Duration _computeReconnectDelay(int attempt) {
+    final initial = config.reconnectInitialDelay.inMicroseconds;
+    final maximum = config.reconnectMaxDelay.inMicroseconds;
+    var base = initial;
+    for (var current = 1; current < attempt && base < maximum; current++) {
+      base = base > maximum ~/ 2 ? maximum : base * 2;
+    }
+
+    final sample = _jitterSource().clamp(0.0, 1.0);
+    final jitter = config.reconnectJitter;
+    final factor = (1 - jitter) + (sample * jitter * 2);
+    final microseconds = (base * factor).round().clamp(1, maximum);
+    return Duration(microseconds: microseconds);
+  }
+
+  MastodonStreamingConnectionException _toConnectionException(
+    Object error,
+    Uri endpoint,
+  ) {
+    if (error is MastodonStreamingConnectionException) {
+      return error;
+    }
+    final statusCode = error is WebSocketConnectorException
+        ? error.statusCode
+        : null;
+    return MastodonStreamingConnectionException(
+      message: statusCode == 401
+          ? 'Streaming authentication failed'
+          : 'Streaming connection failed',
+      statusCode: statusCode,
+      endpoint: _safeUri(endpoint).toString(),
+    );
+  }
+
+  Uri _safeUri(Uri uri) {
+    if (!uri.queryParameters.containsKey('access_token')) {
+      return uri;
+    }
+    return uri.replace(
+      queryParameters: {...uri.queryParameters, 'access_token': '[REDACTED]'},
+    );
+  }
+
+  String get _safeEndpoint => _safeUri(
+    _urlResolver.resolve(
+      baseUrl: _baseUrl,
+      instance: _instance,
+      instanceV1: _instanceV1,
+    ),
+  ).toString();
+
+  bool _isCurrentIntent(int generation) =>
+      !_isDisposed &&
+      !_isSuspended &&
+      _wantsConnection &&
+      _generation == generation;
+
+  bool _isCurrentConnection(_ActiveConnection connection) =>
+      _isCurrentIntent(connection.generation) &&
+      identical(_connection, connection);
+
+  _ActiveConnection? _takeConnection() {
+    final connection = _connection;
+    _connection = null;
+    if (connection != null) {
+      connection.terminationHandled = true;
+    }
+    return connection;
+  }
+
+  Future<void> _releaseConnection(_ActiveConnection? connection) async {
+    if (connection == null) {
+      return;
+    }
+    try {
+      await connection.subscription?.cancel();
+    } catch (_) {
+      _logWarn('Could not cancel the Streaming socket listener');
+    }
+    try {
+      await connection.socket.close(1000, 'Client disconnect');
+    } catch (_) {
+      _logWarn('Could not close the Streaming socket');
+    }
+  }
+
+  void _setState(MastodonStreamingConnectionState value) {
+    if (_state == value) {
+      return;
+    }
+    _state = value;
+    if (!_stateController.isClosed) {
+      _stateController.add(value);
+    }
+  }
+
+  void _emitError(MastodonStreamingException error) {
+    if (!_errorController.isClosed) {
+      _errorController.add(error);
+    }
+  }
+
+  void _logInfo(String message) {
+    if (_enableLog) {
+      _logger.info(message);
+    }
+  }
+
+  void _logWarn(String message) {
+    if (_enableLog) {
+      _logger.warn(message);
+    }
+  }
+
+  void _ensureNotDisposed() {
+    if (_isDisposed) {
+      throw StateError('MastodonStreaming has been disposed');
+    }
+  }
+}
+
+final class _ConnectionResult {
+  const _ConnectionResult({required this.connection, required this.authMode});
+
+  final WebSocketConnection connection;
+  final MastodonStreamingAuthMode authMode;
+}
+
+final class _ActiveConnection {
+  _ActiveConnection({required this.generation, required this.socket});
+
+  final int generation;
+  final WebSocketConnection socket;
+  StreamSubscription<Object?>? subscription;
+  bool terminationHandled = false;
+}

--- a/lib/src/streaming/streaming_config.dart
+++ b/lib/src/streaming/streaming_config.dart
@@ -18,6 +18,7 @@ class MastodonStreamingConfig {
     this.enableAuthFallback = true,
     this.pingInterval = const Duration(seconds: 30),
     this.connectTimeout = const Duration(seconds: 15),
+    this.subscriptionErrorWindow = const Duration(milliseconds: 250),
     this.enableAutoReconnect = true,
     this.reconnectInitialDelay = const Duration(seconds: 1),
     this.reconnectMaxDelay = const Duration(seconds: 30),
@@ -26,6 +27,7 @@ class MastodonStreamingConfig {
   }) {
     _requirePositive(pingInterval, 'pingInterval');
     _requirePositive(connectTimeout, 'connectTimeout');
+    _requirePositive(subscriptionErrorWindow, 'subscriptionErrorWindow');
     _requirePositive(reconnectInitialDelay, 'reconnectInitialDelay');
     _requirePositive(reconnectMaxDelay, 'reconnectMaxDelay');
     if (reconnectInitialDelay > reconnectMaxDelay) {
@@ -68,6 +70,12 @@ class MastodonStreamingConfig {
 
   /// Maximum time allowed for the WebSocket handshake.
   final Duration connectTimeout;
+
+  /// Time allowed for an error response after each subscription frame.
+  ///
+  /// Successful Mastodon subscriptions have no acknowledgement, so requests
+  /// are serialized and considered successful after this quiet period.
+  final Duration subscriptionErrorWindow;
 
   /// Whether unexpected disconnections trigger reconnection.
   final bool enableAutoReconnect;

--- a/lib/src/streaming/streaming_config.dart
+++ b/lib/src/streaming/streaming_config.dart
@@ -1,0 +1,89 @@
+/// Authentication methods supported by the Mastodon Streaming API.
+enum MastodonStreamingAuthMode {
+  /// Sends the access token as the only WebSocket subprotocol.
+  subprotocol,
+
+  /// Sends the access token in an `Authorization` request header.
+  header,
+
+  /// Sends the access token in the `access_token` query parameter.
+  queryParameter,
+}
+
+/// Configuration for the Mastodon Streaming API connection.
+class MastodonStreamingConfig {
+  /// Creates Streaming API connection settings.
+  MastodonStreamingConfig({
+    this.authMode = MastodonStreamingAuthMode.subprotocol,
+    this.enableAuthFallback = true,
+    this.pingInterval = const Duration(seconds: 30),
+    this.connectTimeout = const Duration(seconds: 15),
+    this.enableAutoReconnect = true,
+    this.reconnectInitialDelay = const Duration(seconds: 1),
+    this.reconnectMaxDelay = const Duration(seconds: 30),
+    this.reconnectJitter = 0.2,
+    this.maxReconnectAttempts,
+  }) {
+    _requirePositive(pingInterval, 'pingInterval');
+    _requirePositive(connectTimeout, 'connectTimeout');
+    _requirePositive(reconnectInitialDelay, 'reconnectInitialDelay');
+    _requirePositive(reconnectMaxDelay, 'reconnectMaxDelay');
+    if (reconnectInitialDelay > reconnectMaxDelay) {
+      throw ArgumentError.value(
+        reconnectInitialDelay,
+        'reconnectInitialDelay',
+        'must not be greater than reconnectMaxDelay',
+      );
+    }
+    if (reconnectJitter < 0 || reconnectJitter > 1) {
+      throw ArgumentError.value(
+        reconnectJitter,
+        'reconnectJitter',
+        'must be between 0 and 1',
+      );
+    }
+    if (maxReconnectAttempts != null && maxReconnectAttempts! < 0) {
+      throw ArgumentError.value(
+        maxReconnectAttempts,
+        'maxReconnectAttempts',
+        'must be null or non-negative',
+      );
+    }
+  }
+
+  static void _requirePositive(Duration value, String name) {
+    if (value <= Duration.zero) {
+      throw ArgumentError.value(value, name, 'must be positive');
+    }
+  }
+
+  /// Authentication mode attempted first.
+  final MastodonStreamingAuthMode authMode;
+
+  /// Whether remaining authentication modes are tried after a failure.
+  final bool enableAuthFallback;
+
+  /// Interval used for transport-level ping frames.
+  final Duration pingInterval;
+
+  /// Maximum time allowed for the WebSocket handshake.
+  final Duration connectTimeout;
+
+  /// Whether unexpected disconnections trigger reconnection.
+  final bool enableAutoReconnect;
+
+  /// Delay before the first automatic reconnection attempt.
+  final Duration reconnectInitialDelay;
+
+  /// Upper bound for automatic reconnection delays, including jitter.
+  final Duration reconnectMaxDelay;
+
+  /// Symmetric jitter ratio applied to reconnection delays.
+  final double reconnectJitter;
+
+  /// Maximum number of automatic reconnection attempts.
+  ///
+  /// A value of `null` allows unlimited attempts. A value of zero disables
+  /// automatic attempts after an unexpected disconnection.
+  final int? maxReconnectAttempts;
+}

--- a/lib/src/streaming/streaming_config.dart
+++ b/lib/src/streaming/streaming_config.dart
@@ -75,6 +75,10 @@ class MastodonStreamingConfig {
   ///
   /// Successful Mastodon subscriptions have no acknowledgement, so requests
   /// are serialized and considered successful after this quiet period.
+  /// A delayed server error may be attributed to the next subscription
+  /// operation after this period expires. Higher-latency environments should
+  /// use a longer period, at the cost of slower `subscribe()` responses and
+  /// slower sequential subscription restoration after reconnection.
   final Duration subscriptionErrorWindow;
 
   /// Whether unexpected disconnections trigger reconnection.
@@ -93,5 +97,9 @@ class MastodonStreamingConfig {
   ///
   /// A value of `null` allows unlimited attempts. A value of zero disables
   /// automatic attempts after an unexpected disconnection.
+  ///
+  /// Browsers do not expose WebSocket handshake status codes, so an HTTP 401
+  /// cannot be identified and stopped immediately on Web. Set a finite limit
+  /// for Web applications to avoid unlimited retries with an invalid token.
   final int? maxReconnectAttempts;
 }

--- a/lib/src/streaming/streaming_connection_state.dart
+++ b/lib/src/streaming/streaming_connection_state.dart
@@ -1,0 +1,20 @@
+/// Lifecycle state of a Mastodon Streaming API connection.
+enum MastodonStreamingConnectionState {
+  /// No WebSocket connection is active.
+  disconnected,
+
+  /// The initial WebSocket connection is being established.
+  connecting,
+
+  /// The WebSocket connection is open and ready for messages.
+  connected,
+
+  /// An automatic replacement connection is being established.
+  reconnecting,
+
+  /// The connection is paused until the application resumes.
+  suspended,
+
+  /// The streaming client has released its resources and cannot be reused.
+  disposed,
+}

--- a/lib/src/streaming/streaming_event.dart
+++ b/lib/src/streaming/streaming_event.dart
@@ -1,0 +1,115 @@
+import '../models/mastodon_announcement.dart';
+import '../models/mastodon_conversation.dart';
+import '../models/mastodon_notification.dart';
+import '../models/mastodon_status.dart';
+import '../models/mastodon_streaming_announcement_reaction.dart';
+
+/// A typed event delivered by the Mastodon Streaming API.
+sealed class MastodonStreamEvent {
+  const MastodonStreamEvent({required this.stream});
+
+  /// Raw `stream` array sent by the server.
+  final List<String> stream;
+}
+
+/// A newly published status.
+final class MastodonUpdateEvent extends MastodonStreamEvent {
+  const MastodonUpdateEvent({required super.stream, required this.status});
+
+  final MastodonStatus status;
+}
+
+/// An edited status.
+final class MastodonStatusUpdateEvent extends MastodonStreamEvent {
+  const MastodonStatusUpdateEvent({
+    required super.stream,
+    required this.status,
+  });
+
+  final MastodonStatus status;
+}
+
+/// A deleted status identifier.
+final class MastodonDeleteEvent extends MastodonStreamEvent {
+  const MastodonDeleteEvent({required super.stream, required this.statusId});
+
+  final String statusId;
+}
+
+/// A user notification.
+final class MastodonNotificationEvent extends MastodonStreamEvent {
+  const MastodonNotificationEvent({
+    required super.stream,
+    required this.notification,
+  });
+
+  final MastodonNotification notification;
+}
+
+/// A direct conversation update.
+final class MastodonConversationEvent extends MastodonStreamEvent {
+  const MastodonConversationEvent({
+    required super.stream,
+    required this.conversation,
+  });
+
+  final MastodonConversation conversation;
+}
+
+/// An announcement update.
+final class MastodonAnnouncementEvent extends MastodonStreamEvent {
+  const MastodonAnnouncementEvent({
+    required super.stream,
+    required this.announcement,
+  });
+
+  final MastodonAnnouncement announcement;
+}
+
+/// An announcement reaction count update.
+final class MastodonAnnouncementReactionEvent extends MastodonStreamEvent {
+  const MastodonAnnouncementReactionEvent({
+    required super.stream,
+    required this.reaction,
+  });
+
+  final MastodonStreamingAnnouncementReaction reaction;
+}
+
+/// A deleted announcement identifier.
+final class MastodonAnnouncementDeleteEvent extends MastodonStreamEvent {
+  const MastodonAnnouncementDeleteEvent({
+    required super.stream,
+    required this.announcementId,
+  });
+
+  final String announcementId;
+}
+
+/// Notification cleanup completed on the server.
+final class MastodonNotificationsMergedEvent extends MastodonStreamEvent {
+  const MastodonNotificationsMergedEvent({required super.stream});
+}
+
+/// The authenticated user's filters changed.
+///
+/// Mastodon 4.3 and newer normally discard this payload-free event before it
+/// reaches clients. It remains typed for older and compatible servers.
+final class MastodonFiltersChangedEvent extends MastodonStreamEvent {
+  const MastodonFiltersChangedEvent({required super.stream});
+}
+
+/// An unsupported event or an event whose payload could not be decoded.
+final class MastodonUnknownStreamEvent extends MastodonStreamEvent {
+  const MastodonUnknownStreamEvent({
+    required super.stream,
+    required this.event,
+    required this.rawPayload,
+  });
+
+  /// Wire-format event name.
+  final String event;
+
+  /// Undecoded payload, when present.
+  final String? rawPayload;
+}

--- a/lib/src/streaming/streaming_message.dart
+++ b/lib/src/streaming/streaming_message.dart
@@ -1,0 +1,61 @@
+import 'dart:convert';
+
+/// A raw message envelope received from the Mastodon Streaming API.
+class MastodonStreamingMessage {
+  /// Creates a decoded raw message.
+  MastodonStreamingMessage({
+    required List<String> stream,
+    required this.event,
+    required this.payload,
+    required this.raw,
+  }) : stream = List.unmodifiable(stream);
+
+  /// Decodes one WebSocket text frame.
+  factory MastodonStreamingMessage.fromRaw(String raw) {
+    final decoded = jsonDecode(raw);
+    if (decoded is! Map<String, dynamic>) {
+      throw const FormatException('Streaming message must be a JSON object');
+    }
+
+    final streamValue = decoded['stream'];
+    if (streamValue is! List<dynamic> ||
+        streamValue.isEmpty ||
+        streamValue.length > 2 ||
+        streamValue.any((value) => value is! String)) {
+      throw const FormatException(
+        'Streaming message stream must contain one or two strings',
+      );
+    }
+    final event = decoded['event'];
+    if (event is! String || event.isEmpty) {
+      throw const FormatException(
+        'Streaming message event must be a non-empty string',
+      );
+    }
+    final payload = decoded['payload'];
+    if (payload != null && payload is! String) {
+      throw const FormatException(
+        'Streaming message payload must be a string or null',
+      );
+    }
+
+    return MastodonStreamingMessage(
+      stream: streamValue.cast<String>(),
+      event: event,
+      payload: payload as String?,
+      raw: raw,
+    );
+  }
+
+  /// Raw `stream` array sent by the server.
+  final List<String> stream;
+
+  /// Wire-format event name.
+  final String event;
+
+  /// Undecoded payload string.
+  final String? payload;
+
+  /// Complete WebSocket text frame.
+  final String raw;
+}

--- a/lib/src/streaming/streaming_stream.dart
+++ b/lib/src/streaming/streaming_stream.dart
@@ -1,0 +1,158 @@
+/// A typed definition of a Mastodon Streaming API channel.
+sealed class MastodonStream {
+  const MastodonStream();
+
+  /// Creates the authenticated user's combined home and notification stream.
+  ///
+  /// A token limited to `read:statuses` receives home statuses but silently
+  /// receives no notifications. Use `read` or `read:notifications` when
+  /// notifications are required.
+  const factory MastodonStream.user() = _UserStream;
+
+  /// Creates the authenticated user's notification-only stream.
+  ///
+  /// Subscribing to this together with [MastodonStream.user] delivers each
+  /// notification twice. This stream is unnecessary when `user` is active.
+  const factory MastodonStream.userNotification() = _UserNotificationStream;
+
+  /// Creates a public timeline stream.
+  ///
+  /// Set [onlyMedia] to select the corresponding `public:*:media` channel.
+  /// The WebSocket server ignores an `only_media` parameter, so media-only
+  /// behavior must be represented by the channel name.
+  ///
+  /// Public updates may be silently filtered by language preferences, feed
+  /// access settings, blocks, or mutes. An idle stream is not necessarily a
+  /// client error.
+  const factory MastodonStream.public({
+    bool local,
+    bool remote,
+    bool onlyMedia,
+  }) = _PublicStream;
+
+  /// Creates a hashtag timeline stream.
+  ///
+  /// Hashtag updates may be silently filtered by language preferences, feed
+  /// access settings, blocks, or mutes.
+  const factory MastodonStream.hashtag(String tag, {bool local}) =
+      _HashtagStream;
+
+  /// Creates a list timeline stream.
+  const factory MastodonStream.list(String listId) = _ListStream;
+
+  /// Creates the authenticated user's direct conversation stream.
+  const factory MastodonStream.direct() = _DirectStream;
+
+  /// Wire-format channel name, such as `public:local:media`.
+  String get name;
+
+  /// Parameters sent alongside `stream` in subscription frames.
+  Map<String, String> get params;
+
+  /// Normalized key used for reference counting and inbound routing.
+  String get key;
+}
+
+final class _UserStream extends MastodonStream {
+  const _UserStream();
+
+  @override
+  String get name => 'user';
+
+  @override
+  Map<String, String> get params => const {};
+
+  @override
+  String get key => name;
+}
+
+final class _UserNotificationStream extends MastodonStream {
+  const _UserNotificationStream();
+
+  @override
+  String get name => 'user:notification';
+
+  @override
+  Map<String, String> get params => const {};
+
+  @override
+  String get key => name;
+}
+
+final class _PublicStream extends MastodonStream {
+  const _PublicStream({
+    this.local = false,
+    this.remote = false,
+    this.onlyMedia = false,
+  }) : assert(!local || !remote, 'local and remote cannot both be true');
+
+  final bool local;
+  final bool remote;
+  final bool onlyMedia;
+
+  @override
+  String get name {
+    final parts = <String>['public'];
+    if (local) {
+      parts.add('local');
+    } else if (remote) {
+      parts.add('remote');
+    }
+    if (onlyMedia) {
+      parts.add('media');
+    }
+    return parts.join(':');
+  }
+
+  @override
+  Map<String, String> get params => const {};
+
+  @override
+  String get key => name;
+}
+
+final class _HashtagStream extends MastodonStream {
+  const _HashtagStream(this.tag, {this.local = false})
+    : assert(tag != '', 'tag must not be empty');
+
+  final String tag;
+  final bool local;
+
+  @override
+  String get name => local ? 'hashtag:local' : 'hashtag';
+
+  @override
+  Map<String, String> get params => {'tag': tag};
+
+  @override
+  String get key => '$name:${tag.toLowerCase()}';
+}
+
+final class _ListStream extends MastodonStream {
+  const _ListStream(this.listId)
+    : assert(listId != '', 'listId must not be empty');
+
+  final String listId;
+
+  @override
+  String get name => 'list';
+
+  @override
+  Map<String, String> get params => {'list': listId};
+
+  @override
+  String get key => '$name:$listId';
+}
+
+final class _DirectStream extends MastodonStream {
+  const _DirectStream();
+
+  @override
+  String get name => 'direct';
+
+  @override
+  Map<String, String> get params => const {};
+
+  @override
+  String get key => name;
+}

--- a/lib/src/streaming/streaming_stream.dart
+++ b/lib/src/streaming/streaming_stream.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 /// A typed definition of a Mastodon Streaming API channel.
 sealed class MastodonStream {
   const MastodonStream();
@@ -51,6 +53,24 @@ sealed class MastodonStream {
 
   /// Normalized key used for reference counting and inbound routing.
   String get key;
+
+  /// Builds a structured reference-counting key from a channel definition.
+  ///
+  /// Hashtag values are normalized to lowercase, and parameter order does not
+  /// affect the result.
+  static String keyFor(String name, Map<String, String> params) {
+    final entries = params.entries.toList()
+      ..sort((left, right) => left.key.compareTo(right.key));
+    return jsonEncode([
+      name,
+      {
+        for (final entry in entries)
+          entry.key: entry.key == 'tag'
+              ? entry.value.toLowerCase()
+              : entry.value,
+      },
+    ]);
+  }
 }
 
 final class _UserStream extends MastodonStream {
@@ -63,7 +83,7 @@ final class _UserStream extends MastodonStream {
   Map<String, String> get params => const {};
 
   @override
-  String get key => name;
+  String get key => MastodonStream.keyFor(name, params);
 }
 
 final class _UserNotificationStream extends MastodonStream {
@@ -76,7 +96,7 @@ final class _UserNotificationStream extends MastodonStream {
   Map<String, String> get params => const {};
 
   @override
-  String get key => name;
+  String get key => MastodonStream.keyFor(name, params);
 }
 
 final class _PublicStream extends MastodonStream {
@@ -108,7 +128,7 @@ final class _PublicStream extends MastodonStream {
   Map<String, String> get params => const {};
 
   @override
-  String get key => name;
+  String get key => MastodonStream.keyFor(name, params);
 }
 
 final class _HashtagStream extends MastodonStream {
@@ -125,7 +145,7 @@ final class _HashtagStream extends MastodonStream {
   Map<String, String> get params => {'tag': tag};
 
   @override
-  String get key => '$name:${tag.toLowerCase()}';
+  String get key => MastodonStream.keyFor(name, params);
 }
 
 final class _ListStream extends MastodonStream {
@@ -141,7 +161,7 @@ final class _ListStream extends MastodonStream {
   Map<String, String> get params => {'list': listId};
 
   @override
-  String get key => '$name:$listId';
+  String get key => MastodonStream.keyFor(name, params);
 }
 
 final class _DirectStream extends MastodonStream {
@@ -154,5 +174,5 @@ final class _DirectStream extends MastodonStream {
   Map<String, String> get params => const {};
 
   @override
-  String get key => name;
+  String get key => MastodonStream.keyFor(name, params);
 }

--- a/lib/src/streaming/streaming_subscription.dart
+++ b/lib/src/streaming/streaming_subscription.dart
@@ -1,0 +1,67 @@
+import '../models/mastodon_status.dart';
+import 'streaming_event.dart';
+import 'streaming_message.dart';
+
+/// A reference-counted Mastodon Streaming API subscription handle.
+class MastodonStreamingSubscription {
+  /// Creates a subscription handle managed by [MastodonStreaming].
+  MastodonStreamingSubscription.managed({
+    required this.streamName,
+    required Map<String, String> params,
+    required Stream<MastodonStreamingMessage> messages,
+    required Stream<MastodonStreamEvent> events,
+    required Future<void> Function() onCancel,
+    required bool Function() onIsActive,
+  }) : params = Map.unmodifiable(params),
+       _messages = messages,
+       _events = events,
+       _statuses = events
+           .where(
+             (event) =>
+                 event is MastodonUpdateEvent ||
+                 event is MastodonStatusUpdateEvent,
+           )
+           .map(
+             (event) => switch (event) {
+               MastodonUpdateEvent(:final status) => status,
+               MastodonStatusUpdateEvent(:final status) => status,
+               _ => throw StateError('Unexpected status event'),
+             },
+           ),
+       _onCancel = onCancel,
+       _onIsActive = onIsActive;
+
+  /// Raw wire-format channel name.
+  final String streamName;
+
+  /// Parameters sent alongside the channel name.
+  final Map<String, String> params;
+
+  final Stream<MastodonStreamingMessage> _messages;
+  final Stream<MastodonStreamEvent> _events;
+  final Stream<MastodonStatus> _statuses;
+  final Future<void> Function() _onCancel;
+  final bool Function() _onIsActive;
+  Future<void>? _cancelFuture;
+
+  /// Raw messages routed to this subscription.
+  Stream<MastodonStreamingMessage> get messages => _messages;
+
+  /// Typed events decoded from [messages].
+  Stream<MastodonStreamEvent> get events => _events;
+
+  /// Statuses from `update` and `status.update` events.
+  Stream<MastodonStatus> get statuses => _statuses;
+
+  /// Whether this handle still contributes to the reference count.
+  bool get isActive => _onIsActive();
+
+  /// Releases this handle.
+  ///
+  /// The server receives `unsubscribe` only when the final handle for the
+  /// normalized stream key is released. Repeated calls are safe.
+  Future<void> cancel() => _cancelFuture ??= _onCancel();
+
+  /// Alias for [cancel].
+  Future<void> unsubscribe() => cancel();
+}

--- a/lib/src/streaming/streaming_subscription.dart
+++ b/lib/src/streaming/streaming_subscription.dart
@@ -59,8 +59,25 @@ class MastodonStreamingSubscription {
   /// Releases this handle.
   ///
   /// The server receives `unsubscribe` only when the final handle for the
-  /// normalized stream key is released. Repeated calls are safe.
-  Future<void> cancel() => _cancelFuture ??= _onCancel();
+  /// normalized stream key is released. The first call reports an unsubscribe
+  /// failure, while later calls are safe and complete without repeating it.
+  Future<void> cancel() {
+    final pending = _cancelFuture;
+    if (pending != null) {
+      return pending;
+    }
+    if (!isActive) {
+      return Future<void>.value();
+    }
+
+    final future = _onCancel();
+    _cancelFuture = future;
+    return future.whenComplete(() {
+      if (identical(_cancelFuture, future)) {
+        _cancelFuture = null;
+      }
+    });
+  }
 
   /// Alias for [cancel].
   Future<void> unsubscribe() => cancel();

--- a/lib/src/streaming/streaming_url_resolver.dart
+++ b/lib/src/streaming/streaming_url_resolver.dart
@@ -1,0 +1,82 @@
+import '../models/mastodon_instance.dart';
+import '../models/mastodon_instance_v1.dart';
+
+/// Resolves and normalizes the WebSocket URL for the streaming API.
+class StreamingUrlResolver {
+  const StreamingUrlResolver();
+
+  /// Resolves a URL from v2 instance metadata, v1 metadata, or [baseUrl].
+  ///
+  /// The v2 streaming URL takes precedence over the v1 URL. If neither is
+  /// available, the REST API host and port from [baseUrl] are used.
+  Uri resolve({
+    required String baseUrl,
+    MastodonInstance? instance,
+    MastodonInstanceV1? instanceV1,
+  }) {
+    final v2Url = _nonEmpty(instance?.configuration.urls.streaming);
+    if (v2Url != null) {
+      return _normalize(v2Url);
+    }
+
+    final v1Url = _nonEmpty(instanceV1?.urls?.streamingApi);
+    if (v1Url != null) {
+      return _normalize(v1Url);
+    }
+
+    final restUri = _parse(baseUrl);
+    final restOrigin = Uri(
+      scheme: restUri.scheme,
+      userInfo: restUri.userInfo,
+      host: restUri.host,
+      port: restUri.hasPort ? restUri.port : null,
+    );
+    return _normalizeUri(restOrigin);
+  }
+
+  String? _nonEmpty(String? value) {
+    final trimmed = value?.trim();
+    return trimmed == null || trimmed.isEmpty ? null : trimmed;
+  }
+
+  Uri _normalize(String value) => _normalizeUri(_parse(value));
+
+  Uri _parse(String value) {
+    final trimmed = value.trim();
+    final uri = Uri.parse(
+      trimmed.contains('://') ? trimmed : 'https://$trimmed',
+    );
+    if (uri.host.isEmpty) {
+      throw FormatException('Streaming URL must include a host.', value);
+    }
+    return uri;
+  }
+
+  Uri _normalizeUri(Uri uri) {
+    final scheme = switch (uri.scheme.toLowerCase()) {
+      'http' => 'ws',
+      'https' => 'wss',
+      'ws' => 'ws',
+      'wss' => 'wss',
+      _ => throw FormatException(
+        'Unsupported streaming URL scheme: ${uri.scheme}',
+        uri.toString(),
+      ),
+    };
+
+    return uri.replace(scheme: scheme, path: _normalizePath(uri.path));
+  }
+
+  String _normalizePath(String path) {
+    const endpoint = '/api/v1/streaming';
+    if (path.isEmpty || path == '/') {
+      return endpoint;
+    }
+
+    var trimmed = path;
+    while (trimmed.length > 1 && trimmed.endsWith('/')) {
+      trimmed = trimmed.substring(0, trimmed.length - 1);
+    }
+    return trimmed.endsWith(endpoint) ? trimmed : '$trimmed$endpoint';
+  }
+}

--- a/lib/src/streaming/websocket_connector.dart
+++ b/lib/src/streaming/websocket_connector.dart
@@ -1,0 +1,10 @@
+import 'internal/websocket_connector_factory.dart'
+    if (dart.library.io) 'internal/websocket_connector_factory_io.dart'
+    as platform;
+import 'internal/websocket_types.dart';
+
+export 'internal/websocket_types.dart';
+
+/// Creates the package's platform-default WebSocket connector.
+WebSocketConnector createDefaultWebSocketConnector() =>
+    platform.createDefaultWebSocketConnector();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   dio: ^5.11.0
   json_annotation: ^4.12.0
   logger: ^2.7.0
+  web_socket_channel: ^3.0.3
 dev_dependencies:
   build_runner: ^2.15.1
   json_serializable: ^6.14.1

--- a/test/api/health_api_test.dart
+++ b/test/api/health_api_test.dart
@@ -1,0 +1,45 @@
+import 'package:mastodon_client/src/api/health_api.dart';
+import 'package:mastodon_client/src/client/mastodon_http_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('HealthApi.checkStreaming', () {
+    test('requests the plain-text streaming health endpoint', () async {
+      final http = _FakeMastodonHttpClient('OK');
+      final api = HealthApi(http);
+
+      expect(await api.checkStreaming(), isTrue);
+      expect(http.path, '/api/v1/streaming/health');
+      expect(http.responseType, String);
+    });
+
+    test('returns false for an unexpected response body', () async {
+      final api = HealthApi(_FakeMastodonHttpClient('not OK'));
+
+      expect(await api.checkStreaming(), isFalse);
+    });
+  });
+}
+
+class _FakeMastodonHttpClient extends MastodonHttpClient {
+  _FakeMastodonHttpClient(this.response)
+    : super(baseUrl: 'https://mastodon.example', enableLog: false);
+
+  final Object? response;
+  String? path;
+  Type? responseType;
+
+  @override
+  Future<T?> send<T>(
+    String path, {
+    String method = 'GET',
+    Object? data,
+    Map<String, dynamic>? queryParameters,
+    Map<String, String>? headers,
+    String? contentType,
+  }) async {
+    this.path = path;
+    responseType = T;
+    return response as T?;
+  }
+}

--- a/test/api/health_api_test.dart
+++ b/test/api/health_api_test.dart
@@ -18,7 +18,22 @@ void main() {
 
       expect(await api.checkStreaming(), isFalse);
     });
+
+    for (final body in ['OK\n', ' \tOK\r\n']) {
+      test(
+        'accepts surrounding whitespace in ${body.escapeForTestName()}',
+        () async {
+          final api = HealthApi(_FakeMastodonHttpClient(body));
+
+          expect(await api.checkStreaming(), isTrue);
+        },
+      );
+    }
   });
+}
+
+extension on String {
+  String escapeForTestName() => replaceAll('\n', r'\n').replaceAll('\r', r'\r');
 }
 
 class _FakeMastodonHttpClient extends MastodonHttpClient {

--- a/test/client/mastodon_http_client_test.dart
+++ b/test/client/mastodon_http_client_test.dart
@@ -1,0 +1,31 @@
+import 'package:mastodon_client/src/client/mastodon_http_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MastodonHttpClient configuration', () {
+    test('retains values while preserving Dio options', () {
+      final client = MastodonHttpClient(
+        baseUrl: 'https://mastodon.example',
+        accessToken: 'test-token',
+        enableLog: false,
+      );
+
+      expect(client.baseUrl, 'https://mastodon.example');
+      expect(client.accessToken, 'test-token');
+      expect(client.enableLog, isFalse);
+      expect(client.dio.options.baseUrl, 'https://mastodon.example');
+      expect(client.dio.options.headers['Authorization'], 'Bearer test-token');
+    });
+
+    test('retains a null access token without adding authorization', () {
+      final client = MastodonHttpClient(
+        baseUrl: 'https://mastodon.example',
+        enableLog: true,
+      );
+
+      expect(client.accessToken, isNull);
+      expect(client.enableLog, isTrue);
+      expect(client.dio.options.headers, isNot(contains('Authorization')));
+    });
+  });
+}

--- a/test/e2e/e2e_env.dart
+++ b/test/e2e/e2e_env.dart
@@ -4,6 +4,8 @@ import 'dart:io';
 import 'package:dio/dio.dart';
 import 'package:dio/io.dart';
 import 'package:mastodon_client/mastodon_client.dart';
+import 'package:web_socket_channel/io.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
 
 /// Connection settings for the local closed-federation E2E environment
 /// (`fediverse_e2e`).
@@ -133,6 +135,84 @@ class E2eEnv {
     accessToken: admin ? fedibirdAdminToken : fedibirdUserToken,
     httpClientAdapter: createHttpClientAdapter(),
   );
+
+  /// Creates a [MastodonStreaming] connected to `mastodon.test`.
+  ///
+  /// The default connector cannot complete the TLS handshake against the
+  /// self-signed E2E certificate, so a connector trusting [rootCaPath] is
+  /// injected instead.
+  MastodonStreaming createMastodonStreaming({
+    bool admin = false,
+    MastodonStreamingConfig? config,
+  }) => MastodonStreaming.withConnector(
+    baseUrl: mastodonBaseUrl,
+    accessToken: admin ? mastodonAdminToken : mastodonUserToken,
+    connector: _E2eWebSocketConnector(rootCaPath),
+    config: config,
+  );
+}
+
+/// A [WebSocketConnector] that trusts the E2E root CA.
+final class _E2eWebSocketConnector implements WebSocketConnector {
+  _E2eWebSocketConnector(this._rootCaPath);
+
+  final String _rootCaPath;
+
+  @override
+  Future<WebSocketConnection> connect(WebSocketConnectOptions options) async {
+    final context = SecurityContext(withTrustedRoots: true)
+      ..setTrustedCertificates(_rootCaPath);
+    final channel = IOWebSocketChannel.connect(
+      options.uri,
+      protocols: options.protocols.isEmpty ? null : options.protocols,
+      headers: options.headers.isEmpty ? null : options.headers,
+      pingInterval: options.pingInterval,
+      connectTimeout: options.connectTimeout,
+      customClient: HttpClient(context: context),
+    );
+    try {
+      await channel.ready;
+      return _E2eWebSocketConnection(channel);
+    } on Object catch (error) {
+      try {
+        await channel.sink.close();
+      } on Object {
+        // 接続失敗の原因を close 側の例外で上書きしない。
+      }
+      throw WebSocketConnectorException(
+        message: 'WebSocket handshake failed',
+        statusCode: switch (error) {
+          WebSocketChannelException(inner: final WebSocketException inner) =>
+            inner.httpStatusCode,
+          WebSocketException(:final httpStatusCode) => httpStatusCode,
+          _ => null,
+        },
+        cause: error,
+      );
+    }
+  }
+}
+
+final class _E2eWebSocketConnection implements WebSocketConnection {
+  _E2eWebSocketConnection(this._channel);
+
+  final IOWebSocketChannel _channel;
+
+  @override
+  Stream<Object?> get messages => _channel.stream;
+
+  @override
+  int? get closeCode => _channel.closeCode;
+
+  @override
+  String? get closeReason => _channel.closeReason;
+
+  @override
+  void sendText(String data) => _channel.sink.add(data);
+
+  @override
+  Future<void> close([int? closeCode, String? closeReason]) =>
+      _channel.sink.close(closeCode, closeReason);
 }
 
 /// Polls [probe] until it returns non-null, or fails after [timeout].

--- a/test/e2e/fedibird_compat_e2e_test.dart
+++ b/test/e2e/fedibird_compat_e2e_test.dart
@@ -6,12 +6,11 @@ import 'package:test/test.dart';
 
 import 'e2e_env.dart';
 
-/// fediverse_e2e 環境(fedibird.test)に対する互換性テスト。
+/// Compatibility tests against fedibird.test in fediverse_e2e.
 ///
-/// Fedibird は Mastodon 3.4 系のフォークであり、mastodon_client が前提と
-/// している 4.x のエンドポイントには存在しないものがある。
-/// ここでは「動くもの」と「動かないもの」の両方を実サーバーで固定し、
-/// アプリ側が機能判定を行う際の根拠とする。
+/// Fedibird is a Mastodon 3.4-based fork and lacks some 4.x endpoints assumed
+/// by mastodon_client. These tests record both supported and unsupported
+/// behavior on a real server so applications can make capability decisions.
 void main() {
   final env = E2eEnv.tryLoad();
   if (env == null) {

--- a/test/e2e/mastodon_federation_e2e_test.dart
+++ b/test/e2e/mastodon_federation_e2e_test.dart
@@ -6,7 +6,7 @@ import 'package:test/test.dart';
 
 import 'e2e_env.dart';
 
-/// fediverse_e2e 環境の連合(mastodon.test ⇄ misskey.test)を使うテスト
+/// Federation tests between mastodon.test and misskey.test in fediverse_e2e.
 void main() {
   final env = E2eEnv.tryLoad();
   if (env == null) {

--- a/test/e2e/mastodon_smoke_e2e_test.dart
+++ b/test/e2e/mastodon_smoke_e2e_test.dart
@@ -6,7 +6,7 @@ import 'package:test/test.dart';
 
 import 'e2e_env.dart';
 
-/// fediverse_e2e 環境(mastodon.test)に対する単一サーバーのスモークテスト
+/// Single-server smoke tests against mastodon.test in fediverse_e2e.
 void main() {
   final env = E2eEnv.tryLoad();
   if (env == null) {

--- a/test/e2e/mastodon_streaming_e2e_test.dart
+++ b/test/e2e/mastodon_streaming_e2e_test.dart
@@ -1,0 +1,81 @@
+@Tags(['e2e'])
+library;
+
+import 'package:mastodon_client/mastodon_client.dart';
+import 'package:test/test.dart';
+
+import 'e2e_env.dart';
+
+/// fediverse_e2e 環境(mastodon.test)に対する Streaming API のE2Eテスト
+void main() {
+  final env = E2eEnv.tryLoad();
+  if (env == null) {
+    test('mastodon streaming e2e', () {}, skip: E2eEnv.skipReason);
+    return;
+  }
+
+  late MastodonClient client;
+  late MastodonStreaming streaming;
+
+  setUpAll(() {
+    client = env.createMastodonClient();
+    streaming = env.createMastodonStreaming();
+  });
+
+  tearDownAll(() async {
+    await streaming.dispose();
+    await client.dispose();
+  });
+
+  group('health', () {
+    test('streaming health returns OK without authentication', () async {
+      expect(await client.health.checkStreaming(), isTrue);
+    });
+  });
+
+  group('connection', () {
+    test('connect reaches the connected state', () async {
+      await streaming.connect();
+      expect(streaming.isConnected, isTrue);
+    });
+  });
+
+  group('user stream', () {
+    test('delivers an update for a status posted over REST', () async {
+      await streaming.connect();
+      final subscription = await streaming.subscribe(
+        const MastodonStream.user(),
+      );
+      addTearDown(subscription.cancel);
+
+      final marker = 'e2e streaming ${DateTime.now().millisecondsSinceEpoch}';
+      final received = subscription.statuses
+          .firstWhere((status) => status.content.contains(marker))
+          .timeout(const Duration(seconds: 60));
+
+      // 購読が確立してから投稿しないとイベントを取りこぼす
+      final result = await client.statuses.create(
+        MastodonStatusCreateRequest(status: marker),
+      );
+      final created = (result as MastodonStatusCreated).status;
+      addTearDown(() => client.statuses.delete(created.id));
+
+      expect((await received).id, created.id);
+    });
+
+    test('reports a subscription error for an unknown stream', () async {
+      await streaming.connect();
+
+      await expectLater(
+        streaming.subscribeRaw('definitely-not-a-stream'),
+        throwsA(
+          isA<MastodonStreamingSubscriptionException>().having(
+            (error) => error.status,
+            'status',
+            400,
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/test/e2e/mastodon_streaming_e2e_test.dart
+++ b/test/e2e/mastodon_streaming_e2e_test.dart
@@ -6,7 +6,7 @@ import 'package:test/test.dart';
 
 import 'e2e_env.dart';
 
-/// fediverse_e2e 環境(mastodon.test)に対する Streaming API のE2Eテスト
+/// E2E tests for the Streaming API against mastodon.test in fediverse_e2e.
 void main() {
   final env = E2eEnv.tryLoad();
   if (env == null) {
@@ -19,7 +19,12 @@ void main() {
 
   setUpAll(() {
     client = env.createMastodonClient();
-    streaming = env.createMastodonStreaming();
+    // 実サーバーの往復は既定の250msを超えうるので、購読エラーの待ち受け窓を広げる
+    streaming = env.createMastodonStreaming(
+      config: MastodonStreamingConfig(
+        subscriptionErrorWindow: const Duration(seconds: 5),
+      ),
+    );
   });
 
   tearDownAll(() async {

--- a/test/fixtures/streaming_announcement_reaction.json
+++ b/test/fixtures/streaming_announcement_reaction.json
@@ -1,0 +1,5 @@
+{
+  "name": "wave",
+  "count": 3,
+  "announcement_id": "42"
+}

--- a/test/mastodon_client_test.dart
+++ b/test/mastodon_client_test.dart
@@ -14,4 +14,41 @@ void main() {
     final client = MastodonClient(baseUrl: 'https://mastodon.social');
     expect(client, isNotNull);
   });
+
+  test('MastodonClient.streaming is lazy and cached', () async {
+    final client = MastodonClient(
+      baseUrl: 'https://mastodon.social',
+      accessToken: 'test_token',
+      enableLog: false,
+    );
+
+    final first = client.streaming;
+    final second = client.streaming;
+
+    expect(identical(first, second), isTrue);
+    expect(first.state, MastodonStreamingConnectionState.disconnected);
+    await client.dispose();
+  });
+
+  test('dispose does not create streaming when it was never used', () async {
+    final client = MastodonClient(
+      baseUrl: 'https://mastodon.social',
+      accessToken: 'test_token',
+      enableLog: false,
+    );
+
+    await client.dispose();
+
+    expect(() => client.streaming, throwsStateError);
+  });
+
+  test('streaming requires an access token', () async {
+    final client = MastodonClient(
+      baseUrl: 'https://mastodon.social',
+      enableLog: false,
+    );
+
+    expect(() => client.streaming, throwsStateError);
+    await client.dispose();
+  });
 }

--- a/test/models/fixture_key_coverage_test.dart
+++ b/test/models/fixture_key_coverage_test.dart
@@ -50,6 +50,8 @@ void main() {
     'media_attachment.json': (json) =>
         MastodonMediaAttachment.fromJson(json).toJson(),
     'collection.json': (json) => MastodonCollection.fromJson(json).toJson(),
+    'streaming_announcement_reaction.json': (json) =>
+        MastodonStreamingAnnouncementReaction.fromJson(json).toJson(),
   };
 
   group('fixture key coverage', () {

--- a/test/models/mastodon_streaming_announcement_reaction_test.dart
+++ b/test/models/mastodon_streaming_announcement_reaction_test.dart
@@ -1,0 +1,26 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:mastodon_client/mastodon_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MastodonStreamingAnnouncementReaction.fromJson', () {
+    test('deserializes from fixture', () {
+      final json =
+          jsonDecode(
+                File(
+                  'test/fixtures/streaming_announcement_reaction.json',
+                ).readAsStringSync(),
+              )
+              as Map<String, dynamic>;
+
+      final reaction = MastodonStreamingAnnouncementReaction.fromJson(json);
+
+      expect(reaction.name, 'wave');
+      expect(reaction.count, 3);
+      expect(reaction.announcementId, '42');
+      expect(reaction.toJson(), json);
+    });
+  });
+}

--- a/test/streaming/mastodon_streaming_test.dart
+++ b/test/streaming/mastodon_streaming_test.dart
@@ -161,6 +161,82 @@ void main() {
         await streaming.dispose();
       });
     }
+
+    test('reconnects after close code 1005 when the token is valid', () async {
+      final socket = _FakeWebSocketConnection();
+      final replacement = _FakeWebSocketConnection();
+      final connector = _FakeWebSocketConnector([socket, replacement]);
+      var validations = 0;
+      final streaming = _streaming(
+        connector,
+        tokenValidator: () async {
+          validations++;
+          return true;
+        },
+      );
+      await streaming.connect();
+
+      await socket.closeFromServer(1005);
+      await _waitUntil(() => connector.options.length == 2);
+
+      expect(validations, 1);
+      expect(streaming.state, MastodonStreamingConnectionState.connected);
+      await streaming.dispose();
+    });
+
+    test(
+      'does not reconnect after close code 1005 when the token is invalid',
+      () async {
+        final socket = _FakeWebSocketConnection();
+        final connector = _FakeWebSocketConnector([
+          socket,
+          _FakeWebSocketConnection(),
+        ]);
+        final errors = <MastodonStreamingException>[];
+        final streaming = _streaming(
+          connector,
+          tokenValidator: () async => false,
+        );
+        final errorSubscription = streaming.errors.listen(errors.add);
+        await streaming.connect();
+
+        await socket.closeFromServer(1005);
+        await _waitUntil(() => errors.isNotEmpty);
+
+        expect(connector.options, hasLength(1));
+        expect(streaming.state, MastodonStreamingConnectionState.disconnected);
+        expect(
+          errors.single,
+          isA<MastodonStreamingClosedException>()
+              .having((error) => error.closeCode, 'closeCode', 1005)
+              .having((error) => error.message, 'message', contains('invalid')),
+        );
+        await errorSubscription.cancel();
+        await streaming.dispose();
+      },
+    );
+
+    test('validates the token only after close code 1005', () async {
+      final socket = _FakeWebSocketConnection();
+      final replacement = _FakeWebSocketConnection();
+      var validations = 0;
+      final streaming = _streaming(
+        _FakeWebSocketConnector([socket, replacement]),
+        tokenValidator: () async {
+          validations++;
+          return true;
+        },
+      );
+      await streaming.connect();
+
+      await socket.closeFromServer(1011);
+      await _waitUntil(
+        () => streaming.state == MastodonStreamingConnectionState.connected,
+      );
+
+      expect(validations, 0);
+      await streaming.dispose();
+    });
   });
 
   test('reconnect backoff grows, includes jitter, and stays capped', () async {
@@ -304,6 +380,45 @@ void main() {
       await streaming.dispose();
     });
 
+    test('keeps typed hashtag and colon-named raw channels separate', () async {
+      final socket = _FakeWebSocketConnection();
+      final streaming = _streaming(_FakeWebSocketConnector([socket]));
+      await streaming.connect();
+
+      final typed = await streaming.subscribe(
+        const MastodonStream.hashtag('dart'),
+      );
+      final raw = await streaming.subscribeRaw('hashtag:dart');
+
+      expect(_sentFrames(socket, 'subscribe'), [
+        {'type': 'subscribe', 'stream': 'hashtag', 'tag': 'dart'},
+        {'type': 'subscribe', 'stream': 'hashtag:dart'},
+      ]);
+
+      await typed.cancel();
+      await raw.cancel();
+      await streaming.dispose();
+    });
+
+    test('shares equivalent typed and raw channel definitions', () async {
+      final socket = _FakeWebSocketConnection();
+      final streaming = _streaming(_FakeWebSocketConnector([socket]));
+      await streaming.connect();
+
+      final typed = await streaming.subscribe(
+        const MastodonStream.public(local: true),
+      );
+      final raw = await streaming.subscribeRaw('public:local');
+
+      expect(_sentFrames(socket, 'subscribe'), hasLength(1));
+      await typed.cancel();
+      expect(_sentFrames(socket, 'unsubscribe'), isEmpty);
+      await raw.cancel();
+      expect(_sentFrames(socket, 'unsubscribe'), hasLength(1));
+
+      await streaming.dispose();
+    });
+
     test('matches one- and two-element stream arrays', () async {
       final socket = _FakeWebSocketConnection();
       final streaming = _streaming(_FakeWebSocketConnector([socket]));
@@ -419,6 +534,54 @@ void main() {
       await streaming.dispose();
     });
 
+    test('dispose rejects a subscribe waiting for the error window', () async {
+      final socket = _FakeWebSocketConnection();
+      final errorWindow = Completer<void>();
+      final streaming = _streaming(
+        _FakeWebSocketConnector([socket]),
+        subscriptionDelay: (_) => errorWindow.future,
+      );
+      await streaming.connect();
+
+      final subscription = streaming.subscribe(const MastodonStream.user());
+      await _waitUntil(() => socket.sent.isNotEmpty);
+      final expectation = expectLater(subscription, throwsStateError);
+      await streaming.dispose();
+
+      await expectation;
+    });
+
+    test('does not cache a failed unsubscribe across cancel calls', () async {
+      final socket = _FakeWebSocketConnection();
+      final unsubscribeWindow = Completer<void>();
+      var operation = 0;
+      final streaming = _streaming(
+        _FakeWebSocketConnector([socket]),
+        subscriptionDelay: (_) {
+          operation++;
+          return operation == 1
+              ? Future<void>.value()
+              : unsubscribeWindow.future;
+        },
+      );
+      await streaming.connect();
+      final subscription = await streaming.subscribe(
+        const MastodonStream.user(),
+      );
+
+      final firstCancel = subscription.cancel();
+      final firstExpectation = expectLater(
+        firstCancel,
+        throwsA(isA<MastodonStreamingSubscriptionException>()),
+      );
+      await _waitUntil(() => _sentFrames(socket, 'unsubscribe').isNotEmpty);
+      socket.addFromServer(jsonEncode({'error': 'Could not unsubscribe'}));
+
+      await firstExpectation;
+      await expectLater(subscription.cancel(), completes);
+      await streaming.dispose();
+    });
+
     test('exposes statuses filtered from typed events', () async {
       final socket = _FakeWebSocketConnection();
       final streaming = _streaming(_FakeWebSocketConnector([socket]));
@@ -495,6 +658,7 @@ MastodonStreaming _streaming(
   Logger? logger,
   bool enableLog = false,
   MastodonStreamingReconnectCallback? onReconnect,
+  MastodonStreamingTokenValidator? tokenValidator,
   Future<void> Function(Duration duration)? delay,
   Future<void> Function(Duration duration)? subscriptionDelay,
   double Function()? jitterSource,
@@ -506,6 +670,7 @@ MastodonStreaming _streaming(
   logger: logger,
   enableLog: enableLog,
   onReconnect: onReconnect,
+  tokenValidator: tokenValidator,
   delay: delay ?? (_) async {},
   subscriptionDelay: subscriptionDelay ?? (_) async {},
   jitterSource: jitterSource ?? () => 0.5,

--- a/test/streaming/mastodon_streaming_test.dart
+++ b/test/streaming/mastodon_streaming_test.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
 
 import 'package:mastodon_client/mastodon_client.dart';
 import 'package:test/test.dart';
@@ -88,6 +90,25 @@ void main() {
       expect(connector.options, hasLength(1));
       expect(streaming.state, MastodonStreamingConnectionState.disconnected);
 
+      await streaming.dispose();
+    });
+
+    test('uses lazily resolved instance metadata for the endpoint', () async {
+      final connector = _FakeWebSocketConnector([_FakeWebSocketConnection()]);
+      final streaming = MastodonStreaming.withConnector(
+        baseUrl: 'https://rest.example',
+        accessToken: 'secret-token',
+        connector: connector,
+        metadataProvider: () async =>
+            (instance: null, instanceV1: _instanceV1('wss://stream.example')),
+      );
+
+      await streaming.connect();
+
+      expect(
+        connector.options.single.uri,
+        Uri.parse('wss://stream.example/api/v1/streaming'),
+      );
       await streaming.dispose();
     });
   });
@@ -233,6 +254,239 @@ void main() {
 
     await streaming.dispose();
   });
+
+  group('MastodonStreaming subscriptions', () {
+    test('reference counts duplicate subscriptions', () async {
+      final socket = _FakeWebSocketConnection();
+      final streaming = _streaming(_FakeWebSocketConnector([socket]));
+      await streaming.connect();
+
+      final first = await streaming.subscribe(const MastodonStream.user());
+      final second = await streaming.subscribe(const MastodonStream.user());
+
+      expect(_sentFrames(socket, 'subscribe'), hasLength(1));
+      await first.cancel();
+      expect(_sentFrames(socket, 'unsubscribe'), isEmpty);
+      await second.cancel();
+      expect(_sentFrames(socket, 'unsubscribe'), hasLength(1));
+
+      await streaming.dispose();
+    });
+
+    test('normalizes hashtag keys and inbound matching', () async {
+      final socket = _FakeWebSocketConnection();
+      final streaming = _streaming(_FakeWebSocketConnector([socket]));
+      await streaming.connect();
+
+      final upper = await streaming.subscribe(
+        const MastodonStream.hashtag('Dart'),
+      );
+      final lower = await streaming.subscribe(
+        const MastodonStream.hashtag('dart'),
+      );
+      final upperEvent = upper.events.first;
+      final lowerEvent = lower.events.first;
+
+      socket.addFromServer(
+        jsonEncode({
+          'stream': ['hashtag', 'DART'],
+          'event': 'delete',
+          'payload': '999888777',
+        }),
+      );
+
+      expect(_sentFrames(socket, 'subscribe'), hasLength(1));
+      expect(await upperEvent, isA<MastodonDeleteEvent>());
+      expect(await lowerEvent, isA<MastodonDeleteEvent>());
+
+      await upper.cancel();
+      await lower.cancel();
+      await streaming.dispose();
+    });
+
+    test('matches one- and two-element stream arrays', () async {
+      final socket = _FakeWebSocketConnection();
+      final streaming = _streaming(_FakeWebSocketConnector([socket]));
+      await streaming.connect();
+      final user = await streaming.subscribe(const MastodonStream.user());
+      final list = await streaming.subscribe(const MastodonStream.list('42'));
+      final userMessage = user.messages.first;
+      final listMessage = list.messages.first;
+
+      socket
+        ..addFromServer(
+          jsonEncode({
+            'stream': ['user'],
+            'event': 'delete',
+            'payload': '1',
+          }),
+        )
+        ..addFromServer(
+          jsonEncode({
+            'stream': ['list', '42'],
+            'event': 'delete',
+            'payload': '2',
+          }),
+        );
+
+      expect((await userMessage).stream, ['user']);
+      expect((await listMessage).stream, ['list', '42']);
+
+      await user.cancel();
+      await list.cancel();
+      await streaming.dispose();
+    });
+
+    test('restores every active subscription after reconnecting', () async {
+      final firstSocket = _FakeWebSocketConnection();
+      final secondSocket = _FakeWebSocketConnection();
+      final streaming = _streaming(
+        _FakeWebSocketConnector([firstSocket, secondSocket]),
+      );
+      await streaming.connect();
+      final user = await streaming.subscribe(const MastodonStream.user());
+      final list = await streaming.subscribe(const MastodonStream.list('42'));
+
+      await firstSocket.closeFromServer(1011);
+      await _waitUntil(
+        () => _sentFrames(secondSocket, 'subscribe').length == 2,
+      );
+
+      expect(
+        _sentFrames(secondSocket, 'subscribe').map((frame) => frame['stream']),
+        containsAll(['user', 'list']),
+      );
+
+      await user.cancel();
+      await list.cancel();
+      await streaming.dispose();
+    });
+
+    test('associates an immediate server error with subscribe', () async {
+      final socket = _FakeWebSocketConnection();
+      final errorWindow = Completer<void>();
+      final streaming = _streaming(
+        _FakeWebSocketConnector([socket]),
+        subscriptionDelay: (_) => errorWindow.future,
+      );
+      await streaming.connect();
+
+      final subscription = streaming.subscribeRaw('bogus');
+      await _waitUntil(() => socket.sent.isNotEmpty);
+      socket.addFromServer(
+        jsonEncode({'error': 'Unknown stream type', 'status': 400}),
+      );
+
+      await expectLater(
+        subscription,
+        throwsA(
+          isA<MastodonStreamingSubscriptionException>().having(
+            (error) => error.status,
+            'status',
+            400,
+          ),
+        ),
+      );
+
+      await streaming.dispose();
+    });
+
+    test('serializes subscription frames during the error window', () async {
+      final socket = _FakeWebSocketConnection();
+      final firstWindow = Completer<void>();
+      final secondWindow = Completer<void>();
+      final windows = [firstWindow, secondWindow];
+      var nextWindow = 0;
+      final streaming = _streaming(
+        _FakeWebSocketConnector([socket]),
+        subscriptionDelay: (_) => windows[nextWindow++].future,
+      );
+      await streaming.connect();
+
+      final user = streaming.subscribe(const MastodonStream.user());
+      await _waitUntil(() => socket.sent.length == 1);
+      final list = streaming.subscribe(const MastodonStream.list('42'));
+      await Future<void>.delayed(Duration.zero);
+      expect(socket.sent, hasLength(1));
+
+      firstWindow.complete();
+      await user;
+      await _waitUntil(() => socket.sent.length == 2);
+      secondWindow.complete();
+      await list;
+
+      expect(_sentFrames(socket, 'subscribe'), hasLength(2));
+      await streaming.dispose();
+    });
+
+    test('exposes statuses filtered from typed events', () async {
+      final socket = _FakeWebSocketConnection();
+      final streaming = _streaming(_FakeWebSocketConnector([socket]));
+      await streaming.connect();
+      final subscription = await streaming.subscribe(
+        const MastodonStream.public(),
+      );
+      final status =
+          jsonDecode(File('test/fixtures/status.json').readAsStringSync())
+              as Map<String, dynamic>;
+      final received = subscription.statuses.first;
+
+      socket.addFromServer(
+        jsonEncode({
+          'stream': ['public'],
+          'event': 'status.update',
+          'payload': jsonEncode(status),
+        }),
+      );
+
+      expect((await received).id, status['id']);
+      await subscription.cancel();
+      await streaming.dispose();
+    });
+
+    test(
+      'turns malformed payloads into Unknown without ending streams',
+      () async {
+        final socket = _FakeWebSocketConnection();
+        final streaming = _streaming(_FakeWebSocketConnector([socket]));
+        await streaming.connect();
+        final user = await streaming.subscribe(const MastodonStream.user());
+        final events = <MastodonStreamEvent>[];
+        final eventSubscription = user.events.listen(events.add);
+
+        socket
+          ..addFromServer(
+            jsonEncode({
+              'stream': ['user'],
+              'event': 'update',
+              'payload': '{bad json',
+            }),
+          )
+          ..addFromServer(
+            jsonEncode({
+              'stream': ['user'],
+              'event': 'delete',
+              'payload': '999888777',
+            }),
+          );
+        await _waitUntil(() => events.length == 2);
+
+        expect(events[0], isA<MastodonUnknownStreamEvent>());
+        expect(
+          events[1],
+          isA<MastodonDeleteEvent>().having(
+            (event) => event.statusId,
+            'statusId',
+            '999888777',
+          ),
+        );
+
+        await eventSubscription.cancel();
+        await user.cancel();
+        await streaming.dispose();
+      },
+    );
+  });
 }
 
 MastodonStreaming _streaming(
@@ -242,6 +496,7 @@ MastodonStreaming _streaming(
   bool enableLog = false,
   MastodonStreamingReconnectCallback? onReconnect,
   Future<void> Function(Duration duration)? delay,
+  Future<void> Function(Duration duration)? subscriptionDelay,
   double Function()? jitterSource,
 }) => MastodonStreaming.withConnector(
   baseUrl: 'https://mastodon.example',
@@ -252,7 +507,27 @@ MastodonStreaming _streaming(
   enableLog: enableLog,
   onReconnect: onReconnect,
   delay: delay ?? (_) async {},
+  subscriptionDelay: subscriptionDelay ?? (_) async {},
   jitterSource: jitterSource ?? () => 0.5,
+);
+
+List<Map<String, dynamic>> _sentFrames(
+  _FakeWebSocketConnection socket,
+  String type,
+) => socket.sent
+    .map((frame) => jsonDecode(frame) as Map<String, dynamic>)
+    .where((frame) => frame['type'] == type)
+    .toList();
+
+MastodonInstanceV1 _instanceV1(String streamingUrl) => MastodonInstanceV1(
+  uri: 'rest.example',
+  title: 'Test',
+  version: '3.5.0',
+  rules: const [],
+  urls: MastodonInstanceV1Urls(streamingApi: streamingUrl),
+  registrations: false,
+  approvalRequired: false,
+  invitesEnabled: false,
 );
 
 Future<void> _waitUntil(bool Function() condition) async {

--- a/test/streaming/mastodon_streaming_test.dart
+++ b/test/streaming/mastodon_streaming_test.dart
@@ -1,0 +1,325 @@
+import 'dart:async';
+
+import 'package:mastodon_client/mastodon_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MastodonStreaming authentication', () {
+    test(
+      'falls back across auth modes and remembers the successful mode',
+      () async {
+        final firstSocket = _FakeWebSocketConnection();
+        final replacementSocket = _FakeWebSocketConnection();
+        final connector = _FakeWebSocketConnector([
+          const WebSocketConnectorException(message: 'subprotocol rejected'),
+          const WebSocketConnectorException(message: 'header rejected'),
+          firstSocket,
+          replacementSocket,
+        ]);
+        var reconnects = 0;
+        final streaming = _streaming(
+          connector,
+          onReconnect: () => reconnects++,
+        );
+
+        await streaming.connect();
+
+        expect(connector.options, hasLength(3));
+        expect(connector.options[0].protocols, ['secret-token']);
+        expect(connector.options[0].headers, isEmpty);
+        expect(connector.options[0].pingInterval, const Duration(seconds: 30));
+        expect(connector.options[1].protocols, isEmpty);
+        expect(
+          connector.options[1].headers['Authorization'],
+          'Bearer secret-token',
+        );
+        expect(
+          connector.options[2].uri.queryParameters['access_token'],
+          'secret-token',
+        );
+        expect(
+          streaming.successfulAuthMode,
+          MastodonStreamingAuthMode.queryParameter,
+        );
+
+        await firstSocket.closeFromServer(1011);
+        await _waitUntil(() => connector.options.length == 4);
+
+        expect(
+          connector.options[3].uri.queryParameters['access_token'],
+          'secret-token',
+        );
+        expect(connector.options[3].protocols, isEmpty);
+        expect(reconnects, 1);
+
+        await streaming.dispose();
+      },
+    );
+
+    test('an HTTP 401 aborts fallback and automatic retries', () async {
+      final connector = _FakeWebSocketConnector([
+        const WebSocketConnectorException(
+          message: 'unauthorized',
+          statusCode: 401,
+        ),
+      ]);
+      final streaming = _streaming(connector);
+      final observedError = streaming.errors.first;
+
+      await expectLater(
+        streaming.connect(),
+        throwsA(
+          isA<MastodonStreamingConnectionException>().having(
+            (error) => error.statusCode,
+            'statusCode',
+            401,
+          ),
+        ),
+      );
+      expect(
+        await observedError,
+        isA<MastodonStreamingConnectionException>().having(
+          (error) => error.statusCode,
+          'statusCode',
+          401,
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(connector.options, hasLength(1));
+      expect(streaming.state, MastodonStreamingConnectionState.disconnected);
+
+      await streaming.dispose();
+    });
+  });
+
+  group('MastodonStreaming close handling', () {
+    for (final testCase in [
+      (code: 1000, reconnect: false, emitsError: false),
+      (code: 1005, reconnect: false, emitsError: true),
+      (code: 1003, reconnect: false, emitsError: true),
+      (code: 1011, reconnect: true, emitsError: true),
+    ]) {
+      test('handles close code ${testCase.code}', () async {
+        final socket = _FakeWebSocketConnection();
+        final replacement = _FakeWebSocketConnection();
+        final connector = _FakeWebSocketConnector([socket, replacement]);
+        final streaming = _streaming(connector);
+        final errors = <MastodonStreamingException>[];
+        final errorSubscription = streaming.errors.listen(errors.add);
+        await streaming.connect();
+
+        await socket.closeFromServer(testCase.code);
+        if (testCase.reconnect) {
+          await _waitUntil(() => connector.options.length == 2);
+          expect(streaming.state, MastodonStreamingConnectionState.connected);
+        } else {
+          await Future<void>.delayed(Duration.zero);
+          expect(connector.options, hasLength(1));
+          expect(
+            streaming.state,
+            MastodonStreamingConnectionState.disconnected,
+          );
+        }
+
+        if (testCase.emitsError) {
+          expect(
+            errors,
+            contains(
+              isA<MastodonStreamingClosedException>().having(
+                (error) => error.closeCode,
+                'closeCode',
+                testCase.code,
+              ),
+            ),
+          );
+        } else {
+          expect(errors, isEmpty);
+        }
+
+        await errorSubscription.cancel();
+        await streaming.dispose();
+      });
+    }
+  });
+
+  test('reconnect backoff grows, includes jitter, and stays capped', () async {
+    final socket = _FakeWebSocketConnection();
+    final connector = _FakeWebSocketConnector([socket]);
+    final delays = <Duration>[];
+    final streaming = _streaming(
+      connector,
+      config: MastodonStreamingConfig(
+        reconnectInitialDelay: const Duration(seconds: 1),
+        reconnectMaxDelay: const Duration(seconds: 4),
+        reconnectJitter: 0.5,
+        maxReconnectAttempts: 4,
+      ),
+      jitterSource: () => 1,
+      delay: (duration) async {
+        delays.add(duration);
+      },
+    );
+    await streaming.connect();
+
+    await socket.closeFromServer(1011);
+    await _waitUntil(() => delays.length == 4);
+
+    expect(delays, [
+      const Duration(milliseconds: 1500),
+      const Duration(seconds: 3),
+      const Duration(seconds: 4),
+      const Duration(seconds: 4),
+    ]);
+
+    await streaming.dispose();
+  });
+
+  test('logs redact query authentication tokens', () async {
+    final connector = _FakeWebSocketConnector([_FakeWebSocketConnection()]);
+    final messages = <String>[];
+    final streaming = _streaming(
+      connector,
+      config: MastodonStreamingConfig(
+        authMode: MastodonStreamingAuthMode.queryParameter,
+        enableAuthFallback: false,
+      ),
+      logger: FunctionLogger((level, message) => messages.add(message)),
+      enableLog: true,
+    );
+
+    await streaming.connect();
+
+    expect(messages.join('\n'), isNot(contains('secret-token')));
+    expect(messages.join('\n'), contains('access_token'));
+    expect(messages.join('\n'), contains('REDACTED'));
+
+    await streaming.dispose();
+  });
+
+  test('suspend closes the socket and resume reconnects immediately', () async {
+    final firstSocket = _FakeWebSocketConnection();
+    final secondSocket = _FakeWebSocketConnection();
+    final connector = _FakeWebSocketConnector([firstSocket, secondSocket]);
+    var reconnects = 0;
+    final streaming = _streaming(connector, onReconnect: () => reconnects++);
+    await streaming.connect();
+
+    await streaming.suspend();
+
+    expect(streaming.state, MastodonStreamingConnectionState.suspended);
+    expect(firstSocket.closedByClient, isTrue);
+    expect(connector.options, hasLength(1));
+
+    await streaming.resume();
+
+    expect(connector.options, hasLength(2));
+    expect(streaming.state, MastodonStreamingConnectionState.connected);
+    expect(reconnects, 1);
+
+    await streaming.dispose();
+  });
+
+  test('exposes raw text frames and a text-only send seam', () async {
+    final socket = _FakeWebSocketConnection();
+    final streaming = _streaming(_FakeWebSocketConnector([socket]));
+    await streaming.connect();
+    final received = streaming.rawFrames.first;
+
+    socket.addFromServer('{"event":"update"}');
+    streaming.sendText('{"type":"subscribe"}');
+
+    expect(await received, '{"event":"update"}');
+    expect(socket.sent, ['{"type":"subscribe"}']);
+
+    await streaming.dispose();
+  });
+}
+
+MastodonStreaming _streaming(
+  WebSocketConnector connector, {
+  MastodonStreamingConfig? config,
+  Logger? logger,
+  bool enableLog = false,
+  MastodonStreamingReconnectCallback? onReconnect,
+  Future<void> Function(Duration duration)? delay,
+  double Function()? jitterSource,
+}) => MastodonStreaming.withConnector(
+  baseUrl: 'https://mastodon.example',
+  accessToken: 'secret-token',
+  connector: connector,
+  config: config,
+  logger: logger,
+  enableLog: enableLog,
+  onReconnect: onReconnect,
+  delay: delay ?? (_) async {},
+  jitterSource: jitterSource ?? () => 0.5,
+);
+
+Future<void> _waitUntil(bool Function() condition) async {
+  for (var attempt = 0; attempt < 100; attempt++) {
+    if (condition()) {
+      return;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+  }
+  fail('Condition was not met before the test timeout');
+}
+
+final class _FakeWebSocketConnector implements WebSocketConnector {
+  _FakeWebSocketConnector(this._outcomes);
+
+  final List<Object> _outcomes;
+  final List<WebSocketConnectOptions> options = [];
+  var _nextOutcome = 0;
+
+  @override
+  Future<WebSocketConnection> connect(WebSocketConnectOptions options) async {
+    this.options.add(options);
+    if (_nextOutcome >= _outcomes.length) {
+      throw const WebSocketConnectorException(message: 'connection failed');
+    }
+    final outcome = _outcomes[_nextOutcome++];
+    if (outcome is WebSocketConnection) {
+      return outcome;
+    }
+    throw outcome;
+  }
+}
+
+final class _FakeWebSocketConnection implements WebSocketConnection {
+  final StreamController<Object?> _controller = StreamController<Object?>();
+  final List<String> sent = [];
+  int? _closeCode;
+  String? _closeReason;
+  bool closedByClient = false;
+
+  @override
+  Stream<Object?> get messages => _controller.stream;
+
+  @override
+  int? get closeCode => _closeCode;
+
+  @override
+  String? get closeReason => _closeReason;
+
+  @override
+  void sendText(String data) => sent.add(data);
+
+  void addFromServer(String data) => _controller.add(data);
+
+  Future<void> closeFromServer(int? code, [String? reason]) async {
+    _closeCode = code;
+    _closeReason = reason;
+    await _controller.close();
+  }
+
+  @override
+  Future<void> close([int? closeCode, String? closeReason]) async {
+    closedByClient = true;
+    _closeCode ??= closeCode;
+    _closeReason ??= closeReason;
+    if (!_controller.isClosed) {
+      await _controller.close();
+    }
+  }
+}

--- a/test/streaming/streaming_event_test.dart
+++ b/test/streaming/streaming_event_test.dart
@@ -1,0 +1,142 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:mastodon_client/mastodon_client.dart';
+import 'package:mastodon_client/src/streaming/internal/streaming_event_decoder.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('decodes an envelope with a double-encoded status payload', () {
+    final status = jsonDecode(
+      File('test/fixtures/status.json').readAsStringSync(),
+    );
+    final message = MastodonStreamingMessage.fromRaw(
+      jsonEncode({
+        'stream': ['public'],
+        'event': 'update',
+        'payload': jsonEncode(status),
+      }),
+    );
+
+    final event = decodeMastodonStreamEvent(message);
+
+    expect(message.stream, ['public']);
+    expect(message.payload, isA<String>());
+    expect(
+      event,
+      isA<MastodonUpdateEvent>().having(
+        (event) => event.status.id,
+        'status.id',
+        (status as Map<String, dynamic>)['id'],
+      ),
+    );
+  });
+
+  test('keeps a numeric delete payload as a String', () {
+    final message = MastodonStreamingMessage.fromRaw(
+      jsonEncode({
+        'stream': ['user'],
+        'event': 'delete',
+        'payload': '999888777',
+      }),
+    );
+
+    final event = decodeMastodonStreamEvent(message);
+
+    expect(
+      event,
+      isA<MastodonDeleteEvent>()
+          .having((event) => event.statusId, 'statusId', '999888777')
+          .having((event) => event.statusId, 'runtimeType', isA<String>()),
+    );
+  });
+
+  test('decodes the streaming announcement reaction model', () {
+    final reaction = jsonDecode(
+      File(
+        'test/fixtures/streaming_announcement_reaction.json',
+      ).readAsStringSync(),
+    );
+    final message = MastodonStreamingMessage.fromRaw(
+      jsonEncode({
+        'stream': ['user'],
+        'event': 'announcement.reaction',
+        'payload': jsonEncode(reaction),
+      }),
+    );
+
+    final event = decodeMastodonStreamEvent(message);
+
+    expect(
+      event,
+      isA<MastodonAnnouncementReactionEvent>().having(
+        (event) => event.reaction.announcementId,
+        'announcementId',
+        (reaction as Map<String, dynamic>)['announcement_id'],
+      ),
+    );
+  });
+
+  test('preserves unknown events and their raw payload', () {
+    final message = MastodonStreamingMessage.fromRaw(
+      jsonEncode({
+        'stream': ['user'],
+        'event': 'pleroma.custom',
+        'payload': '{"custom":true}',
+      }),
+    );
+
+    final event = decodeMastodonStreamEvent(message);
+
+    expect(
+      event,
+      isA<MastodonUnknownStreamEvent>()
+          .having((event) => event.event, 'event', 'pleroma.custom')
+          .having((event) => event.rawPayload, 'rawPayload', '{"custom":true}'),
+    );
+  });
+
+  test('falls back to Unknown when a known payload cannot be parsed', () {
+    final message = MastodonStreamingMessage.fromRaw(
+      jsonEncode({
+        'stream': ['user'],
+        'event': 'notification',
+        'payload': '{bad json',
+      }),
+    );
+
+    expect(
+      decodeMastodonStreamEvent(message),
+      isA<MastodonUnknownStreamEvent>().having(
+        (event) => event.event,
+        'event',
+        'notification',
+      ),
+    );
+  });
+
+  test('ignores payloads for payload-free events', () {
+    final merged = MastodonStreamingMessage.fromRaw(
+      jsonEncode({
+        'stream': ['user'],
+        'event': 'notifications_merged',
+        'payload': '1',
+      }),
+    );
+    final filters = MastodonStreamingMessage.fromRaw(
+      jsonEncode({
+        'stream': ['user'],
+        'event': 'filters_changed',
+      }),
+    );
+
+    expect(
+      decodeMastodonStreamEvent(merged),
+      isA<MastodonNotificationsMergedEvent>(),
+    );
+    expect(
+      decodeMastodonStreamEvent(filters),
+      isA<MastodonFiltersChangedEvent>(),
+    );
+  });
+}

--- a/test/streaming/streaming_stream_test.dart
+++ b/test/streaming/streaming_stream_test.dart
@@ -1,0 +1,58 @@
+import 'package:mastodon_client/mastodon_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('represents all twelve official stream names', () {
+    final streams = <MastodonStream>[
+      const MastodonStream.user(),
+      const MastodonStream.userNotification(),
+      const MastodonStream.public(),
+      const MastodonStream.public(local: true),
+      const MastodonStream.public(remote: true),
+      const MastodonStream.public(onlyMedia: true),
+      const MastodonStream.public(local: true, onlyMedia: true),
+      const MastodonStream.public(remote: true, onlyMedia: true),
+      const MastodonStream.hashtag('dart'),
+      const MastodonStream.hashtag('dart', local: true),
+      const MastodonStream.direct(),
+      const MastodonStream.list('42'),
+    ];
+
+    expect(streams.map((stream) => stream.name), [
+      'user',
+      'user:notification',
+      'public',
+      'public:local',
+      'public:remote',
+      'public:media',
+      'public:local:media',
+      'public:remote:media',
+      'hashtag',
+      'hashtag:local',
+      'direct',
+      'list',
+    ]);
+  });
+
+  test('rejects local and remote public flags together', () {
+    expect(
+      () => MastodonStream.public(local: true, remote: true),
+      throwsA(isA<AssertionError>()),
+    );
+  });
+
+  test('normalizes hashtag reference-counting keys', () {
+    const upper = MastodonStream.hashtag('Dart');
+    const lower = MastodonStream.hashtag('dart');
+
+    expect(upper.params, {'tag': 'Dart'});
+    expect(upper.key, lower.key);
+  });
+
+  test('uses list ID as the list parameter and key suffix', () {
+    const stream = MastodonStream.list('42');
+
+    expect(stream.params, {'list': '42'});
+    expect(stream.key, 'list:42');
+  });
+}

--- a/test/streaming/streaming_stream_test.dart
+++ b/test/streaming/streaming_stream_test.dart
@@ -49,10 +49,25 @@ void main() {
     expect(upper.key, lower.key);
   });
 
-  test('uses list ID as the list parameter and key suffix', () {
+  test('uses the list ID in the list parameter and structured key', () {
     const stream = MastodonStream.list('42');
 
     expect(stream.params, {'list': '42'});
-    expect(stream.key, 'list:42');
+    expect(stream.key, MastodonStream.keyFor('list', const {'list': '42'}));
+  });
+
+  test('builds keys from channel names and normalized parameters', () {
+    expect(
+      MastodonStream.keyFor('hashtag', const {'tag': 'Dart'}),
+      MastodonStream.keyFor('hashtag', const {'tag': 'dart'}),
+    );
+    expect(
+      MastodonStream.keyFor('hashtag', const {'tag': 'dart'}),
+      isNot(MastodonStream.keyFor('hashtag:dart', const {})),
+    );
+    expect(
+      const MastodonStream.public(local: true).key,
+      MastodonStream.keyFor('public:local', const {}),
+    );
   });
 }

--- a/test/streaming/streaming_url_resolver_test.dart
+++ b/test/streaming/streaming_url_resolver_test.dart
@@ -1,0 +1,128 @@
+import 'package:mastodon_client/mastodon_client.dart';
+import 'package:mastodon_client/src/streaming/streaming_url_resolver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const resolver = StreamingUrlResolver();
+
+  group('StreamingUrlResolver source selection', () {
+    test('prefers the v2 URL and supports a separate host', () {
+      final uri = resolver.resolve(
+        baseUrl: 'https://rest.example',
+        instance: _v2('wss://v2-stream.example'),
+        instanceV1: _v1('wss://v1-stream.example'),
+      );
+
+      expect(uri, Uri.parse('wss://v2-stream.example/api/v1/streaming'));
+    });
+
+    test('falls back to the v1 URL when v2 has no URL', () {
+      final uri = resolver.resolve(
+        baseUrl: 'https://rest.example',
+        instance: _v2(null),
+        instanceV1: _v1('wss://v1-stream.example'),
+      );
+
+      expect(uri, Uri.parse('wss://v1-stream.example/api/v1/streaming'));
+    });
+
+    test('falls back to the REST host when instance URLs are absent', () {
+      final uri = resolver.resolve(
+        baseUrl: 'https://rest.example:8443/rest/path',
+        instance: _v2(null),
+        instanceV1: _v1(null),
+      );
+
+      expect(uri, Uri.parse('wss://rest.example:8443/api/v1/streaming'));
+    });
+
+    test('treats blank instance URLs as absent', () {
+      final uri = resolver.resolve(
+        baseUrl: 'https://rest.example',
+        instance: _v2('  '),
+        instanceV1: _v1(' streaming.example '),
+      );
+
+      expect(uri, Uri.parse('wss://streaming.example/api/v1/streaming'));
+    });
+  });
+
+  group('StreamingUrlResolver normalization', () {
+    test('converts HTTP schemes and preserves WebSocket schemes', () {
+      final cases = <String, String>{
+        'http://stream.example': 'ws://stream.example/api/v1/streaming',
+        'https://stream.example': 'wss://stream.example/api/v1/streaming',
+        'ws://stream.example': 'ws://stream.example/api/v1/streaming',
+        'wss://stream.example': 'wss://stream.example/api/v1/streaming',
+      };
+
+      for (final entry in cases.entries) {
+        expect(
+          resolver.resolve(
+            baseUrl: 'https://rest.example',
+            instance: _v2(entry.key),
+          ),
+          Uri.parse(entry.value),
+          reason: entry.key,
+        );
+      }
+    });
+
+    test('assumes HTTPS when the scheme is omitted', () {
+      final uri = resolver.resolve(
+        baseUrl: 'https://rest.example',
+        instance: _v2('stream.example:9443'),
+      );
+
+      expect(uri, Uri.parse('wss://stream.example:9443/api/v1/streaming'));
+    });
+
+    test('removes a trailing slash before appending the path', () {
+      final uri = resolver.resolve(
+        baseUrl: 'https://rest.example',
+        instance: _v2('https://stream.example/custom///'),
+      );
+
+      expect(uri, Uri.parse('wss://stream.example/custom/api/v1/streaming'));
+    });
+
+    test('does not duplicate an existing streaming path', () {
+      final uri = resolver.resolve(
+        baseUrl: 'https://rest.example',
+        instance: _v2('https://stream.example/api/v1/streaming/'),
+      );
+
+      expect(uri, Uri.parse('wss://stream.example/api/v1/streaming'));
+    });
+
+    test('appends the streaming path to an existing prefix', () {
+      final uri = resolver.resolve(
+        baseUrl: 'https://rest.example',
+        instance: _v2('https://stream.example/mastodon'),
+      );
+
+      expect(uri, Uri.parse('wss://stream.example/mastodon/api/v1/streaming'));
+    });
+  });
+}
+
+MastodonInstance _v2(String? streamingUrl) => MastodonInstance(
+  domain: 'rest.example',
+  title: 'Test',
+  version: '4.6.3',
+  configuration: MastodonInstanceConfiguration(
+    urls: MastodonInstanceUrls(streaming: streamingUrl),
+  ),
+  rules: const [],
+);
+
+MastodonInstanceV1 _v1(String? streamingUrl) => MastodonInstanceV1(
+  uri: 'rest.example',
+  title: 'Test',
+  version: '3.5.0',
+  rules: const [],
+  urls: MastodonInstanceV1Urls(streamingApi: streamingUrl),
+  registrations: false,
+  approvalRequired: false,
+  invitesEnabled: false,
+);


### PR DESCRIPTION
## 概要

issue #21 の Streaming API (WebSocket) を実装し、`client.streaming` として公開する。

pub.dev の Dart エコシステムには実用に耐える Mastodon streaming 実装が存在しなかったため、本パッケージが唯一の実用実装となる。仕様は issue #21 の調査（Mastodon v4.6.3 の streaming サーバのソース読解と実サーバへの実接続による実測）に完全に従っている。

Closes #21

## 実装

単一の WebSocket にすべての購読を多重化し、接続先はインスタンス情報から自動解決する。`client.streaming` へのアクセスだけでは接続は開かず、REST のみの利用者は WebSocket を一切開かない。

```dart
await client.streaming.connect();

final home = await client.streaming.subscribe(const MastodonStream.user());
home.events.listen((event) {
  switch (event) {
    case MastodonUpdateEvent(:final status): /* ... */
    case MastodonDeleteEvent(:final statusId): /* ... */
    default: break;
  }
});

await home.cancel();
await client.dispose();
```

- `MastodonStream`（sealed）で全 12 ストリームを表現
- 購読ハンドルは `events` / `statuses` / `messages` の 3 層
- 未知ストリーム向けに `subscribeRaw`
- 認証 3 方式（既定 `subprotocol`）とフォールバック、成功モードの記憶
- close code 別の再接続判定、指数バックオフ + ジッタ、`suspend()` / `resume()`
- 再接続後の全購読の自動再送
- `MastodonClient.dispose()` と `HealthApi.checkStreaming()` を新設

## issue で挙がっていた落とし穴への対応

実測で確認された落とし穴は、コードとドキュメンテーションコメントの両方で対処している。

- **payload の二重パース** — `delete` / `announcement.delete` はイベント名で分岐して生の ID 文字列として扱い、`"999888777"` が `int` にパースされないようにした
- **サブプロトコルは必ず 1 個だけ** — 2 個渡すと `"mastodon, <token>"` がそのままトークン扱いされて 401 になる事故を回避
- **接続時 401 の即時例外化** — リトライループに入らない
- **参照カウント** — 0→1 でのみ subscribe、1→0 でのみ unsubscribe。ハッシュタグのキーは正規化し、大文字小文字違いの二重購読事故を防ぐ
- **逐次 subscribe** — ack も相関 ID も無いため、購読は逐次送信して直後のエラーを直近の subscribe に紐づける
- **`onlyMedia` はストリーム名に反映** — `only_media` パラメータは WS で無視されるため
- **ログのトークンマスク** — URL・ログ・例外のいずれにもトークンを出さない

`read:statuses` のみのトークンで通知が来ないこと、`filters_changed` が v4.3+ で配送されないこと、`user` + `user:notification` の二重通知、言語フィルタ / フィード公開設定によるサイレントドロップ、切断中イベントが補填されないことは、ドキュメンテーションコメント・README・docs に明記した。

## テスト

- ユニットテスト **279 件**（URL 解決・正規化、payload の二重パース、未知イベントのフォールバック、参照カウント、ハッシュタグ正規化、`stream` 配列の突き合わせ、close code 別の再接続判定、認証フォールバック、バックオフとジッタ、トークンマスク、`suspend()` / `resume()`）
- E2E テスト（`test/e2e/mastodon_streaming_e2e_test.dart`、`e2e` タグ）。自己署名 CA を信頼する `WebSocketConnector` を `E2eEnv` に用意し、接続・購読・イベント受信・未知ストリームのエラーを検証する

## ドキュメント

- README 6 言語（en / ja / zh-Hans / de / fr / ko）に Streaming セクションを追加
- docs サイトに `api/streaming` を 6 言語分追加
- CHANGELOG の `[Unreleased]` に記載

## レビューと修正

実装後に 2 系統の独立したコードレビューを実施し、指摘 5 件を修正した（`9c549ac`）。

- close code 1005 でトークンを検証してから再接続を判断する（未指定時は保守的に再接続しない）
- `dispose()` や接続切り替えと進行中の `subscribe()` が競合した場合に、閉じたハンドルを返さず `StateError` を投げる
- 参照カウントのキーを `name` + 正規化 params の構造化キーにし、typed と raw の衝突を解消（`public:local` の typed / raw 共有は維持）
- `HealthApi.checkStreaming()` がボディをトリムしてから比較する
- `cancel()` が失敗した Future をキャッシュしないようにする

Web では WebSocket ハンドシェイクの HTTP ステータスを取得できず 401 を識別できない制約、および `subscriptionErrorWindow` の既定値と `subscribe()` 応答時間のトレードオフは、既定値を変えずドキュメンテーションコメントに明記した。

## 検証

- `dart format --output=none --set-exit-if-changed .` — 0 changed
- `dart analyze --fatal-infos` — No issues found
- `dart run build_runner build` — 生成物をコミット済み
- `dart test --exclude-tags e2e` — 279 passed
- `dart pub publish --dry-run` — 0 warnings

## 補足

依存追加は `web_socket_channel` のみ。既存の公開 API に破壊的変更は無い。SSE、切断中イベントの自動穴埋め、`tokenProvider` 化は issue #21 のスコープ外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
