### PR TITLE
fix: MastodonCollectionのtag型とitemsを修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** `MastodonCollection.tag` is now a
+  `MastodonCollectionTag?` object instead of `String?`, matching Mastodon's
+  `{name, url}` response. `MastodonCollection.items` now exposes collection
+  item IDs, states, creation times, and conditional account IDs (issue #11)
 - **Breaking:** Added value equality (`==` / `hashCode`) and `copyWith` to all
-  121 JSON response models with Freezed. Existing constructors and JSON
+  JSON response models with Freezed. Existing constructors and JSON
   behavior are preserved, while generated `toString` output is disabled to
   avoid exposing model contents in logs (issue #29)
 - `MastodonHttpClient` now retains and exposes `baseUrl`, `accessToken`, and `enableLog` (issue #21)

--- a/lib/src/models/mastodon_collection.dart
+++ b/lib/src/models/mastodon_collection.dart
@@ -27,6 +27,7 @@ class MastodonCollection with _$MastodonCollection {
     this.createdAt,
     this.updatedAt,
     this.tag,
+    this.items = const <MastodonCollectionItem>[],
   });
 
   factory MastodonCollection.fromJson(Map<String, dynamic> json) =>
@@ -91,5 +92,65 @@ class MastodonCollection with _$MastodonCollection {
 
   /// Hashtag associated with the collection, if any.
   @override
-  final String? tag;
+  final MastodonCollectionTag? tag;
+
+  /// Items included in the collection for the authenticated account.
+  @JsonKey(defaultValue: <MastodonCollectionItem>[])
+  @override
+  final List<MastodonCollectionItem> items;
+}
+
+/// A shallow hashtag embedded in a collection.
+@Freezed(toStringOverride: false)
+@JsonSerializable(fieldRename: FieldRename.snake)
+class MastodonCollectionTag with _$MastodonCollectionTag {
+  const MastodonCollectionTag({required this.name, required this.url});
+
+  factory MastodonCollectionTag.fromJson(Map<String, dynamic> json) =>
+      _$MastodonCollectionTagFromJson(json);
+
+  /// Serializes to JSON.
+  Map<String, dynamic> toJson() => _$MastodonCollectionTagToJson(this);
+
+  /// Name of the hashtag without the `#` symbol.
+  @override
+  final String name;
+
+  /// URL to the hashtag on the instance.
+  @override
+  final String url;
+}
+
+/// An item included in a collection.
+@Freezed(toStringOverride: false)
+@JsonSerializable(fieldRename: FieldRename.snake)
+class MastodonCollectionItem with _$MastodonCollectionItem {
+  const MastodonCollectionItem({
+    required this.id,
+    required this.state,
+    required this.createdAt,
+    this.accountId,
+  });
+
+  factory MastodonCollectionItem.fromJson(Map<String, dynamic> json) =>
+      _$MastodonCollectionItemFromJson(json);
+
+  /// Serializes to JSON.
+  Map<String, dynamic> toJson() => _$MastodonCollectionItemToJson(this);
+
+  /// Internal ID of the collection item.
+  @override
+  final String id;
+
+  /// Moderation state of the item.
+  @override
+  final String state;
+
+  /// Date and time the item was created.
+  @override
+  final DateTime createdAt;
+
+  /// ID of the associated account for pending or accepted items.
+  @override
+  final String? accountId;
 }

--- a/lib/src/models/mastodon_collection.freezed.dart
+++ b/lib/src/models/mastodon_collection.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$MastodonCollection {
 
- String get id; String? get uri; String get name; String? get description; String? get language; String? get accountId; bool? get local; bool? get sensitive; bool? get discoverable; String? get url; int? get itemCount; DateTime? get createdAt; DateTime? get updatedAt; String? get tag;
+ String get id; String? get uri; String get name; String? get description; String? get language; String? get accountId; bool? get local; bool? get sensitive; bool? get discoverable; String? get url; int? get itemCount; DateTime? get createdAt; DateTime? get updatedAt; MastodonCollectionTag? get tag; List<MastodonCollectionItem> get items;
 /// Create a copy of MastodonCollection
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,12 +26,12 @@ $MastodonCollectionCopyWith<MastodonCollection> get copyWith => _$MastodonCollec
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonCollection&&(identical(other.id, id) || other.id == id)&&(identical(other.uri, uri) || other.uri == uri)&&(identical(other.name, name) || other.name == name)&&(identical(other.description, description) || other.description == description)&&(identical(other.language, language) || other.language == language)&&(identical(other.accountId, accountId) || other.accountId == accountId)&&(identical(other.local, local) || other.local == local)&&(identical(other.sensitive, sensitive) || other.sensitive == sensitive)&&(identical(other.discoverable, discoverable) || other.discoverable == discoverable)&&(identical(other.url, url) || other.url == url)&&(identical(other.itemCount, itemCount) || other.itemCount == itemCount)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.tag, tag) || other.tag == tag));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonCollection&&(identical(other.id, id) || other.id == id)&&(identical(other.uri, uri) || other.uri == uri)&&(identical(other.name, name) || other.name == name)&&(identical(other.description, description) || other.description == description)&&(identical(other.language, language) || other.language == language)&&(identical(other.accountId, accountId) || other.accountId == accountId)&&(identical(other.local, local) || other.local == local)&&(identical(other.sensitive, sensitive) || other.sensitive == sensitive)&&(identical(other.discoverable, discoverable) || other.discoverable == discoverable)&&(identical(other.url, url) || other.url == url)&&(identical(other.itemCount, itemCount) || other.itemCount == itemCount)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.tag, tag) || other.tag == tag)&&const DeepCollectionEquality().equals(other.items, items));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,uri,name,description,language,accountId,local,sensitive,discoverable,url,itemCount,createdAt,updatedAt,tag);
+int get hashCode => Object.hash(runtimeType,id,uri,name,description,language,accountId,local,sensitive,discoverable,url,itemCount,createdAt,updatedAt,tag,const DeepCollectionEquality().hash(items));
 
 
 
