### PR TITLE
fix: MastodonSuggestion.sourceのnullを許容

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `MastodonHttpClient` now retains and exposes `baseUrl`, `accessToken`, and `enableLog` (issue #21)
+- **Breaking:** `MastodonSuggestion.source` is now nullable and deprecated in
+  favor of `sources`. This prevents deserialization failures when Mastodon
+  returns `null` or omits the legacy source value (issue #18)
 
 ## [1.0.0-beta.2] - 2026-08-13
 

--- a/lib/src/models/mastodon_suggestion.dart
+++ b/lib/src/models/mastodon_suggestion.dart
@@ -9,7 +9,9 @@ part 'mastodon_suggestion.g.dart';
 class MastodonSuggestion {
   /// Creates a [MastodonSuggestion] with the given fields.
   const MastodonSuggestion({
-    required this.source,
+    // ignore: remove_deprecations_in_breaking_versions
+    @Deprecated('Deprecated in Mastodon 4.3.0. Use sources instead')
+    this.source,
     required this.account,
     this.sources = const <String>[],
   });
@@ -21,12 +23,15 @@ class MastodonSuggestion {
   /// Serializes to JSON.
   Map<String, dynamic> toJson() => _$MastodonSuggestionToJson(this);
 
-  /// String indicating the reason for the suggestion.
+  /// Legacy string indicating the reason for the suggestion.
   ///
   /// Officially defined values are `staff` (staff recommendation),
   /// `past_interactions` (based on past interactions), and
-  /// `global` (based on global popularity).
-  final String source;
+  /// `global` (based on global popularity). This can be `null` when the server
+  /// does not provide a legacy value or cannot map an entry from [sources].
+  // ignore: remove_deprecations_in_breaking_versions
+  @Deprecated('Deprecated in Mastodon 4.3.0. Use sources instead')
+  final String? source;
 
   /// Suggested account.
   final MastodonAccount account;
@@ -34,9 +39,9 @@ class MastodonSuggestion {
   /// Reasons for the suggestion, in the current (non-legacy) vocabulary.
   ///
   /// Values include `featured`, `most_followed`, `most_interactions`,
-  /// `similar_to_recently_followed` and `friends_of_friends`. [source] is a
-  /// lossy mapping of the first entry onto the legacy three-value vocabulary,
-  /// so prefer this field when distinguishing suggestion reasons.
+  /// `similar_to_recently_followed` and `friends_of_friends`. The legacy source
+  /// field is a lossy mapping of the first entry onto the legacy three-value
+  /// vocabulary, so prefer this field when distinguishing suggestion reasons.
   @JsonKey(defaultValue: <String>[])
   final List<String> sources;
 }

--- a/lib/src/models/mastodon_suggestion.g.dart
+++ b/lib/src/models/mastodon_suggestion.g.dart
@@ -11,7 +11,7 @@ part of 'mastodon_suggestion.dart';
 MastodonSuggestion _$MastodonSuggestionFromJson(
   Map<String, dynamic> json,
 ) => MastodonSuggestion(
-  source: json['source'] as String,
+  source: json['source'] as String?,
   account: MastodonAccount.fromJson(json['account'] as Map<String, dynamic>),
   sources:
       (json['sources'] as List<dynamic>?)?.map((e) => e as String).toList() ??

--- a/test/models/mastodon_suggestion_test.dart
+++ b/test/models/mastodon_suggestion_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'dart:convert';
 import 'dart:io';
 import 'package:mastodon_client/mastodon_client.dart';
@@ -81,6 +83,31 @@ void main() {
       final suggestion = MastodonSuggestion.fromJson(json);
 
       expect(suggestion.account.note, '<p>A great person to follow.</p>');
+    });
+
+    test('deserializes a null legacy source for a FASP suggestion', () {
+      final json = <String, dynamic>{
+        'source': null,
+        'sources': <String>['fasp'],
+        'account': _minimalAccountJson(),
+      };
+
+      final suggestion = MastodonSuggestion.fromJson(json);
+
+      expect(suggestion.source, isNull);
+      expect(suggestion.sources, <String>['fasp']);
+    });
+
+    test('deserializes a suggestion when the legacy source is absent', () {
+      final json = <String, dynamic>{
+        'sources': <String>['featured'],
+        'account': _minimalAccountJson(),
+      };
+
+      final suggestion = MastodonSuggestion.fromJson(json);
+
+      expect(suggestion.source, isNull);
+      expect(suggestion.sources, <String>['featured']);
     });
   });
 


### PR DESCRIPTION
## 概要

`MastodonSuggestion.source`をnullableかつdeprecatedに変更し、Mastodonがlegacy sourceを`null`で返す場合やキーを省略する場合でも`/api/v2/suggestions`をデシリアライズできるようにします。

Closes #18

## 背景

Mastodon v4.6.3ではFASP由来の候補が`sources: ["fasp"]`を返し得ますが、legacy sourceの変換表に`fasp`がないため、`source`は`null`になります。従来の`json["source"] as String`ではこの応答で型キャスト例外が発生します。

## 変更内容

- `MastodonSuggestion.source`を`String?`へ変更
- コンストラクタ引数をoptionalに変更
- Mastodon 4.3.0以降の公式仕様に合わせて`source`をdeprecated化し、`sources`への移行を案内
- `source: null`となるFASP応答と、`source`キー欠落の回帰テストを追加
- CHANGELOGへ破壊的変更として記載

## 互換性

`source`のgetter型が`String`から`String?`になるため、利用側でnull対応が必要となる破壊的変更です。旧サーバーが返す文字列`source`と、`sources`を持たない従来形式は引き続きデシリアライズできます。

## 検証

- `dart run build_runner build`
- `dart analyze`: No issues found
- `dart test`: 281 passed、E2E 4件は環境未設定のためskip
- `dart test test/models/mastodon_suggestion_test.dart`: 9 passed
- コミット前に別エージェントで差分レビューを実施: 指摘なし