### PR TITLE
fix: 削除済みfetchCardを非推奨化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** `MastodonSuggestion.source` is now nullable and deprecated in
   favor of `sources`. This prevents deserialization failures when Mastodon
   returns `null` or omits the legacy source value (issue #18)
+- Deprecated `StatusesApi.fetchCard()`, whose endpoint was removed in Mastodon
+  3.0.0. Use the `card` property returned by `StatusesApi.fetch()` instead.
+  `fetchCard()` is retained for Mastodon 2.x compatibility and will be removed
+  in the next major version (issue #12)
 
 ## [1.0.0-beta.2] - 2026-08-13
 
@@ -67,7 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tests covering the `unknownEnumValue` fallback for `MastodonFilterAction`, `MastodonTimelineAccessLevel`, `MastodonPreviewCardType`, `MastodonMediaType`, `MastodonVisibility`, `MastodonAdminIpBlockSeverity`, and `MastodonAdminDomainBlockSeverity` when the server returns a value not yet known to this client
 - Tests for the HTTP error conversion logic (`convertDioException`): all status-code branches (401/403/404/422/429/5xx/unmapped), error body parsing (`{"error": "..."}` extraction and fallbacks), retry-after header parsing, and network-level errors (connection/timeout/cancel)
 - Tests pinning the `int` → `String` coercion of `MastodonRole.id` and `MastodonAdminRole.id`, and the deserialization of every Mastodon 4.6.0 field from a live server response
-- `MastodonStatus.card`, exposing the link preview as a `MastodonPreviewCard`. From Mastodon 4.6.0 this is the only way to obtain a status's preview card, as `GET /api/v1/statuses/:id/card` was removed
+- `MastodonStatus.card`, exposing the link preview as a `MastodonPreviewCard`. Mastodon added this field in 2.6.0 as the replacement for `GET /api/v1/statuses/:id/card`, then removed the dedicated endpoint in 3.0.0
 - `MastodonStatus.filtered`, listing the filters a status matched for the authenticated user as `MastodonFilterResult`s. Without it, the v2 filters already implemented in `FiltersApi` could not be honoured on the timeline side
 - `MastodonStatus.application`, the app a status was posted from, as a `MastodonStatusApplication` (`name` / `website` only — the status API does not disclose client credentials)
 - `MastodonStatus.quoteApproval` (as `MastodonQuoteApproval`) and `MastodonStatus.quotesCount` (Mastodon 4.5.0)

--- a/lib/src/api/statuses_api.dart
+++ b/lib/src/api/statuses_api.dart
@@ -94,7 +94,13 @@ class StatusesApi {
   ///
   /// `GET /api/v1/statuses/{id}/card`
   ///
+  /// **Deprecated in Mastodon 2.6.0, removed in 3.0.0.**
+  /// Use the [MastodonStatus.card] property returned by [fetch] instead.
+  /// This method is retained only for compatibility with Mastodon 2.x.
+  ///
   /// Throws a `MastodonException` on failure.
+  // ignore: remove_deprecations_in_breaking_versions
+  @Deprecated('Removed in Mastodon 3.0.0. Use (await fetch(id)).card instead')
   Future<MastodonPreviewCard> fetchCard(String id) async {
     final data = await _http.send<Map<String, dynamic>>(
       '/api/v1/statuses/$id/card',

--- a/lib/src/models/mastodon_preview_card.dart
+++ b/lib/src/models/mastodon_preview_card.dart
@@ -21,7 +21,8 @@ enum MastodonPreviewCardType {
 
 /// Preview card for a link.
 ///
-/// Corresponds to the response from `GET /api/v1/statuses/:id/card`.
+/// Embedded in the `MastodonStatus.card` property since Mastodon 2.6.0.
+/// The former `GET /api/v1/statuses/:id/card` endpoint was removed in 3.0.0.
 @Freezed(toStringOverride: false)
 @JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonPreviewCard with _$MastodonPreviewCard {

--- a/lib/src/models/mastodon_status.dart
+++ b/lib/src/models/mastodon_status.dart
@@ -237,9 +237,8 @@ class MastodonStatus with _$MastodonStatus {
   /// Link preview card for the first link in the status.
   ///
   /// Null when the status contains no link, or when the card has not been
-  /// fetched yet. From Mastodon 4.6.0 this is the only way to obtain a
-  /// status's preview card; the dedicated `GET /api/v1/statuses/:id/card`
-  /// endpoint was removed.
+  /// fetched yet. Added in Mastodon 2.6.0 as the replacement for the dedicated
+  /// `GET /api/v1/statuses/:id/card` endpoint, which was removed in 3.0.0.
   @override
   final MastodonPreviewCard? card;
 


### PR DESCRIPTION
## 概要

削除済みの `GET /api/v1/statuses/:id/card` を呼ぶ `StatusesApi.fetchCard()` を非推奨化し、現行の `MastodonStatus.card` への移行を案内します。

公式のバージョン履歴を再確認した結果、`MastodonStatus.card` は Mastodon 2.6.0で追加され、専用エンドポイントは同バージョンで非推奨化、3.0.0で削除されていました。従来の「4.6.0から唯一の取得経路」という記述も併せて訂正します。

## 変更内容

- `StatusesApi.fetchCard()` に `@Deprecated` を追加
- docコメントで `(await fetch(id)).card` への移行を案内
- `MastodonStatus.card` と `MastodonPreviewCard` のバージョン履歴を訂正
- CHANGELOGに非推奨化と次期メジャーバージョンでの削除予定を記載
- v1.0.0-beta.2のCHANGELOGに含まれていた不正確な履歴を訂正

## 検証

- `dart format`: 変更なし
- `dart analyze`: No issues found
- `dart test`: 292 tests passed
  - E2E 4件は環境未起動のため既定どおりskip

Closes #12