@@ -42,7 +42,7 @@ abstract mixin class $MastodonCollectionCopyWith<$Res>  {
   factory $MastodonCollectionCopyWith(MastodonCollection value, $Res Function(MastodonCollection) _then) = _$MastodonCollectionCopyWithImpl;
 @useResult
 $Res call({
- String id, String? uri, String name, String? description, String? language, String? accountId, bool? local, bool? sensitive, bool? discoverable, String? url, int? itemCount, DateTime? createdAt, DateTime? updatedAt, String? tag
+ String id, String? uri, String name, String? description, String? language, String? accountId, bool? local, bool? sensitive, bool? discoverable, String? url, int? itemCount, DateTime? createdAt, DateTime? updatedAt, MastodonCollectionTag? tag, List<MastodonCollectionItem> items
 });
 
 
@@ -59,7 +59,7 @@ class _$MastodonCollectionCopyWithImpl<$Res>
 
 /// Create a copy of MastodonCollection
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? uri = freezed,Object? name = null,Object? description = freezed,Object? language = freezed,Object? accountId = freezed,Object? local = freezed,Object? sensitive = freezed,Object? discoverable = freezed,Object? url = freezed,Object? itemCount = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,Object? tag = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? uri = freezed,Object? name = null,Object? description = freezed,Object? language = freezed,Object? accountId = freezed,Object? local = freezed,Object? sensitive = freezed,Object? discoverable = freezed,Object? url = freezed,Object? itemCount = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,Object? tag = freezed,Object? items = null,}) {
   return _then(MastodonCollection(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,uri: freezed == uri ? _self.uri : uri // ignore: cast_nullable_to_non_nullable
@@ -75,7 +75,8 @@ as String?,itemCount: freezed == itemCount ? _self.itemCount : itemCount // igno
 as int?,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,tag: freezed == tag ? _self.tag : tag // ignore: cast_nullable_to_non_nullable
-as String?,
+as MastodonCollectionTag?,items: null == items ? _self.items : items // ignore: cast_nullable_to_non_nullable
+as List<MastodonCollectionItem>,
   ));
 }
 
@@ -84,6 +85,374 @@ as String?,
 
 /// Adds pattern-matching-related methods to [MastodonCollection].
 extension MastodonCollectionPatterns on MastodonCollection {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+
+/// @nodoc
+mixin _$MastodonCollectionTag {
+
+ String get name; String get url;
+/// Create a copy of MastodonCollectionTag
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MastodonCollectionTagCopyWith<MastodonCollectionTag> get copyWith => _$MastodonCollectionTagCopyWithImpl<MastodonCollectionTag>(this as MastodonCollectionTag, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonCollectionTag&&(identical(other.name, name) || other.name == name)&&(identical(other.url, url) || other.url == url));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,url);
+
+
+
+}
+
+/// @nodoc
+abstract mixin class $MastodonCollectionTagCopyWith<$Res>  {
+  factory $MastodonCollectionTagCopyWith(MastodonCollectionTag value, $Res Function(MastodonCollectionTag) _then) = _$MastodonCollectionTagCopyWithImpl;
+@useResult
+$Res call({
+ String name, String url
+});
+
+
+
+
+}
+/// @nodoc
+class _$MastodonCollectionTagCopyWithImpl<$Res>
+    implements $MastodonCollectionTagCopyWith<$Res> {
+  _$MastodonCollectionTagCopyWithImpl(this._self, this._then);
+
+  final MastodonCollectionTag _self;
+  final $Res Function(MastodonCollectionTag) _then;
+
+/// Create a copy of MastodonCollectionTag
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? name = null,Object? url = null,}) {
+  return _then(MastodonCollectionTag(
+name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [MastodonCollectionTag].
+extension MastodonCollectionTagPatterns on MastodonCollectionTag {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+
+/// @nodoc
+mixin _$MastodonCollectionItem {
+
+ String get id; String get state; DateTime get createdAt; String? get accountId;
+/// Create a copy of MastodonCollectionItem
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MastodonCollectionItemCopyWith<MastodonCollectionItem> get copyWith => _$MastodonCollectionItemCopyWithImpl<MastodonCollectionItem>(this as MastodonCollectionItem, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonCollectionItem&&(identical(other.id, id) || other.id == id)&&(identical(other.state, state) || other.state == state)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.accountId, accountId) || other.accountId == accountId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,state,createdAt,accountId);
+
+
+
+}
+
+/// @nodoc
+abstract mixin class $MastodonCollectionItemCopyWith<$Res>  {
+  factory $MastodonCollectionItemCopyWith(MastodonCollectionItem value, $Res Function(MastodonCollectionItem) _then) = _$MastodonCollectionItemCopyWithImpl;
+@useResult
+$Res call({
+ String id, String state, DateTime createdAt, String? accountId
+});
+
+
+
+
+}
+/// @nodoc
+class _$MastodonCollectionItemCopyWithImpl<$Res>
+    implements $MastodonCollectionItemCopyWith<$Res> {
+  _$MastodonCollectionItemCopyWithImpl(this._self, this._then);
+
+  final MastodonCollectionItem _self;
+  final $Res Function(MastodonCollectionItem) _then;
+
+/// Create a copy of MastodonCollectionItem
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? state = null,Object? createdAt = null,Object? accountId = freezed,}) {
+  return _then(MastodonCollectionItem(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,state: null == state ? _self.state : state // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,accountId: freezed == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [MastodonCollectionItem].
+extension MastodonCollectionItemPatterns on MastodonCollectionItem {
 /// A variant of `map` that fallback to returning `orElse`.
 ///
 /// It is equivalent to doing:

--- a/lib/src/models/mastodon_collection.g.dart
+++ b/lib/src/models/mastodon_collection.g.dart
@@ -27,7 +27,17 @@ MastodonCollection _$MastodonCollectionFromJson(Map<String, dynamic> json) =>
       updatedAt: const SafeDateTimeConverter().fromJson(
         json['updated_at'] as String?,
       ),
-      tag: json['tag'] as String?,
+      tag: json['tag'] == null
+          ? null
+          : MastodonCollectionTag.fromJson(json['tag'] as Map<String, dynamic>),
+      items:
+          (json['items'] as List<dynamic>?)
+              ?.map(
+                (e) =>
+                    MastodonCollectionItem.fromJson(e as Map<String, dynamic>),
+              )
+              .toList() ??
+          [],
     );
 
 Map<String, dynamic> _$MastodonCollectionToJson(MastodonCollection instance) =>
@@ -45,5 +55,35 @@ Map<String, dynamic> _$MastodonCollectionToJson(MastodonCollection instance) =>
       'item_count': instance.itemCount,
       'created_at': const SafeDateTimeConverter().toJson(instance.createdAt),
       'updated_at': const SafeDateTimeConverter().toJson(instance.updatedAt),
-      'tag': instance.tag,
+      'tag': instance.tag?.toJson(),
+      'items': instance.items.map((e) => e.toJson()).toList(),
     };
+
+MastodonCollectionTag _$MastodonCollectionTagFromJson(
+  Map<String, dynamic> json,
+) => MastodonCollectionTag(
+  name: json['name'] as String,
+  url: json['url'] as String,
+);
+
+Map<String, dynamic> _$MastodonCollectionTagToJson(
+  MastodonCollectionTag instance,
+) => <String, dynamic>{'name': instance.name, 'url': instance.url};
+
+MastodonCollectionItem _$MastodonCollectionItemFromJson(
+  Map<String, dynamic> json,
+) => MastodonCollectionItem(
+  id: json['id'] as String,
+  state: json['state'] as String,
+  createdAt: DateTime.parse(json['created_at'] as String),
+  accountId: json['account_id'] as String?,
+);
+
+Map<String, dynamic> _$MastodonCollectionItemToJson(
+  MastodonCollectionItem instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'state': instance.state,
+  'created_at': instance.createdAt.toIso8601String(),
+  'account_id': instance.accountId,
+};

--- a/test/fixtures/collection_tagged.json
+++ b/test/fixtures/collection_tagged.json
@@ -1,0 +1,11 @@
+{
+  "id": "117036905954333172",
+  "name": "probe-tagged",
+  "sensitive": false,
+  "discoverable": true,
+  "tag": {
+    "name": "probetag",
+    "url": "https://mastodon.test/tags/probetag"
+  },
+  "items": []
+}

--- a/test/models/fixture_key_coverage_test.dart
+++ b/test/models/fixture_key_coverage_test.dart
@@ -28,7 +28,6 @@ void main() {
   const outstandingGaps = <String, Set<String>>{
     'preview_card.json': {'language', 'image_description', 'published_at'},
     'media_attachment.json': {'preview_remote_url', 'text_url', 'meta'},
-    'collection.json': {'items'},
   };
 
   final cases = <String, Map<String, dynamic> Function(Map<String, dynamic>)>{
@@ -50,6 +49,8 @@ void main() {
     'media_attachment.json': (json) =>
         MastodonMediaAttachment.fromJson(json).toJson(),
     'collection.json': (json) => MastodonCollection.fromJson(json).toJson(),
+    'collection_tagged.json': (json) =>
+        MastodonCollection.fromJson(json).toJson(),
     'streaming_announcement_reaction.json': (json) =>
         MastodonStreamingAnnouncementReaction.fromJson(json).toJson(),
   };

--- a/test/models/freezed_model_test.dart
+++ b/test/models/freezed_model_test.dart
@@ -55,7 +55,7 @@ void main() {
         freezedCount += fileFreezedCount;
       }
 
-      expect(jsonSerializableCount, 121);
+      expect(jsonSerializableCount, 123);
       expect(freezedCount, jsonSerializableCount);
     });
 

--- a/test/models/mastodon_collection_test.dart
+++ b/test/models/mastodon_collection_test.dart
@@ -19,7 +19,43 @@ void main() {
       expect(collection.itemCount, 0);
       expect(collection.description, isNull);
       expect(collection.tag, isNull);
+      expect(collection.items, isEmpty);
       expect(collection.createdAt, isA<DateTime>());
+    });
+
+    test('deserializes a shallow tag returned by Mastodon 4.6.3', () {
+      final file = File('test/fixtures/collection_tagged.json');
+      final json = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+      final collection = MastodonCollection.fromJson(json);
+
+      expect(collection.tag, isNotNull);
+      expect(collection.tag!.name, 'probetag');
+      expect(collection.tag!.url, 'https://mastodon.test/tags/probetag');
+    });
+
+    test('deserializes collection items with conditional account IDs', () {
+      final collection = MastodonCollection.fromJson({
+        'id': 'collection-id',
+        'name': 'collection',
+        'items': <Map<String, dynamic>>[
+          {
+            'id': 'pending-item',
+            'state': 'pending',
+            'created_at': '2026-08-04T11:22:47.000Z',
+            'account_id': 'account-id',
+          },
+          {
+            'id': 'rejected-item',
+            'state': 'rejected',
+            'created_at': '2026-08-04T11:23:47.000Z',
+          },
+        ],
+      });
+
+      expect(collection.items, hasLength(2));
+      expect(collection.items.first.accountId, 'account-id');
+      expect(collection.items.first.createdAt, isA<DateTime>());
+      expect(collection.items.last.accountId, isNull);
     });
   });
 

--- a/test/models/mastodon_status_test.dart
+++ b/test/models/mastodon_status_test.dart
@@ -61,6 +61,24 @@ void main() {
       expect(status.taggedCollections.first.name, collection['name']);
     });
 
+    test('deserializes a collection with an embedded shallow tag', () {
+      final file = File('test/fixtures/status.json');
+      final json = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+      final collection =
+          jsonDecode(
+                File('test/fixtures/collection_tagged.json').readAsStringSync(),
+              )
+              as Map<String, dynamic>;
+
+      final status = MastodonStatus.fromJson({
+        ...json,
+        'tagged_collections': <Map<String, dynamic>>[collection],
+      });
+
+      expect(status.taggedCollections, hasLength(1));
+      expect(status.taggedCollections.single.tag?.name, 'probetag');
+    });
+
     test('defaults to an empty list on servers older than 4.6.0', () {
       final file = File('test/fixtures/status.json');
       final json = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>


### PR DESCRIPTION
## 概要

Mastodon 4.6.3が返すCollectionレスポンスにモデルを合わせ、タグ付きコレクションを含む投稿のデシリアライズ失敗を修正します。

## 変更内容

- `MastodonCollection.tag`を`String?`から`MastodonCollectionTag?`へ変更
- `MastodonCollectionItem`と`MastodonCollection.items`を追加
- `account_id`が欠落するcollection itemをnullableとして処理
- タグ付きfixtureと`MastodonStatus.taggedCollections`経由の回帰テストを追加
- fixture key coverageとCHANGELOGを更新

## 検証

- `dart analyze`: No issues found
- `dart test`: 292件成功、E2E 4件は環境未設定のためskip
- サブエージェントによる独立レビュー: no findings

Closes #11