### PR TITLE
feat: Mastodon 4.6のモデルとパラメータを補完 (#17)

### DIFF
--- a/lib/src/api/accounts_api.dart
+++ b/lib/src/api/accounts_api.dart
@@ -181,9 +181,10 @@ class AccountsApi {
   /// when omitted). Pass the last status ID as [maxId] to page backward,
   /// or use [minId] for forward pagination; [sinceId] returns only statuses
   /// newer than that ID. Set [excludeReplies] or [excludeReblogs] to `true`
-  /// to omit replies or boosts respectively. [onlyMedia] restricts results
-  /// to statuses with media attachments, [pinned] to pinned statuses only,
-  /// and [tagged] filters to statuses containing the specified hashtag.
+  /// to omit replies or boosts respectively. Set [excludeDirect] to omit
+  /// direct mentions (Mastodon 4.6+). [onlyMedia] restricts results to
+  /// statuses with media attachments, [pinned] to pinned statuses only, and
+  /// [tagged] filters to statuses containing the specified hashtag.
   ///
   /// Throws a subclass of [MastodonException] on failure.
   Future<MastodonPage<MastodonStatus>> fetchStatuses(
@@ -194,6 +195,7 @@ class AccountsApi {
     String? minId,
     bool? excludeReplies,
     bool? excludeReblogs,
+    bool? excludeDirect,
     bool? onlyMedia,
     bool? pinned,
     String? tagged,
@@ -207,6 +209,7 @@ class AccountsApi {
         'min_id': ?minId,
         'exclude_replies': ?excludeReplies,
         'exclude_reblogs': ?excludeReblogs,
+        'exclude_direct': ?excludeDirect,
         'only_media': ?onlyMedia,
         'pinned': ?pinned,
         'tagged': ?tagged,

--- a/lib/src/api/grouped_notifications_api.dart
+++ b/lib/src/api/grouped_notifications_api.dart
@@ -31,6 +31,8 @@ class GroupedNotificationsApi {
   /// sets the account expansion method (`full` or `partial_avatars`).
   /// [groupedTypes] lists the notification types to group, and
   /// [includeFiltered] controls whether filtered notifications are included.
+  /// [supportedTypes] tells Mastodon which types the client can render so
+  /// unsupported notifications include fallback text (Mastodon 4.6+).
   ///
   /// Pagination cursors are parsed from the `Link` response header and
   /// stored in [MastodonPage]. [MastodonPage.items] contains a single
@@ -45,6 +47,7 @@ class GroupedNotificationsApi {
     String? accountId,
     String? expandAccounts,
     List<String>? groupedTypes,
+    List<String>? supportedTypes,
     bool? includeFiltered,
   }) async {
     final query = <String, dynamic>{
@@ -60,6 +63,8 @@ class GroupedNotificationsApi {
         'expand_accounts': expandAccounts,
       if (groupedTypes != null && groupedTypes.isNotEmpty)
         'grouped_types[]': groupedTypes,
+      if (supportedTypes != null && supportedTypes.isNotEmpty)
+        'supported_types[]': supportedTypes,
       'include_filtered': ?includeFiltered,
     };
     final response = await _http.sendRaw<Map<String, dynamic>>(
@@ -81,10 +86,15 @@ class GroupedNotificationsApi {
   ///
   /// `GET /api/v2/notifications/:group_key`
   Future<MastodonGroupedNotificationsResults> fetchByGroupKey(
-    String groupKey,
-  ) async {
+    String groupKey, {
+    List<String>? supportedTypes,
+  }) async {
     final data = await _http.send<Map<String, dynamic>>(
       '/api/v2/notifications/$groupKey',
+      queryParameters: <String, dynamic>{
+        if (supportedTypes != null && supportedTypes.isNotEmpty)
+          'supported_types[]': supportedTypes,
+      },
     );
     return MastodonGroupedNotificationsResults.fromJson(data!);
   }

--- a/lib/src/api/notifications_api.dart
+++ b/lib/src/api/notifications_api.dart
@@ -21,7 +21,9 @@ class NotificationsApi {
   /// older ones, and [minId] for immediate forward pagination. [types]
   /// and [excludeTypes] filter by notification type. [accountId] restricts
   /// results to a specific account, and [includeFiltered] controls whether
-  /// filtered notifications are included.
+  /// filtered notifications are included. [supportedTypes] tells Mastodon
+  /// which types the client can render so unsupported notifications include
+  /// a fallback title and summary (Mastodon 4.6+).
   Future<MastodonPage<MastodonNotification>> fetch({
     int? limit,
     String? sinceId,
@@ -29,6 +31,7 @@ class NotificationsApi {
     String? minId,
     List<String>? types,
     List<String>? excludeTypes,
+    List<String>? supportedTypes,
     String? accountId,
     bool? includeFiltered,
   }) async {
@@ -40,6 +43,8 @@ class NotificationsApi {
       if (types != null && types.isNotEmpty) 'types[]': types,
       if (excludeTypes != null && excludeTypes.isNotEmpty)
         'exclude_types[]': excludeTypes,
+      if (supportedTypes != null && supportedTypes.isNotEmpty)
+        'supported_types[]': supportedTypes,
       if (accountId != null && accountId.isNotEmpty) 'account_id': accountId,
       'include_filtered': ?includeFiltered,
     };
@@ -62,9 +67,16 @@ class NotificationsApi {
   /// Fetches a notification by its ID.
   ///
   /// `GET /api/v1/notifications/:id`
-  Future<MastodonNotification> fetchById(String id) async {
+  Future<MastodonNotification> fetchById(
+    String id, {
+    List<String>? supportedTypes,
+  }) async {
     final data = await _http.send<Map<String, dynamic>>(
       '/api/v1/notifications/$id',
+      queryParameters: <String, dynamic>{
+        if (supportedTypes != null && supportedTypes.isNotEmpty)
+          'supported_types[]': supportedTypes,
+      },
     );
     return MastodonNotification.fromJson(data!);
   }

--- a/lib/src/models/admin/mastodon_admin_trends_link.dart
+++ b/lib/src/models/admin/mastodon_admin_trends_link.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import '../json_converters.dart';
 import '../mastodon_preview_card.dart';
 import '../mastodon_trends_link.dart';
 
@@ -29,8 +30,12 @@ class MastodonAdminTrendsLink with _$MastodonAdminTrendsLink {
     required this.embedUrl,
     required this.authors,
     required this.history,
+    this.language,
     this.image,
+    this.imageDescription = '',
     this.blurhash,
+    this.publishedAt,
+    this.missingAttribution,
     this.requiresReview,
   });
 
@@ -60,6 +65,10 @@ class MastodonAdminTrendsLink with _$MastodonAdminTrendsLink {
   @JsonKey(defaultValue: '')
   @override
   final String description;
+
+  /// ISO 639 language code detected for the linked content.
+  @override
+  final String? language;
 
   /// Type of the preview card.
   @JsonKey(readValue: _readType, unknownEnumValue: MastodonPreviewCardType.link)
@@ -105,6 +114,11 @@ class MastodonAdminTrendsLink with _$MastodonAdminTrendsLink {
   @override
   final String? image;
 
+  /// Alternative text for the preview image.
+  @JsonKey(defaultValue: '')
+  @override
+  final String imageDescription;
+
   /// URL for embedding photos.
   @JsonKey(defaultValue: '')
   @override
@@ -113,6 +127,15 @@ class MastodonAdminTrendsLink with _$MastodonAdminTrendsLink {
   /// Blurhash string for the thumbnail.
   @override
   final String? blurhash;
+
+  /// Publication timestamp of the linked content.
+  @SafeDateTimeConverter()
+  @override
+  final DateTime? publishedAt;
+
+  /// Whether the current user is an author whose attribution is missing.
+  @override
+  final bool? missingAttribution;
 
   /// List of content authors (Mastodon 4.3.0+).
   @JsonKey(defaultValue: <MastodonPreviewCardAuthor>[])

--- a/lib/src/models/admin/mastodon_admin_trends_link.freezed.dart
+++ b/lib/src/models/admin/mastodon_admin_trends_link.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$MastodonAdminTrendsLink {
 
- String get id; String get url; String get title; String get description; MastodonPreviewCardType get type; String get authorName; String get authorUrl; String get providerName; String get providerUrl; String get html; int get width; int get height; String? get image; String get embedUrl; String? get blurhash; List<MastodonPreviewCardAuthor> get authors; List<MastodonTrendsLinkHistory> get history; bool? get requiresReview;
+ String get id; String get url; String get title; String get description; String? get language; MastodonPreviewCardType get type; String get authorName; String get authorUrl; String get providerName; String get providerUrl; String get html; int get width; int get height; String? get image; String get imageDescription; String get embedUrl; String? get blurhash; DateTime? get publishedAt; bool? get missingAttribution; List<MastodonPreviewCardAuthor> get authors; List<MastodonTrendsLinkHistory> get history; bool? get requiresReview;
 /// Create a copy of MastodonAdminTrendsLink
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,12 +26,12 @@ $MastodonAdminTrendsLinkCopyWith<MastodonAdminTrendsLink> get copyWith => _$Mast
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonAdminTrendsLink&&(identical(other.id, id) || other.id == id)&&(identical(other.url, url) || other.url == url)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.type, type) || other.type == type)&&(identical(other.authorName, authorName) || other.authorName == authorName)&&(identical(other.authorUrl, authorUrl) || other.authorUrl == authorUrl)&&(identical(other.providerName, providerName) || other.providerName == providerName)&&(identical(other.providerUrl, providerUrl) || other.providerUrl == providerUrl)&&(identical(other.html, html) || other.html == html)&&(identical(other.width, width) || other.width == width)&&(identical(other.height, height) || other.height == height)&&(identical(other.image, image) || other.image == image)&&(identical(other.embedUrl, embedUrl) || other.embedUrl == embedUrl)&&(identical(other.blurhash, blurhash) || other.blurhash == blurhash)&&const DeepCollectionEquality().equals(other.authors, authors)&&const DeepCollectionEquality().equals(other.history, history)&&(identical(other.requiresReview, requiresReview) || other.requiresReview == requiresReview));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonAdminTrendsLink&&(identical(other.id, id) || other.id == id)&&(identical(other.url, url) || other.url == url)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.language, language) || other.language == language)&&(identical(other.type, type) || other.type == type)&&(identical(other.authorName, authorName) || other.authorName == authorName)&&(identical(other.authorUrl, authorUrl) || other.authorUrl == authorUrl)&&(identical(other.providerName, providerName) || other.providerName == providerName)&&(identical(other.providerUrl, providerUrl) || other.providerUrl == providerUrl)&&(identical(other.html, html) || other.html == html)&&(identical(other.width, width) || other.width == width)&&(identical(other.height, height) || other.height == height)&&(identical(other.image, image) || other.image == image)&&(identical(other.imageDescription, imageDescription) || other.imageDescription == imageDescription)&&(identical(other.embedUrl, embedUrl) || other.embedUrl == embedUrl)&&(identical(other.blurhash, blurhash) || other.blurhash == blurhash)&&(identical(other.publishedAt, publishedAt) || other.publishedAt == publishedAt)&&(identical(other.missingAttribution, missingAttribution) || other.missingAttribution == missingAttribution)&&const DeepCollectionEquality().equals(other.authors, authors)&&const DeepCollectionEquality().equals(other.history, history)&&(identical(other.requiresReview, requiresReview) || other.requiresReview == requiresReview));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,url,title,description,type,authorName,authorUrl,providerName,providerUrl,html,width,height,image,embedUrl,blurhash,const DeepCollectionEquality().hash(authors),const DeepCollectionEquality().hash(history),requiresReview);
+int get hashCode => Object.hashAll([runtimeType,id,url,title,description,language,type,authorName,authorUrl,providerName,providerUrl,html,width,height,image,imageDescription,embedUrl,blurhash,publishedAt,missingAttribution,const DeepCollectionEquality().hash(authors),const DeepCollectionEquality().hash(history),requiresReview]);
 
 
 
@@ -42,7 +42,7 @@ abstract mixin class $MastodonAdminTrendsLinkCopyWith<$Res>  {
   factory $MastodonAdminTrendsLinkCopyWith(MastodonAdminTrendsLink value, $Res Function(MastodonAdminTrendsLink) _then) = _$MastodonAdminTrendsLinkCopyWithImpl;
 @useResult
 $Res call({
- String id, String url, String title, String description, MastodonPreviewCardType type, String authorName, String authorUrl, String providerName, String providerUrl, String html, int width, int height, String embedUrl, List<MastodonPreviewCardAuthor> authors, List<MastodonTrendsLinkHistory> history, String? image, String? blurhash, bool? requiresReview
+ String id, String url, String title, String description, MastodonPreviewCardType type, String authorName, String authorUrl, String providerName, String providerUrl, String html, int width, int height, String embedUrl, List<MastodonPreviewCardAuthor> authors, List<MastodonTrendsLinkHistory> history, String? language, String? image, String imageDescription, String? blurhash, DateTime? publishedAt, bool? missingAttribution, bool? requiresReview
 });
 
 
@@ -59,7 +59,7 @@ class _$MastodonAdminTrendsLinkCopyWithImpl<$Res>
 
 /// Create a copy of MastodonAdminTrendsLink
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? url = null,Object? title = null,Object? description = null,Object? type = null,Object? authorName = null,Object? authorUrl = null,Object? providerName = null,Object? providerUrl = null,Object? html = null,Object? width = null,Object? height = null,Object? embedUrl = null,Object? authors = null,Object? history = null,Object? image = freezed,Object? blurhash = freezed,Object? requiresReview = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? url = null,Object? title = null,Object? description = null,Object? type = null,Object? authorName = null,Object? authorUrl = null,Object? providerName = null,Object? providerUrl = null,Object? html = null,Object? width = null,Object? height = null,Object? embedUrl = null,Object? authors = null,Object? history = null,Object? language = freezed,Object? image = freezed,Object? imageDescription = null,Object? blurhash = freezed,Object? publishedAt = freezed,Object? missingAttribution = freezed,Object? requiresReview = freezed,}) {
   return _then(MastodonAdminTrendsLink(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
@@ -76,9 +76,13 @@ as int,height: null == height ? _self.height : height // ignore: cast_nullable_t
 as int,embedUrl: null == embedUrl ? _self.embedUrl : embedUrl // ignore: cast_nullable_to_non_nullable
 as String,authors: null == authors ? _self.authors : authors // ignore: cast_nullable_to_non_nullable
 as List<MastodonPreviewCardAuthor>,history: null == history ? _self.history : history // ignore: cast_nullable_to_non_nullable
-as List<MastodonTrendsLinkHistory>,image: freezed == image ? _self.image : image // ignore: cast_nullable_to_non_nullable
-as String?,blurhash: freezed == blurhash ? _self.blurhash : blurhash // ignore: cast_nullable_to_non_nullable
-as String?,requiresReview: freezed == requiresReview ? _self.requiresReview : requiresReview // ignore: cast_nullable_to_non_nullable
+as List<MastodonTrendsLinkHistory>,language: freezed == language ? _self.language : language // ignore: cast_nullable_to_non_nullable
+as String?,image: freezed == image ? _self.image : image // ignore: cast_nullable_to_non_nullable
+as String?,imageDescription: null == imageDescription ? _self.imageDescription : imageDescription // ignore: cast_nullable_to_non_nullable
+as String,blurhash: freezed == blurhash ? _self.blurhash : blurhash // ignore: cast_nullable_to_non_nullable
+as String?,publishedAt: freezed == publishedAt ? _self.publishedAt : publishedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,missingAttribution: freezed == missingAttribution ? _self.missingAttribution : missingAttribution // ignore: cast_nullable_to_non_nullable
+as bool?,requiresReview: freezed == requiresReview ? _self.requiresReview : requiresReview // ignore: cast_nullable_to_non_nullable
 as bool?,
   ));
 }

--- a/lib/src/models/admin/mastodon_admin_trends_link.g.dart
+++ b/lib/src/models/admin/mastodon_admin_trends_link.g.dart
@@ -44,8 +44,14 @@ MastodonAdminTrendsLink _$MastodonAdminTrendsLinkFromJson(
           )
           .toList() ??
       [],
+  language: json['language'] as String?,
   image: json['image'] as String?,
+  imageDescription: json['image_description'] as String? ?? '',
   blurhash: json['blurhash'] as String?,
+  publishedAt: const SafeDateTimeConverter().fromJson(
+    json['published_at'] as String?,
+  ),
+  missingAttribution: json['missing_attribution'] as bool?,
   requiresReview: json['requires_review'] as bool?,
 );
 
@@ -56,6 +62,7 @@ Map<String, dynamic> _$MastodonAdminTrendsLinkToJson(
   'url': instance.url,
   'title': instance.title,
   'description': instance.description,
+  'language': instance.language,
   'type': _$MastodonPreviewCardTypeEnumMap[instance.type]!,
   'author_name': instance.authorName,
   'author_url': instance.authorUrl,
@@ -65,8 +72,11 @@ Map<String, dynamic> _$MastodonAdminTrendsLinkToJson(
   'width': instance.width,
   'height': instance.height,
   'image': instance.image,
+  'image_description': instance.imageDescription,
   'embed_url': instance.embedUrl,
   'blurhash': instance.blurhash,
+  'published_at': const SafeDateTimeConverter().toJson(instance.publishedAt),
+  'missing_attribution': instance.missingAttribution,
   'authors': instance.authors.map((e) => e.toJson()).toList(),
   'history': instance.history.map((e) => e.toJson()).toList(),
   'requires_review': instance.requiresReview,

--- a/lib/src/models/mastodon_instance.dart
+++ b/lib/src/models/mastodon_instance.dart
@@ -284,6 +284,10 @@ class MastodonPollsConfiguration with _$MastodonPollsConfiguration {
 @JsonSerializable(fieldRename: FieldRename.snake)
 class MastodonAccountsConfiguration with _$MastodonAccountsConfiguration {
   const MastodonAccountsConfiguration({
+    this.maxDisplayNameLength = 40,
+    this.maxNoteLength = 500,
+    this.maxAvatarDescriptionLength = 150,
+    this.maxHeaderDescriptionLength = 150,
     required this.maxFeaturedTags,
     required this.maxPinnedStatuses,
     required this.maxProfileFields,
@@ -296,6 +300,26 @@ class MastodonAccountsConfiguration with _$MastodonAccountsConfiguration {
 
   /// Serializes to JSON.
   Map<String, dynamic> toJson() => _$MastodonAccountsConfigurationToJson(this);
+
+  /// Maximum character count for display names.
+  @JsonKey(defaultValue: 40)
+  @override
+  final int maxDisplayNameLength;
+
+  /// Maximum character count for profile notes.
+  @JsonKey(defaultValue: 500)
+  @override
+  final int maxNoteLength;
+
+  /// Maximum character count for avatar descriptions.
+  @JsonKey(defaultValue: 150)
+  @override
+  final int maxAvatarDescriptionLength;
+
+  /// Maximum character count for header descriptions.
+  @JsonKey(defaultValue: 150)
+  @override
+  final int maxHeaderDescriptionLength;
 
   /// Maximum number of featured tags.
   @JsonKey(defaultValue: 10)

--- a/lib/src/models/mastodon_instance.freezed.dart
+++ b/lib/src/models/mastodon_instance.freezed.dart
@@ -1308,7 +1308,7 @@ case _:
 /// @nodoc
 mixin _$MastodonAccountsConfiguration {
 
- int get maxFeaturedTags; int get maxPinnedStatuses; int get maxProfileFields; int get profileFieldNameLimit; int get profileFieldValueLimit;
+ int get maxDisplayNameLength; int get maxNoteLength; int get maxAvatarDescriptionLength; int get maxHeaderDescriptionLength; int get maxFeaturedTags; int get maxPinnedStatuses; int get maxProfileFields; int get profileFieldNameLimit; int get profileFieldValueLimit;
 /// Create a copy of MastodonAccountsConfiguration
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1319,12 +1319,12 @@ $MastodonAccountsConfigurationCopyWith<MastodonAccountsConfiguration> get copyWi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonAccountsConfiguration&&(identical(other.maxFeaturedTags, maxFeaturedTags) || other.maxFeaturedTags == maxFeaturedTags)&&(identical(other.maxPinnedStatuses, maxPinnedStatuses) || other.maxPinnedStatuses == maxPinnedStatuses)&&(identical(other.maxProfileFields, maxProfileFields) || other.maxProfileFields == maxProfileFields)&&(identical(other.profileFieldNameLimit, profileFieldNameLimit) || other.profileFieldNameLimit == profileFieldNameLimit)&&(identical(other.profileFieldValueLimit, profileFieldValueLimit) || other.profileFieldValueLimit == profileFieldValueLimit));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonAccountsConfiguration&&(identical(other.maxDisplayNameLength, maxDisplayNameLength) || other.maxDisplayNameLength == maxDisplayNameLength)&&(identical(other.maxNoteLength, maxNoteLength) || other.maxNoteLength == maxNoteLength)&&(identical(other.maxAvatarDescriptionLength, maxAvatarDescriptionLength) || other.maxAvatarDescriptionLength == maxAvatarDescriptionLength)&&(identical(other.maxHeaderDescriptionLength, maxHeaderDescriptionLength) || other.maxHeaderDescriptionLength == maxHeaderDescriptionLength)&&(identical(other.maxFeaturedTags, maxFeaturedTags) || other.maxFeaturedTags == maxFeaturedTags)&&(identical(other.maxPinnedStatuses, maxPinnedStatuses) || other.maxPinnedStatuses == maxPinnedStatuses)&&(identical(other.maxProfileFields, maxProfileFields) || other.maxProfileFields == maxProfileFields)&&(identical(other.profileFieldNameLimit, profileFieldNameLimit) || other.profileFieldNameLimit == profileFieldNameLimit)&&(identical(other.profileFieldValueLimit, profileFieldValueLimit) || other.profileFieldValueLimit == profileFieldValueLimit));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,maxFeaturedTags,maxPinnedStatuses,maxProfileFields,profileFieldNameLimit,profileFieldValueLimit);
+int get hashCode => Object.hash(runtimeType,maxDisplayNameLength,maxNoteLength,maxAvatarDescriptionLength,maxHeaderDescriptionLength,maxFeaturedTags,maxPinnedStatuses,maxProfileFields,profileFieldNameLimit,profileFieldValueLimit);
 
 
 
@@ -1335,7 +1335,7 @@ abstract mixin class $MastodonAccountsConfigurationCopyWith<$Res>  {
   factory $MastodonAccountsConfigurationCopyWith(MastodonAccountsConfiguration value, $Res Function(MastodonAccountsConfiguration) _then) = _$MastodonAccountsConfigurationCopyWithImpl;
 @useResult
 $Res call({
- int maxFeaturedTags, int maxPinnedStatuses, int maxProfileFields, int profileFieldNameLimit, int profileFieldValueLimit
+ int maxDisplayNameLength, int maxNoteLength, int maxAvatarDescriptionLength, int maxHeaderDescriptionLength, int maxFeaturedTags, int maxPinnedStatuses, int maxProfileFields, int profileFieldNameLimit, int profileFieldValueLimit
 });
 
 
@@ -1352,9 +1352,13 @@ class _$MastodonAccountsConfigurationCopyWithImpl<$Res>
 
 /// Create a copy of MastodonAccountsConfiguration
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? maxFeaturedTags = null,Object? maxPinnedStatuses = null,Object? maxProfileFields = null,Object? profileFieldNameLimit = null,Object? profileFieldValueLimit = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? maxDisplayNameLength = null,Object? maxNoteLength = null,Object? maxAvatarDescriptionLength = null,Object? maxHeaderDescriptionLength = null,Object? maxFeaturedTags = null,Object? maxPinnedStatuses = null,Object? maxProfileFields = null,Object? profileFieldNameLimit = null,Object? profileFieldValueLimit = null,}) {
   return _then(MastodonAccountsConfiguration(
-maxFeaturedTags: null == maxFeaturedTags ? _self.maxFeaturedTags : maxFeaturedTags // ignore: cast_nullable_to_non_nullable
+maxDisplayNameLength: null == maxDisplayNameLength ? _self.maxDisplayNameLength : maxDisplayNameLength // ignore: cast_nullable_to_non_nullable
+as int,maxNoteLength: null == maxNoteLength ? _self.maxNoteLength : maxNoteLength // ignore: cast_nullable_to_non_nullable
+as int,maxAvatarDescriptionLength: null == maxAvatarDescriptionLength ? _self.maxAvatarDescriptionLength : maxAvatarDescriptionLength // ignore: cast_nullable_to_non_nullable
+as int,maxHeaderDescriptionLength: null == maxHeaderDescriptionLength ? _self.maxHeaderDescriptionLength : maxHeaderDescriptionLength // ignore: cast_nullable_to_non_nullable
+as int,maxFeaturedTags: null == maxFeaturedTags ? _self.maxFeaturedTags : maxFeaturedTags // ignore: cast_nullable_to_non_nullable
 as int,maxPinnedStatuses: null == maxPinnedStatuses ? _self.maxPinnedStatuses : maxPinnedStatuses // ignore: cast_nullable_to_non_nullable
 as int,maxProfileFields: null == maxProfileFields ? _self.maxProfileFields : maxProfileFields // ignore: cast_nullable_to_non_nullable
 as int,profileFieldNameLimit: null == profileFieldNameLimit ? _self.profileFieldNameLimit : profileFieldNameLimit // ignore: cast_nullable_to_non_nullable

--- a/lib/src/models/mastodon_instance.g.dart
+++ b/lib/src/models/mastodon_instance.g.dart
@@ -173,6 +173,13 @@ Map<String, dynamic> _$MastodonPollsConfigurationToJson(
 MastodonAccountsConfiguration _$MastodonAccountsConfigurationFromJson(
   Map<String, dynamic> json,
 ) => MastodonAccountsConfiguration(
+  maxDisplayNameLength:
+      (json['max_display_name_length'] as num?)?.toInt() ?? 40,
+  maxNoteLength: (json['max_note_length'] as num?)?.toInt() ?? 500,
+  maxAvatarDescriptionLength:
+      (json['max_avatar_description_length'] as num?)?.toInt() ?? 150,
+  maxHeaderDescriptionLength:
+      (json['max_header_description_length'] as num?)?.toInt() ?? 150,
   maxFeaturedTags: (json['max_featured_tags'] as num?)?.toInt() ?? 10,
   maxPinnedStatuses: (json['max_pinned_statuses'] as num?)?.toInt() ?? 5,
   maxProfileFields: (json['max_profile_fields'] as num?)?.toInt() ?? 4,
@@ -185,6 +192,10 @@ MastodonAccountsConfiguration _$MastodonAccountsConfigurationFromJson(
 Map<String, dynamic> _$MastodonAccountsConfigurationToJson(
   MastodonAccountsConfiguration instance,
 ) => <String, dynamic>{
+  'max_display_name_length': instance.maxDisplayNameLength,
+  'max_note_length': instance.maxNoteLength,
+  'max_avatar_description_length': instance.maxAvatarDescriptionLength,
+  'max_header_description_length': instance.maxHeaderDescriptionLength,
   'max_featured_tags': instance.maxFeaturedTags,
   'max_pinned_statuses': instance.maxPinnedStatuses,
   'max_profile_fields': instance.maxProfileFields,

--- a/lib/src/models/mastodon_media_attachment.dart
+++ b/lib/src/models/mastodon_media_attachment.dart
@@ -17,6 +17,9 @@ class MastodonMediaAttachment with _$MastodonMediaAttachment {
     this.url,
     this.previewUrl,
     this.remoteUrl,
+    this.previewRemoteUrl,
+    this.textUrl,
+    this.meta,
     this.description,
     this.blurhash,
   });
@@ -50,6 +53,24 @@ class MastodonMediaAttachment with _$MastodonMediaAttachment {
   /// Original URL on the remote instance.
   @override
   final String? remoteUrl;
+
+  /// Original thumbnail URL on the remote instance.
+  @override
+  final String? previewRemoteUrl;
+
+  /// Legacy shortened URL for the media attachment.
+  ///
+  /// Deprecated by Mastodon in 3.5.0 and always `null` on recent servers.
+  @Deprecated('Use url instead.')
+  @override
+  final String? textUrl;
+
+  /// Media metadata returned by the server.
+  ///
+  /// Its structure depends on the media type and may contain `original`,
+  /// `small`, `focus`, and audio-specific entries.
+  @override
+  final Map<String, dynamic>? meta;
 
   /// Alt text (for screen readers).
   @override

--- a/lib/src/models/mastodon_media_attachment.freezed.dart
+++ b/lib/src/models/mastodon_media_attachment.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$MastodonMediaAttachment {
 
- String get id; MastodonMediaType get type; String? get url; String? get previewUrl; String? get remoteUrl; String? get description; String? get blurhash;
+ String get id; MastodonMediaType get type; String? get url; String? get previewUrl; String? get remoteUrl; String? get previewRemoteUrl; String? get textUrl; Map<String, dynamic>? get meta; String? get description; String? get blurhash;
 /// Create a copy of MastodonMediaAttachment
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,12 +26,12 @@ $MastodonMediaAttachmentCopyWith<MastodonMediaAttachment> get copyWith => _$Mast
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonMediaAttachment&&(identical(other.id, id) || other.id == id)&&(identical(other.type, type) || other.type == type)&&(identical(other.url, url) || other.url == url)&&(identical(other.previewUrl, previewUrl) || other.previewUrl == previewUrl)&&(identical(other.remoteUrl, remoteUrl) || other.remoteUrl == remoteUrl)&&(identical(other.description, description) || other.description == description)&&(identical(other.blurhash, blurhash) || other.blurhash == blurhash));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonMediaAttachment&&(identical(other.id, id) || other.id == id)&&(identical(other.type, type) || other.type == type)&&(identical(other.url, url) || other.url == url)&&(identical(other.previewUrl, previewUrl) || other.previewUrl == previewUrl)&&(identical(other.remoteUrl, remoteUrl) || other.remoteUrl == remoteUrl)&&(identical(other.previewRemoteUrl, previewRemoteUrl) || other.previewRemoteUrl == previewRemoteUrl)&&(identical(other.textUrl, textUrl) || other.textUrl == textUrl)&&const DeepCollectionEquality().equals(other.meta, meta)&&(identical(other.description, description) || other.description == description)&&(identical(other.blurhash, blurhash) || other.blurhash == blurhash));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,type,url,previewUrl,remoteUrl,description,blurhash);
+int get hashCode => Object.hash(runtimeType,id,type,url,previewUrl,remoteUrl,previewRemoteUrl,textUrl,const DeepCollectionEquality().hash(meta),description,blurhash);
 
 
 
@@ -42,7 +42,7 @@ abstract mixin class $MastodonMediaAttachmentCopyWith<$Res>  {
   factory $MastodonMediaAttachmentCopyWith(MastodonMediaAttachment value, $Res Function(MastodonMediaAttachment) _then) = _$MastodonMediaAttachmentCopyWithImpl;
 @useResult
 $Res call({
- String id, MastodonMediaType type, String? url, String? previewUrl, String? remoteUrl, String? description, String? blurhash
+ String id, MastodonMediaType type, String? url, String? previewUrl, String? remoteUrl, String? previewRemoteUrl, String? textUrl, Map<String, dynamic>? meta, String? description, String? blurhash
 });
 
 
@@ -59,14 +59,17 @@ class _$MastodonMediaAttachmentCopyWithImpl<$Res>
 
 /// Create a copy of MastodonMediaAttachment
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? type = null,Object? url = freezed,Object? previewUrl = freezed,Object? remoteUrl = freezed,Object? description = freezed,Object? blurhash = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? type = null,Object? url = freezed,Object? previewUrl = freezed,Object? remoteUrl = freezed,Object? previewRemoteUrl = freezed,Object? textUrl = freezed,Object? meta = freezed,Object? description = freezed,Object? blurhash = freezed,}) {
   return _then(MastodonMediaAttachment(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
 as MastodonMediaType,url: freezed == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
 as String?,previewUrl: freezed == previewUrl ? _self.previewUrl : previewUrl // ignore: cast_nullable_to_non_nullable
 as String?,remoteUrl: freezed == remoteUrl ? _self.remoteUrl : remoteUrl // ignore: cast_nullable_to_non_nullable
-as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,previewRemoteUrl: freezed == previewRemoteUrl ? _self.previewRemoteUrl : previewRemoteUrl // ignore: cast_nullable_to_non_nullable
+as String?,textUrl: freezed == textUrl ? _self.textUrl : textUrl // ignore: cast_nullable_to_non_nullable
+as String?,meta: freezed == meta ? _self.meta : meta // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
 as String?,blurhash: freezed == blurhash ? _self.blurhash : blurhash // ignore: cast_nullable_to_non_nullable
 as String?,
   ));

--- a/lib/src/models/mastodon_media_attachment.g.dart
+++ b/lib/src/models/mastodon_media_attachment.g.dart
@@ -20,6 +20,9 @@ MastodonMediaAttachment _$MastodonMediaAttachmentFromJson(
   url: json['url'] as String?,
   previewUrl: json['preview_url'] as String?,
   remoteUrl: json['remote_url'] as String?,
+  previewRemoteUrl: json['preview_remote_url'] as String?,
+  textUrl: json['text_url'] as String?,
+  meta: json['meta'] as Map<String, dynamic>?,
   description: json['description'] as String?,
   blurhash: json['blurhash'] as String?,
 );
@@ -32,6 +35,9 @@ Map<String, dynamic> _$MastodonMediaAttachmentToJson(
   'url': instance.url,
   'preview_url': instance.previewUrl,
   'remote_url': instance.remoteUrl,
+  'preview_remote_url': instance.previewRemoteUrl,
+  'text_url': instance.textUrl,
+  'meta': instance.meta,
   'description': instance.description,
   'blurhash': instance.blurhash,
 };

--- a/lib/src/models/mastodon_notification.dart
+++ b/lib/src/models/mastodon_notification.dart
@@ -2,6 +2,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 import 'json_converters.dart';
 import 'mastodon_account.dart';
+import 'mastodon_collection.dart';
 import 'mastodon_status.dart';
 
 part 'mastodon_notification.freezed.dart';
@@ -57,8 +58,68 @@ enum MastodonNotificationType {
   /// A quoted status was updated (Mastodon 4.5+ / FEP-044f).
   quotedUpdate,
 
+  /// Your annual report is available (Mastodon 4.6+).
+  annualReport,
+
+  /// You were added to a collection (Mastodon 4.6+).
+  addedToCollection,
+
+  /// A collection involving you was updated (Mastodon 4.6+).
+  collectionUpdate,
+
   /// Unknown or future notification type.
   unknown,
+}
+
+/// Generic presentation for a notification type unsupported by the client.
+///
+/// Returned by Mastodon 4.6+ when `supported_types[]` is supplied and a
+/// notification cannot be represented by one of those types.
+@Freezed(toStringOverride: false)
+@JsonSerializable(fieldRename: FieldRename.snake)
+class MastodonNotificationFallback with _$MastodonNotificationFallback {
+  const MastodonNotificationFallback({
+    required this.title,
+    required this.summary,
+    this.description,
+  });
+
+  factory MastodonNotificationFallback.fromJson(Map<String, dynamic> json) =>
+      _$MastodonNotificationFallbackFromJson(json);
+
+  /// Serializes to JSON.
+  Map<String, dynamic> toJson() => _$MastodonNotificationFallbackToJson(this);
+
+  /// Human-readable notification title. May contain sanitized HTML.
+  @JsonKey(defaultValue: '')
+  @override
+  final String title;
+
+  /// Human-readable notification summary. May contain sanitized HTML.
+  @JsonKey(defaultValue: '')
+  @override
+  final String summary;
+
+  /// Optional longer notification description.
+  @override
+  final String? description;
+}
+
+/// Annual report event embedded in a grouped notification.
+@Freezed(toStringOverride: false)
+@JsonSerializable(fieldRename: FieldRename.snake)
+class MastodonAnnualReportEvent with _$MastodonAnnualReportEvent {
+  const MastodonAnnualReportEvent({required this.year});
+
+  factory MastodonAnnualReportEvent.fromJson(Map<String, dynamic> json) =>
+      _$MastodonAnnualReportEventFromJson(json);
+
+  /// Serializes to JSON.
+  Map<String, dynamic> toJson() => _$MastodonAnnualReportEventToJson(this);
+
+  /// Calendar year represented by the report.
+  @override
+  final String year;
 }
 
 /// Relationship severance event (Mastodon 4.3+).
@@ -174,6 +235,8 @@ class MastodonNotification with _$MastodonNotification {
     this.status,
     this.relationshipSeveranceEvent,
     this.moderationWarning,
+    this.collection,
+    this.fallback,
   });
 
   factory MastodonNotification.fromJson(Map<String, dynamic> json) =>
@@ -229,4 +292,12 @@ class MastodonNotification with _$MastodonNotification {
   /// [MastodonNotificationType.moderationWarning].
   @override
   final MastodonAccountWarning? moderationWarning;
+
+  /// Associated collection for collection-related notifications.
+  @override
+  final MastodonCollection? collection;
+
+  /// Generic rendering for a notification type not supported by the client.
+  @override
+  final MastodonNotificationFallback? fallback;
 }

--- a/lib/src/models/mastodon_notification.freezed.dart
+++ b/lib/src/models/mastodon_notification.freezed.dart
@@ -13,6 +13,372 @@ part of 'mastodon_notification.dart';
 T _$identity<T>(T value) => value;
 
 /// @nodoc
+mixin _$MastodonNotificationFallback {
+
+ String get title; String get summary; String? get description;
+/// Create a copy of MastodonNotificationFallback
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MastodonNotificationFallbackCopyWith<MastodonNotificationFallback> get copyWith => _$MastodonNotificationFallbackCopyWithImpl<MastodonNotificationFallback>(this as MastodonNotificationFallback, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonNotificationFallback&&(identical(other.title, title) || other.title == title)&&(identical(other.summary, summary) || other.summary == summary)&&(identical(other.description, description) || other.description == description));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,title,summary,description);
+
+
+
+}
+
+/// @nodoc
+abstract mixin class $MastodonNotificationFallbackCopyWith<$Res>  {
+  factory $MastodonNotificationFallbackCopyWith(MastodonNotificationFallback value, $Res Function(MastodonNotificationFallback) _then) = _$MastodonNotificationFallbackCopyWithImpl;
+@useResult
+$Res call({
+ String title, String summary, String? description
+});
+
+
+
+
+}
+/// @nodoc
+class _$MastodonNotificationFallbackCopyWithImpl<$Res>
+    implements $MastodonNotificationFallbackCopyWith<$Res> {
+  _$MastodonNotificationFallbackCopyWithImpl(this._self, this._then);
+
+  final MastodonNotificationFallback _self;
+  final $Res Function(MastodonNotificationFallback) _then;
+
+/// Create a copy of MastodonNotificationFallback
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? title = null,Object? summary = null,Object? description = freezed,}) {
+  return _then(MastodonNotificationFallback(
+title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,summary: null == summary ? _self.summary : summary // ignore: cast_nullable_to_non_nullable
+as String,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [MastodonNotificationFallback].
+extension MastodonNotificationFallbackPatterns on MastodonNotificationFallback {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+
+/// @nodoc
+mixin _$MastodonAnnualReportEvent {
+
+ String get year;
+/// Create a copy of MastodonAnnualReportEvent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MastodonAnnualReportEventCopyWith<MastodonAnnualReportEvent> get copyWith => _$MastodonAnnualReportEventCopyWithImpl<MastodonAnnualReportEvent>(this as MastodonAnnualReportEvent, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonAnnualReportEvent&&(identical(other.year, year) || other.year == year));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,year);
+
+
+
+}
+
+/// @nodoc
+abstract mixin class $MastodonAnnualReportEventCopyWith<$Res>  {
+  factory $MastodonAnnualReportEventCopyWith(MastodonAnnualReportEvent value, $Res Function(MastodonAnnualReportEvent) _then) = _$MastodonAnnualReportEventCopyWithImpl;
+@useResult
+$Res call({
+ String year
+});
+
+
+
+
+}
+/// @nodoc
+class _$MastodonAnnualReportEventCopyWithImpl<$Res>
+    implements $MastodonAnnualReportEventCopyWith<$Res> {
+  _$MastodonAnnualReportEventCopyWithImpl(this._self, this._then);
+
+  final MastodonAnnualReportEvent _self;
+  final $Res Function(MastodonAnnualReportEvent) _then;
+
+/// Create a copy of MastodonAnnualReportEvent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? year = null,}) {
+  return _then(MastodonAnnualReportEvent(
+year: null == year ? _self.year : year // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [MastodonAnnualReportEvent].
+extension MastodonAnnualReportEventPatterns on MastodonAnnualReportEvent {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+
+/// @nodoc
 mixin _$MastodonRelationshipSeveranceEvent {
 
  String get id; String get type; bool get purged; String get targetName; int get followersCount; int get followingCount; DateTime? get createdAt;
@@ -389,7 +755,7 @@ case _:
 /// @nodoc
 mixin _$MastodonNotification {
 
- String get id; MastodonNotificationType get type; DateTime get createdAt; MastodonAccount get account; String? get groupKey; MastodonStatus? get status; MastodonRelationshipSeveranceEvent? get relationshipSeveranceEvent; MastodonAccountWarning? get moderationWarning;
+ String get id; MastodonNotificationType get type; DateTime get createdAt; MastodonAccount get account; String? get groupKey; MastodonStatus? get status; MastodonRelationshipSeveranceEvent? get relationshipSeveranceEvent; MastodonAccountWarning? get moderationWarning; MastodonCollection? get collection; MastodonNotificationFallback? get fallback;
 /// Create a copy of MastodonNotification
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -400,12 +766,12 @@ $MastodonNotificationCopyWith<MastodonNotification> get copyWith => _$MastodonNo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonNotification&&(identical(other.id, id) || other.id == id)&&(identical(other.type, type) || other.type == type)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.account, account) || other.account == account)&&(identical(other.groupKey, groupKey) || other.groupKey == groupKey)&&(identical(other.status, status) || other.status == status)&&(identical(other.relationshipSeveranceEvent, relationshipSeveranceEvent) || other.relationshipSeveranceEvent == relationshipSeveranceEvent)&&(identical(other.moderationWarning, moderationWarning) || other.moderationWarning == moderationWarning));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonNotification&&(identical(other.id, id) || other.id == id)&&(identical(other.type, type) || other.type == type)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.account, account) || other.account == account)&&(identical(other.groupKey, groupKey) || other.groupKey == groupKey)&&(identical(other.status, status) || other.status == status)&&(identical(other.relationshipSeveranceEvent, relationshipSeveranceEvent) || other.relationshipSeveranceEvent == relationshipSeveranceEvent)&&(identical(other.moderationWarning, moderationWarning) || other.moderationWarning == moderationWarning)&&(identical(other.collection, collection) || other.collection == collection)&&(identical(other.fallback, fallback) || other.fallback == fallback));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,type,createdAt,account,groupKey,status,relationshipSeveranceEvent,moderationWarning);
+int get hashCode => Object.hash(runtimeType,id,type,createdAt,account,groupKey,status,relationshipSeveranceEvent,moderationWarning,collection,fallback);
 
 
 
@@ -416,7 +782,7 @@ abstract mixin class $MastodonNotificationCopyWith<$Res>  {
   factory $MastodonNotificationCopyWith(MastodonNotification value, $Res Function(MastodonNotification) _then) = _$MastodonNotificationCopyWithImpl;
 @useResult
 $Res call({
- String id, MastodonNotificationType type, DateTime createdAt, MastodonAccount account, String? groupKey, MastodonStatus? status, MastodonRelationshipSeveranceEvent? relationshipSeveranceEvent, MastodonAccountWarning? moderationWarning
+ String id, MastodonNotificationType type, DateTime createdAt, MastodonAccount account, String? groupKey, MastodonStatus? status, MastodonRelationshipSeveranceEvent? relationshipSeveranceEvent, MastodonAccountWarning? moderationWarning, MastodonCollection? collection, MastodonNotificationFallback? fallback
 });
 
 
@@ -433,7 +799,7 @@ class _$MastodonNotificationCopyWithImpl<$Res>
 
 /// Create a copy of MastodonNotification
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? type = null,Object? createdAt = null,Object? account = null,Object? groupKey = freezed,Object? status = freezed,Object? relationshipSeveranceEvent = freezed,Object? moderationWarning = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? type = null,Object? createdAt = null,Object? account = null,Object? groupKey = freezed,Object? status = freezed,Object? relationshipSeveranceEvent = freezed,Object? moderationWarning = freezed,Object? collection = freezed,Object? fallback = freezed,}) {
   return _then(MastodonNotification(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
@@ -443,7 +809,9 @@ as MastodonAccount,groupKey: freezed == groupKey ? _self.groupKey : groupKey // 
 as String?,status: freezed == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
 as MastodonStatus?,relationshipSeveranceEvent: freezed == relationshipSeveranceEvent ? _self.relationshipSeveranceEvent : relationshipSeveranceEvent // ignore: cast_nullable_to_non_nullable
 as MastodonRelationshipSeveranceEvent?,moderationWarning: freezed == moderationWarning ? _self.moderationWarning : moderationWarning // ignore: cast_nullable_to_non_nullable
-as MastodonAccountWarning?,
+as MastodonAccountWarning?,collection: freezed == collection ? _self.collection : collection // ignore: cast_nullable_to_non_nullable
+as MastodonCollection?,fallback: freezed == fallback ? _self.fallback : fallback // ignore: cast_nullable_to_non_nullable
+as MastodonNotificationFallback?,
   ));
 }
 

--- a/lib/src/models/mastodon_notification.g.dart
+++ b/lib/src/models/mastodon_notification.g.dart
@@ -8,6 +8,30 @@ part of 'mastodon_notification.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+MastodonNotificationFallback _$MastodonNotificationFallbackFromJson(
+  Map<String, dynamic> json,
+) => MastodonNotificationFallback(
+  title: json['title'] as String? ?? '',
+  summary: json['summary'] as String? ?? '',
+  description: json['description'] as String?,
+);
+
+Map<String, dynamic> _$MastodonNotificationFallbackToJson(
+  MastodonNotificationFallback instance,
+) => <String, dynamic>{
+  'title': instance.title,
+  'summary': instance.summary,
+  'description': instance.description,
+};
+
+MastodonAnnualReportEvent _$MastodonAnnualReportEventFromJson(
+  Map<String, dynamic> json,
+) => MastodonAnnualReportEvent(year: json['year'] as String);
+
+Map<String, dynamic> _$MastodonAnnualReportEventToJson(
+  MastodonAnnualReportEvent instance,
+) => <String, dynamic>{'year': instance.year};
+
 MastodonRelationshipSeveranceEvent _$MastodonRelationshipSeveranceEventFromJson(
   Map<String, dynamic> json,
 ) => MastodonRelationshipSeveranceEvent(
@@ -81,6 +105,14 @@ MastodonNotification _$MastodonNotificationFromJson(
       : MastodonAccountWarning.fromJson(
           json['moderation_warning'] as Map<String, dynamic>,
         ),
+  collection: json['collection'] == null
+      ? null
+      : MastodonCollection.fromJson(json['collection'] as Map<String, dynamic>),
+  fallback: json['fallback'] == null
+      ? null
+      : MastodonNotificationFallback.fromJson(
+          json['fallback'] as Map<String, dynamic>,
+        ),
 );
 
 Map<String, dynamic> _$MastodonNotificationToJson(
@@ -94,6 +126,8 @@ Map<String, dynamic> _$MastodonNotificationToJson(
   'status': instance.status?.toJson(),
   'relationship_severance_event': instance.relationshipSeveranceEvent?.toJson(),
   'moderation_warning': instance.moderationWarning?.toJson(),
+  'collection': instance.collection?.toJson(),
+  'fallback': instance.fallback?.toJson(),
 };
 
 const _$MastodonNotificationTypeEnumMap = {
@@ -111,5 +145,8 @@ const _$MastodonNotificationTypeEnumMap = {
   MastodonNotificationType.moderationWarning: 'moderation_warning',
   MastodonNotificationType.quote: 'quote',
   MastodonNotificationType.quotedUpdate: 'quoted_update',
+  MastodonNotificationType.annualReport: 'annual_report',
+  MastodonNotificationType.addedToCollection: 'added_to_collection',
+  MastodonNotificationType.collectionUpdate: 'collection_update',
   MastodonNotificationType.unknown: 'unknown',
 };

--- a/lib/src/models/mastodon_notification_group.dart
+++ b/lib/src/models/mastodon_notification_group.dart
@@ -1,6 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 import 'json_converters.dart';
+import 'mastodon_collection.dart';
 import 'mastodon_notification.dart';
 import 'mastodon_report.dart';
 
@@ -27,6 +28,9 @@ class MastodonNotificationGroup with _$MastodonNotificationGroup {
     this.report,
     this.event,
     this.moderationWarning,
+    this.annualReport,
+    this.collection,
+    this.fallback,
   });
 
   factory MastodonNotificationGroup.fromJson(Map<String, dynamic> json) =>
@@ -97,4 +101,18 @@ class MastodonNotificationGroup with _$MastodonNotificationGroup {
   /// Non-null only for [MastodonNotificationType.moderationWarning].
   @override
   final MastodonAccountWarning? moderationWarning;
+
+  /// Annual report metadata.
+  ///
+  /// Non-null only for [MastodonNotificationType.annualReport].
+  @override
+  final MastodonAnnualReportEvent? annualReport;
+
+  /// Associated collection for collection-related notifications.
+  @override
+  final MastodonCollection? collection;
+
+  /// Generic rendering for a notification type not supported by the client.
+  @override
+  final MastodonNotificationFallback? fallback;
 }

--- a/lib/src/models/mastodon_notification_group.freezed.dart
+++ b/lib/src/models/mastodon_notification_group.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$MastodonNotificationGroup {
 
- String get groupKey; int get notificationsCount; MastodonNotificationType get type; String? get mostRecentNotificationId; String? get pageMinId; String? get pageMaxId; DateTime? get latestPageNotificationAt; List<String> get sampleAccountIds; String? get statusId; MastodonReport? get report; MastodonRelationshipSeveranceEvent? get event; MastodonAccountWarning? get moderationWarning;
+ String get groupKey; int get notificationsCount; MastodonNotificationType get type; String? get mostRecentNotificationId; String? get pageMinId; String? get pageMaxId; DateTime? get latestPageNotificationAt; List<String> get sampleAccountIds; String? get statusId; MastodonReport? get report; MastodonRelationshipSeveranceEvent? get event; MastodonAccountWarning? get moderationWarning; MastodonAnnualReportEvent? get annualReport; MastodonCollection? get collection; MastodonNotificationFallback? get fallback;
 /// Create a copy of MastodonNotificationGroup
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,12 +26,12 @@ $MastodonNotificationGroupCopyWith<MastodonNotificationGroup> get copyWith => _$
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonNotificationGroup&&(identical(other.groupKey, groupKey) || other.groupKey == groupKey)&&(identical(other.notificationsCount, notificationsCount) || other.notificationsCount == notificationsCount)&&(identical(other.type, type) || other.type == type)&&(identical(other.mostRecentNotificationId, mostRecentNotificationId) || other.mostRecentNotificationId == mostRecentNotificationId)&&(identical(other.pageMinId, pageMinId) || other.pageMinId == pageMinId)&&(identical(other.pageMaxId, pageMaxId) || other.pageMaxId == pageMaxId)&&(identical(other.latestPageNotificationAt, latestPageNotificationAt) || other.latestPageNotificationAt == latestPageNotificationAt)&&const DeepCollectionEquality().equals(other.sampleAccountIds, sampleAccountIds)&&(identical(other.statusId, statusId) || other.statusId == statusId)&&(identical(other.report, report) || other.report == report)&&(identical(other.event, event) || other.event == event)&&(identical(other.moderationWarning, moderationWarning) || other.moderationWarning == moderationWarning));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonNotificationGroup&&(identical(other.groupKey, groupKey) || other.groupKey == groupKey)&&(identical(other.notificationsCount, notificationsCount) || other.notificationsCount == notificationsCount)&&(identical(other.type, type) || other.type == type)&&(identical(other.mostRecentNotificationId, mostRecentNotificationId) || other.mostRecentNotificationId == mostRecentNotificationId)&&(identical(other.pageMinId, pageMinId) || other.pageMinId == pageMinId)&&(identical(other.pageMaxId, pageMaxId) || other.pageMaxId == pageMaxId)&&(identical(other.latestPageNotificationAt, latestPageNotificationAt) || other.latestPageNotificationAt == latestPageNotificationAt)&&const DeepCollectionEquality().equals(other.sampleAccountIds, sampleAccountIds)&&(identical(other.statusId, statusId) || other.statusId == statusId)&&(identical(other.report, report) || other.report == report)&&(identical(other.event, event) || other.event == event)&&(identical(other.moderationWarning, moderationWarning) || other.moderationWarning == moderationWarning)&&(identical(other.annualReport, annualReport) || other.annualReport == annualReport)&&(identical(other.collection, collection) || other.collection == collection)&&(identical(other.fallback, fallback) || other.fallback == fallback));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,groupKey,notificationsCount,type,mostRecentNotificationId,pageMinId,pageMaxId,latestPageNotificationAt,const DeepCollectionEquality().hash(sampleAccountIds),statusId,report,event,moderationWarning);
+int get hashCode => Object.hash(runtimeType,groupKey,notificationsCount,type,mostRecentNotificationId,pageMinId,pageMaxId,latestPageNotificationAt,const DeepCollectionEquality().hash(sampleAccountIds),statusId,report,event,moderationWarning,annualReport,collection,fallback);
 
 
 
@@ -42,7 +42,7 @@ abstract mixin class $MastodonNotificationGroupCopyWith<$Res>  {
   factory $MastodonNotificationGroupCopyWith(MastodonNotificationGroup value, $Res Function(MastodonNotificationGroup) _then) = _$MastodonNotificationGroupCopyWithImpl;
 @useResult
 $Res call({
- String groupKey, int notificationsCount, MastodonNotificationType type, String? mostRecentNotificationId, String? pageMinId, String? pageMaxId, DateTime? latestPageNotificationAt, List<String> sampleAccountIds, String? statusId, MastodonReport? report, MastodonRelationshipSeveranceEvent? event, MastodonAccountWarning? moderationWarning
+ String groupKey, int notificationsCount, MastodonNotificationType type, String? mostRecentNotificationId, String? pageMinId, String? pageMaxId, DateTime? latestPageNotificationAt, List<String> sampleAccountIds, String? statusId, MastodonReport? report, MastodonRelationshipSeveranceEvent? event, MastodonAccountWarning? moderationWarning, MastodonAnnualReportEvent? annualReport, MastodonCollection? collection, MastodonNotificationFallback? fallback
 });
 
 
@@ -59,7 +59,7 @@ class _$MastodonNotificationGroupCopyWithImpl<$Res>
 
 /// Create a copy of MastodonNotificationGroup
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? groupKey = null,Object? notificationsCount = null,Object? type = null,Object? mostRecentNotificationId = freezed,Object? pageMinId = freezed,Object? pageMaxId = freezed,Object? latestPageNotificationAt = freezed,Object? sampleAccountIds = null,Object? statusId = freezed,Object? report = freezed,Object? event = freezed,Object? moderationWarning = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? groupKey = null,Object? notificationsCount = null,Object? type = null,Object? mostRecentNotificationId = freezed,Object? pageMinId = freezed,Object? pageMaxId = freezed,Object? latestPageNotificationAt = freezed,Object? sampleAccountIds = null,Object? statusId = freezed,Object? report = freezed,Object? event = freezed,Object? moderationWarning = freezed,Object? annualReport = freezed,Object? collection = freezed,Object? fallback = freezed,}) {
   return _then(MastodonNotificationGroup(
 groupKey: null == groupKey ? _self.groupKey : groupKey // ignore: cast_nullable_to_non_nullable
 as String,notificationsCount: null == notificationsCount ? _self.notificationsCount : notificationsCount // ignore: cast_nullable_to_non_nullable
@@ -73,7 +73,10 @@ as List<String>,statusId: freezed == statusId ? _self.statusId : statusId // ign
 as String?,report: freezed == report ? _self.report : report // ignore: cast_nullable_to_non_nullable
 as MastodonReport?,event: freezed == event ? _self.event : event // ignore: cast_nullable_to_non_nullable
 as MastodonRelationshipSeveranceEvent?,moderationWarning: freezed == moderationWarning ? _self.moderationWarning : moderationWarning // ignore: cast_nullable_to_non_nullable
-as MastodonAccountWarning?,
+as MastodonAccountWarning?,annualReport: freezed == annualReport ? _self.annualReport : annualReport // ignore: cast_nullable_to_non_nullable
+as MastodonAnnualReportEvent?,collection: freezed == collection ? _self.collection : collection // ignore: cast_nullable_to_non_nullable
+as MastodonCollection?,fallback: freezed == fallback ? _self.fallback : fallback // ignore: cast_nullable_to_non_nullable
+as MastodonNotificationFallback?,
   ));
 }
 

--- a/lib/src/models/mastodon_notification_group.g.dart
+++ b/lib/src/models/mastodon_notification_group.g.dart
@@ -45,6 +45,19 @@ MastodonNotificationGroup _$MastodonNotificationGroupFromJson(
       : MastodonAccountWarning.fromJson(
           json['moderation_warning'] as Map<String, dynamic>,
         ),
+  annualReport: json['annual_report'] == null
+      ? null
+      : MastodonAnnualReportEvent.fromJson(
+          json['annual_report'] as Map<String, dynamic>,
+        ),
+  collection: json['collection'] == null
+      ? null
+      : MastodonCollection.fromJson(json['collection'] as Map<String, dynamic>),
+  fallback: json['fallback'] == null
+      ? null
+      : MastodonNotificationFallback.fromJson(
+          json['fallback'] as Map<String, dynamic>,
+        ),
 );
 
 Map<String, dynamic> _$MastodonNotificationGroupToJson(
@@ -64,6 +77,9 @@ Map<String, dynamic> _$MastodonNotificationGroupToJson(
   'report': instance.report?.toJson(),
   'event': instance.event?.toJson(),
   'moderation_warning': instance.moderationWarning?.toJson(),
+  'annual_report': instance.annualReport?.toJson(),
+  'collection': instance.collection?.toJson(),
+  'fallback': instance.fallback?.toJson(),
 };
 
 const _$MastodonNotificationTypeEnumMap = {
@@ -81,5 +97,8 @@ const _$MastodonNotificationTypeEnumMap = {
   MastodonNotificationType.moderationWarning: 'moderation_warning',
   MastodonNotificationType.quote: 'quote',
   MastodonNotificationType.quotedUpdate: 'quoted_update',
+  MastodonNotificationType.annualReport: 'annual_report',
+  MastodonNotificationType.addedToCollection: 'added_to_collection',
+  MastodonNotificationType.collectionUpdate: 'collection_update',
   MastodonNotificationType.unknown: 'unknown',
 };

--- a/lib/src/models/mastodon_preview_card.dart
+++ b/lib/src/models/mastodon_preview_card.dart
@@ -1,5 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'json_converters.dart';
+
 part 'mastodon_preview_card.freezed.dart';
 part 'mastodon_preview_card.g.dart';
 
@@ -40,8 +42,12 @@ class MastodonPreviewCard with _$MastodonPreviewCard {
     required this.height,
     required this.embedUrl,
     required this.authors,
+    this.language,
     this.image,
+    this.imageDescription = '',
     this.blurhash,
+    this.publishedAt,
+    this.missingAttribution,
   });
 
   factory MastodonPreviewCard.fromJson(Map<String, dynamic> json) =>
@@ -66,6 +72,10 @@ class MastodonPreviewCard with _$MastodonPreviewCard {
   @JsonKey(defaultValue: '')
   @override
   final String description;
+
+  /// ISO 639 language code detected for the linked content.
+  @override
+  final String? language;
 
   /// Type of the preview card.
   @JsonKey(readValue: _readType, unknownEnumValue: MastodonPreviewCardType.link)
@@ -115,6 +125,11 @@ class MastodonPreviewCard with _$MastodonPreviewCard {
   @override
   final String? image;
 
+  /// Alternative text for the preview image.
+  @JsonKey(defaultValue: '')
+  @override
+  final String imageDescription;
+
   /// URL for embedding photos.
   @JsonKey(defaultValue: '')
   @override
@@ -123,6 +138,17 @@ class MastodonPreviewCard with _$MastodonPreviewCard {
   /// Blurhash string for the thumbnail. `null` if not available.
   @override
   final String? blurhash;
+
+  /// Publication timestamp of the linked content.
+  @SafeDateTimeConverter()
+  @override
+  final DateTime? publishedAt;
+
+  /// Whether the current user is an author whose attribution is missing.
+  ///
+  /// This field is returned only for authenticated requests.
+  @override
+  final bool? missingAttribution;
 
   /// List of content authors (Mastodon 4.3.0+).
   @JsonKey(defaultValue: <MastodonPreviewCardAuthor>[])

--- a/lib/src/models/mastodon_preview_card.freezed.dart
+++ b/lib/src/models/mastodon_preview_card.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$MastodonPreviewCard {
 
- String get url; String get title; String get description; MastodonPreviewCardType get type; String get authorName; String get authorUrl; String get providerName; String get providerUrl; String get html; int get width; int get height; String? get image; String get embedUrl; String? get blurhash; List<MastodonPreviewCardAuthor> get authors;
+ String get url; String get title; String get description; String? get language; MastodonPreviewCardType get type; String get authorName; String get authorUrl; String get providerName; String get providerUrl; String get html; int get width; int get height; String? get image; String get imageDescription; String get embedUrl; String? get blurhash; DateTime? get publishedAt; bool? get missingAttribution; List<MastodonPreviewCardAuthor> get authors;
 /// Create a copy of MastodonPreviewCard
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,12 +26,12 @@ $MastodonPreviewCardCopyWith<MastodonPreviewCard> get copyWith => _$MastodonPrev
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonPreviewCard&&(identical(other.url, url) || other.url == url)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.type, type) || other.type == type)&&(identical(other.authorName, authorName) || other.authorName == authorName)&&(identical(other.authorUrl, authorUrl) || other.authorUrl == authorUrl)&&(identical(other.providerName, providerName) || other.providerName == providerName)&&(identical(other.providerUrl, providerUrl) || other.providerUrl == providerUrl)&&(identical(other.html, html) || other.html == html)&&(identical(other.width, width) || other.width == width)&&(identical(other.height, height) || other.height == height)&&(identical(other.image, image) || other.image == image)&&(identical(other.embedUrl, embedUrl) || other.embedUrl == embedUrl)&&(identical(other.blurhash, blurhash) || other.blurhash == blurhash)&&const DeepCollectionEquality().equals(other.authors, authors));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonPreviewCard&&(identical(other.url, url) || other.url == url)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.language, language) || other.language == language)&&(identical(other.type, type) || other.type == type)&&(identical(other.authorName, authorName) || other.authorName == authorName)&&(identical(other.authorUrl, authorUrl) || other.authorUrl == authorUrl)&&(identical(other.providerName, providerName) || other.providerName == providerName)&&(identical(other.providerUrl, providerUrl) || other.providerUrl == providerUrl)&&(identical(other.html, html) || other.html == html)&&(identical(other.width, width) || other.width == width)&&(identical(other.height, height) || other.height == height)&&(identical(other.image, image) || other.image == image)&&(identical(other.imageDescription, imageDescription) || other.imageDescription == imageDescription)&&(identical(other.embedUrl, embedUrl) || other.embedUrl == embedUrl)&&(identical(other.blurhash, blurhash) || other.blurhash == blurhash)&&(identical(other.publishedAt, publishedAt) || other.publishedAt == publishedAt)&&(identical(other.missingAttribution, missingAttribution) || other.missingAttribution == missingAttribution)&&const DeepCollectionEquality().equals(other.authors, authors));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,url,title,description,type,authorName,authorUrl,providerName,providerUrl,html,width,height,image,embedUrl,blurhash,const DeepCollectionEquality().hash(authors));
+int get hashCode => Object.hashAll([runtimeType,url,title,description,language,type,authorName,authorUrl,providerName,providerUrl,html,width,height,image,imageDescription,embedUrl,blurhash,publishedAt,missingAttribution,const DeepCollectionEquality().hash(authors)]);
 
 
 
@@ -42,7 +42,7 @@ abstract mixin class $MastodonPreviewCardCopyWith<$Res>  {
   factory $MastodonPreviewCardCopyWith(MastodonPreviewCard value, $Res Function(MastodonPreviewCard) _then) = _$MastodonPreviewCardCopyWithImpl;
 @useResult
 $Res call({
- String url, String title, String description, MastodonPreviewCardType type, String authorName, String authorUrl, String providerName, String providerUrl, String html, int width, int height, String embedUrl, List<MastodonPreviewCardAuthor> authors, String? image, String? blurhash
+ String url, String title, String description, MastodonPreviewCardType type, String authorName, String authorUrl, String providerName, String providerUrl, String html, int width, int height, String embedUrl, List<MastodonPreviewCardAuthor> authors, String? language, String? image, String imageDescription, String? blurhash, DateTime? publishedAt, bool? missingAttribution
 });
 
 
@@ -59,7 +59,7 @@ class _$MastodonPreviewCardCopyWithImpl<$Res>
 
 /// Create a copy of MastodonPreviewCard
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? url = null,Object? title = null,Object? description = null,Object? type = null,Object? authorName = null,Object? authorUrl = null,Object? providerName = null,Object? providerUrl = null,Object? html = null,Object? width = null,Object? height = null,Object? embedUrl = null,Object? authors = null,Object? image = freezed,Object? blurhash = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? url = null,Object? title = null,Object? description = null,Object? type = null,Object? authorName = null,Object? authorUrl = null,Object? providerName = null,Object? providerUrl = null,Object? html = null,Object? width = null,Object? height = null,Object? embedUrl = null,Object? authors = null,Object? language = freezed,Object? image = freezed,Object? imageDescription = null,Object? blurhash = freezed,Object? publishedAt = freezed,Object? missingAttribution = freezed,}) {
   return _then(MastodonPreviewCard(
 url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
 as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
@@ -74,9 +74,13 @@ as String,width: null == width ? _self.width : width // ignore: cast_nullable_to
 as int,height: null == height ? _self.height : height // ignore: cast_nullable_to_non_nullable
 as int,embedUrl: null == embedUrl ? _self.embedUrl : embedUrl // ignore: cast_nullable_to_non_nullable
 as String,authors: null == authors ? _self.authors : authors // ignore: cast_nullable_to_non_nullable
-as List<MastodonPreviewCardAuthor>,image: freezed == image ? _self.image : image // ignore: cast_nullable_to_non_nullable
-as String?,blurhash: freezed == blurhash ? _self.blurhash : blurhash // ignore: cast_nullable_to_non_nullable
-as String?,
+as List<MastodonPreviewCardAuthor>,language: freezed == language ? _self.language : language // ignore: cast_nullable_to_non_nullable
+as String?,image: freezed == image ? _self.image : image // ignore: cast_nullable_to_non_nullable
+as String?,imageDescription: null == imageDescription ? _self.imageDescription : imageDescription // ignore: cast_nullable_to_non_nullable
+as String,blurhash: freezed == blurhash ? _self.blurhash : blurhash // ignore: cast_nullable_to_non_nullable
+as String?,publishedAt: freezed == publishedAt ? _self.publishedAt : publishedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,missingAttribution: freezed == missingAttribution ? _self.missingAttribution : missingAttribution // ignore: cast_nullable_to_non_nullable
+as bool?,
   ));
 }
 

--- a/lib/src/models/mastodon_preview_card.g.dart
+++ b/lib/src/models/mastodon_preview_card.g.dart
@@ -35,8 +35,14 @@ MastodonPreviewCard _$MastodonPreviewCardFromJson(Map<String, dynamic> json) =>
               )
               .toList() ??
           [],
+      language: json['language'] as String?,
       image: json['image'] as String?,
+      imageDescription: json['image_description'] as String? ?? '',
       blurhash: json['blurhash'] as String?,
+      publishedAt: const SafeDateTimeConverter().fromJson(
+        json['published_at'] as String?,
+      ),
+      missingAttribution: json['missing_attribution'] as bool?,
     );
 
 Map<String, dynamic> _$MastodonPreviewCardToJson(
@@ -45,6 +51,7 @@ Map<String, dynamic> _$MastodonPreviewCardToJson(
   'url': instance.url,
   'title': instance.title,
   'description': instance.description,
+  'language': instance.language,
   'type': _$MastodonPreviewCardTypeEnumMap[instance.type]!,
   'author_name': instance.authorName,
   'author_url': instance.authorUrl,
@@ -54,8 +61,11 @@ Map<String, dynamic> _$MastodonPreviewCardToJson(
   'width': instance.width,
   'height': instance.height,
   'image': instance.image,
+  'image_description': instance.imageDescription,
   'embed_url': instance.embedUrl,
   'blurhash': instance.blurhash,
+  'published_at': const SafeDateTimeConverter().toJson(instance.publishedAt),
+  'missing_attribution': instance.missingAttribution,
   'authors': instance.authors.map((e) => e.toJson()).toList(),
 };
 

--- a/lib/src/models/mastodon_trends_link.dart
+++ b/lib/src/models/mastodon_trends_link.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'json_converters.dart';
 import 'mastodon_preview_card.dart';
 
 part 'mastodon_trends_link.freezed.dart';
@@ -59,8 +60,12 @@ class MastodonTrendsLink with _$MastodonTrendsLink {
     required this.embedUrl,
     required this.authors,
     required this.history,
+    this.language,
     this.image,
+    this.imageDescription = '',
     this.blurhash,
+    this.publishedAt,
+    this.missingAttribution,
   });
 
   factory MastodonTrendsLink.fromJson(Map<String, dynamic> json) =>
@@ -85,6 +90,10 @@ class MastodonTrendsLink with _$MastodonTrendsLink {
   @JsonKey(defaultValue: '')
   @override
   final String description;
+
+  /// ISO 639 language code detected for the linked content.
+  @override
+  final String? language;
 
   /// Type of the preview card.
   @JsonKey(readValue: _readType, unknownEnumValue: MastodonPreviewCardType.link)
@@ -130,6 +139,11 @@ class MastodonTrendsLink with _$MastodonTrendsLink {
   @override
   final String? image;
 
+  /// Alternative text for the preview image.
+  @JsonKey(defaultValue: '')
+  @override
+  final String imageDescription;
+
   /// URL for embedding photos.
   @JsonKey(defaultValue: '')
   @override
@@ -138,6 +152,15 @@ class MastodonTrendsLink with _$MastodonTrendsLink {
   /// Blurhash string for the thumbnail.
   @override
   final String? blurhash;
+
+  /// Publication timestamp of the linked content.
+  @SafeDateTimeConverter()
+  @override
+  final DateTime? publishedAt;
+
+  /// Whether the current user is an author whose attribution is missing.
+  @override
+  final bool? missingAttribution;
 
   /// List of content authors (Mastodon 4.3.0+).
   @JsonKey(defaultValue: <MastodonPreviewCardAuthor>[])

--- a/lib/src/models/mastodon_trends_link.freezed.dart
+++ b/lib/src/models/mastodon_trends_link.freezed.dart
@@ -199,7 +199,7 @@ case _:
 /// @nodoc
 mixin _$MastodonTrendsLink {
 
- String get url; String get title; String get description; MastodonPreviewCardType get type; String get authorName; String get authorUrl; String get providerName; String get providerUrl; String get html; int get width; int get height; String? get image; String get embedUrl; String? get blurhash; List<MastodonPreviewCardAuthor> get authors; List<MastodonTrendsLinkHistory> get history;
+ String get url; String get title; String get description; String? get language; MastodonPreviewCardType get type; String get authorName; String get authorUrl; String get providerName; String get providerUrl; String get html; int get width; int get height; String? get image; String get imageDescription; String get embedUrl; String? get blurhash; DateTime? get publishedAt; bool? get missingAttribution; List<MastodonPreviewCardAuthor> get authors; List<MastodonTrendsLinkHistory> get history;
 /// Create a copy of MastodonTrendsLink
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -210,12 +210,12 @@ $MastodonTrendsLinkCopyWith<MastodonTrendsLink> get copyWith => _$MastodonTrends
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonTrendsLink&&(identical(other.url, url) || other.url == url)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.type, type) || other.type == type)&&(identical(other.authorName, authorName) || other.authorName == authorName)&&(identical(other.authorUrl, authorUrl) || other.authorUrl == authorUrl)&&(identical(other.providerName, providerName) || other.providerName == providerName)&&(identical(other.providerUrl, providerUrl) || other.providerUrl == providerUrl)&&(identical(other.html, html) || other.html == html)&&(identical(other.width, width) || other.width == width)&&(identical(other.height, height) || other.height == height)&&(identical(other.image, image) || other.image == image)&&(identical(other.embedUrl, embedUrl) || other.embedUrl == embedUrl)&&(identical(other.blurhash, blurhash) || other.blurhash == blurhash)&&const DeepCollectionEquality().equals(other.authors, authors)&&const DeepCollectionEquality().equals(other.history, history));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonTrendsLink&&(identical(other.url, url) || other.url == url)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.language, language) || other.language == language)&&(identical(other.type, type) || other.type == type)&&(identical(other.authorName, authorName) || other.authorName == authorName)&&(identical(other.authorUrl, authorUrl) || other.authorUrl == authorUrl)&&(identical(other.providerName, providerName) || other.providerName == providerName)&&(identical(other.providerUrl, providerUrl) || other.providerUrl == providerUrl)&&(identical(other.html, html) || other.html == html)&&(identical(other.width, width) || other.width == width)&&(identical(other.height, height) || other.height == height)&&(identical(other.image, image) || other.image == image)&&(identical(other.imageDescription, imageDescription) || other.imageDescription == imageDescription)&&(identical(other.embedUrl, embedUrl) || other.embedUrl == embedUrl)&&(identical(other.blurhash, blurhash) || other.blurhash == blurhash)&&(identical(other.publishedAt, publishedAt) || other.publishedAt == publishedAt)&&(identical(other.missingAttribution, missingAttribution) || other.missingAttribution == missingAttribution)&&const DeepCollectionEquality().equals(other.authors, authors)&&const DeepCollectionEquality().equals(other.history, history));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,url,title,description,type,authorName,authorUrl,providerName,providerUrl,html,width,height,image,embedUrl,blurhash,const DeepCollectionEquality().hash(authors),const DeepCollectionEquality().hash(history));
+int get hashCode => Object.hashAll([runtimeType,url,title,description,language,type,authorName,authorUrl,providerName,providerUrl,html,width,height,image,imageDescription,embedUrl,blurhash,publishedAt,missingAttribution,const DeepCollectionEquality().hash(authors),const DeepCollectionEquality().hash(history)]);
 
 
 
@@ -226,7 +226,7 @@ abstract mixin class $MastodonTrendsLinkCopyWith<$Res>  {
   factory $MastodonTrendsLinkCopyWith(MastodonTrendsLink value, $Res Function(MastodonTrendsLink) _then) = _$MastodonTrendsLinkCopyWithImpl;
 @useResult
 $Res call({
- String url, String title, String description, MastodonPreviewCardType type, String authorName, String authorUrl, String providerName, String providerUrl, String html, int width, int height, String embedUrl, List<MastodonPreviewCardAuthor> authors, List<MastodonTrendsLinkHistory> history, String? image, String? blurhash
+ String url, String title, String description, MastodonPreviewCardType type, String authorName, String authorUrl, String providerName, String providerUrl, String html, int width, int height, String embedUrl, List<MastodonPreviewCardAuthor> authors, List<MastodonTrendsLinkHistory> history, String? language, String? image, String imageDescription, String? blurhash, DateTime? publishedAt, bool? missingAttribution
 });
 
 
@@ -243,7 +243,7 @@ class _$MastodonTrendsLinkCopyWithImpl<$Res>
 
 /// Create a copy of MastodonTrendsLink
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? url = null,Object? title = null,Object? description = null,Object? type = null,Object? authorName = null,Object? authorUrl = null,Object? providerName = null,Object? providerUrl = null,Object? html = null,Object? width = null,Object? height = null,Object? embedUrl = null,Object? authors = null,Object? history = null,Object? image = freezed,Object? blurhash = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? url = null,Object? title = null,Object? description = null,Object? type = null,Object? authorName = null,Object? authorUrl = null,Object? providerName = null,Object? providerUrl = null,Object? html = null,Object? width = null,Object? height = null,Object? embedUrl = null,Object? authors = null,Object? history = null,Object? language = freezed,Object? image = freezed,Object? imageDescription = null,Object? blurhash = freezed,Object? publishedAt = freezed,Object? missingAttribution = freezed,}) {
   return _then(MastodonTrendsLink(
 url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
 as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
@@ -259,9 +259,13 @@ as int,height: null == height ? _self.height : height // ignore: cast_nullable_t
 as int,embedUrl: null == embedUrl ? _self.embedUrl : embedUrl // ignore: cast_nullable_to_non_nullable
 as String,authors: null == authors ? _self.authors : authors // ignore: cast_nullable_to_non_nullable
 as List<MastodonPreviewCardAuthor>,history: null == history ? _self.history : history // ignore: cast_nullable_to_non_nullable
-as List<MastodonTrendsLinkHistory>,image: freezed == image ? _self.image : image // ignore: cast_nullable_to_non_nullable
-as String?,blurhash: freezed == blurhash ? _self.blurhash : blurhash // ignore: cast_nullable_to_non_nullable
-as String?,
+as List<MastodonTrendsLinkHistory>,language: freezed == language ? _self.language : language // ignore: cast_nullable_to_non_nullable
+as String?,image: freezed == image ? _self.image : image // ignore: cast_nullable_to_non_nullable
+as String?,imageDescription: null == imageDescription ? _self.imageDescription : imageDescription // ignore: cast_nullable_to_non_nullable
+as String,blurhash: freezed == blurhash ? _self.blurhash : blurhash // ignore: cast_nullable_to_non_nullable
+as String?,publishedAt: freezed == publishedAt ? _self.publishedAt : publishedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,missingAttribution: freezed == missingAttribution ? _self.missingAttribution : missingAttribution // ignore: cast_nullable_to_non_nullable
+as bool?,
   ));
 }
 

--- a/lib/src/models/mastodon_trends_link.g.dart
+++ b/lib/src/models/mastodon_trends_link.g.dart
@@ -59,29 +59,40 @@ MastodonTrendsLink _$MastodonTrendsLinkFromJson(
           )
           .toList() ??
       [],
+  language: json['language'] as String?,
   image: json['image'] as String?,
+  imageDescription: json['image_description'] as String? ?? '',
   blurhash: json['blurhash'] as String?,
+  publishedAt: const SafeDateTimeConverter().fromJson(
+    json['published_at'] as String?,
+  ),
+  missingAttribution: json['missing_attribution'] as bool?,
 );
 
-Map<String, dynamic> _$MastodonTrendsLinkToJson(MastodonTrendsLink instance) =>
-    <String, dynamic>{
-      'url': instance.url,
-      'title': instance.title,
-      'description': instance.description,
-      'type': _$MastodonPreviewCardTypeEnumMap[instance.type]!,
-      'author_name': instance.authorName,
-      'author_url': instance.authorUrl,
-      'provider_name': instance.providerName,
-      'provider_url': instance.providerUrl,
-      'html': instance.html,
-      'width': instance.width,
-      'height': instance.height,
-      'image': instance.image,
-      'embed_url': instance.embedUrl,
-      'blurhash': instance.blurhash,
-      'authors': instance.authors.map((e) => e.toJson()).toList(),
-      'history': instance.history.map((e) => e.toJson()).toList(),
-    };
+Map<String, dynamic> _$MastodonTrendsLinkToJson(
+  MastodonTrendsLink instance,
+) => <String, dynamic>{
+  'url': instance.url,
+  'title': instance.title,
+  'description': instance.description,
+  'language': instance.language,
+  'type': _$MastodonPreviewCardTypeEnumMap[instance.type]!,
+  'author_name': instance.authorName,
+  'author_url': instance.authorUrl,
+  'provider_name': instance.providerName,
+  'provider_url': instance.providerUrl,
+  'html': instance.html,
+  'width': instance.width,
+  'height': instance.height,
+  'image': instance.image,
+  'image_description': instance.imageDescription,
+  'embed_url': instance.embedUrl,
+  'blurhash': instance.blurhash,
+  'published_at': const SafeDateTimeConverter().toJson(instance.publishedAt),
+  'missing_attribution': instance.missingAttribution,
+  'authors': instance.authors.map((e) => e.toJson()).toList(),
+  'history': instance.history.map((e) => e.toJson()).toList(),
+};
 
 const _$MastodonPreviewCardTypeEnumMap = {
   MastodonPreviewCardType.link: 'link',

--- a/test/api/mastodon_4_6_compat_api_test.dart
+++ b/test/api/mastodon_4_6_compat_api_test.dart
@@ -1,0 +1,45 @@
+import 'package:mastodon_client/src/api/accounts_api.dart';
+import 'package:mastodon_client/src/api/grouped_notifications_api.dart';
+import 'package:mastodon_client/src/api/notifications_api.dart';
+import 'package:test/test.dart';
+
+import '../helpers/recording_http_client.dart';
+
+void main() {
+  test('notification list requests send supported_types[]', () async {
+    final http = RecordingHttpClient([
+      <dynamic>[],
+      {
+        'accounts': <dynamic>[],
+        'partial_accounts': <dynamic>[],
+        'statuses': <dynamic>[],
+        'notification_groups': <dynamic>[],
+      },
+    ]);
+
+    await NotificationsApi(
+      http,
+    ).fetch(supportedTypes: const ['mention', 'follow']);
+    await GroupedNotificationsApi(
+      http,
+    ).fetch(supportedTypes: const ['mention', 'follow']);
+
+    expect(http.requests[0].queryParameters?['supported_types[]'], [
+      'mention',
+      'follow',
+    ]);
+    expect(http.requests[1].queryParameters?['supported_types[]'], [
+      'mention',
+      'follow',
+    ]);
+  });
+
+  test('account statuses request sends exclude_direct', () async {
+    final http = RecordingHttpClient([<dynamic>[]]);
+
+    await AccountsApi(http).fetchStatuses('42', excludeDirect: true);
+
+    expect(http.requests.single.path, '/api/v1/accounts/42/statuses');
+    expect(http.requests.single.queryParameters?['exclude_direct'], isTrue);
+  });
+}

--- a/test/helpers/recording_http_client.dart
+++ b/test/helpers/recording_http_client.dart
@@ -1,3 +1,4 @@
+import 'package:dio/dio.dart';
 import 'package:mastodon_client/src/client/mastodon_http_client.dart';
 
 class RecordedRequest {
@@ -44,5 +45,30 @@ class RecordingHttpClient extends MastodonHttpClient {
     );
     if (_responses.isEmpty) return null;
     return _responses.removeAt(0) as T?;
+  }
+
+  @override
+  Future<Response<T>> sendRaw<T>(
+    String path, {
+    String method = 'GET',
+    Object? data,
+    Map<String, dynamic>? queryParameters,
+    Map<String, String>? headers,
+    String? contentType,
+  }) async {
+    requests.add(
+      RecordedRequest(
+        path: path,
+        method: method,
+        data: data,
+        queryParameters: queryParameters,
+        contentType: contentType,
+      ),
+    );
+    final responseData = _responses.isEmpty ? null : _responses.removeAt(0);
+    return Response<T>(
+      data: responseData as T?,
+      requestOptions: RequestOptions(path: path),
+    );
   }
 }

--- a/test/models/fixture_key_coverage_test.dart
+++ b/test/models/fixture_key_coverage_test.dart
@@ -21,15 +21,6 @@ void main() {
     'instance_v2.json': {'api_versions'},
   };
 
-  /// 未実装と分かっているが issue #13 の対象外のフィールド。
-  ///
-  /// このチェックを導入した際に検出されたもので、実装した時点でここから外す。
-  /// 新しい欠落を素通りさせないために、除外は一覧として明示しておく。
-  const outstandingGaps = <String, Set<String>>{
-    'preview_card.json': {'language', 'image_description', 'published_at'},
-    'media_attachment.json': {'preview_remote_url', 'text_url', 'meta'},
-  };
-
   final cases = <String, Map<String, dynamic> Function(Map<String, dynamic>)>{
     'status.json': (json) => MastodonStatus.fromJson(json).toJson(),
     'status_filtered.json': (json) => MastodonStatus.fromJson(json).toJson(),
@@ -66,8 +57,7 @@ void main() {
 
         final missing = json.keys.toSet()
           ..removeAll(roundTrip(json).keys)
-          ..removeAll(knownDivergences[fixture] ?? const <String>{})
-          ..removeAll(outstandingGaps[fixture] ?? const <String>{});
+          ..removeAll(knownDivergences[fixture] ?? const <String>{});
 
         expect(
           missing,

--- a/test/models/freezed_model_test.dart
+++ b/test/models/freezed_model_test.dart
@@ -55,7 +55,7 @@ void main() {
         freezedCount += fileFreezedCount;
       }
 
-      expect(jsonSerializableCount, 131);
+      expect(jsonSerializableCount, 133);
       expect(freezedCount, jsonSerializableCount);
     });
 

--- a/test/models/mastodon_instance_test.dart
+++ b/test/models/mastodon_instance_test.dart
@@ -65,6 +65,12 @@ void main() {
       expect(config.polls!.minExpiration, 300);
       expect(config.polls!.maxExpiration, 2629746);
 
+      expect(config.accounts, isNotNull);
+      expect(config.accounts!.maxDisplayNameLength, 40);
+      expect(config.accounts!.maxNoteLength, 500);
+      expect(config.accounts!.maxAvatarDescriptionLength, 150);
+      expect(config.accounts!.maxHeaderDescriptionLength, 150);
+
       expect(config.timelinesAccess, isNotNull);
       expect(config.timelinesAccess!.liveFeeds, isNotNull);
       expect(

--- a/test/models/mastodon_media_attachment_test.dart
+++ b/test/models/mastodon_media_attachment_test.dart
@@ -25,6 +25,15 @@ void main() {
         ),
       );
       expect(attachment.remoteUrl, isNull);
+      expect(attachment.previewRemoteUrl, isNull);
+      // ignore: deprecated_member_use_from_same_package
+      expect(attachment.textUrl, isNull);
+      expect(attachment.meta?['original'], {
+        'width': 16,
+        'height': 16,
+        'size': '16x16',
+        'aspect': 1.0,
+      });
       expect(
         attachment.description,
         equals('Test image for fixture collection'),

--- a/test/models/mastodon_notification_group_test.dart
+++ b/test/models/mastodon_notification_group_test.dart
@@ -65,5 +65,35 @@ void main() {
       final group = MastodonNotificationGroup.fromJson(base);
       expect(group.type, equals(MastodonNotificationType.unknown));
     });
+
+    test('deserializes an annual report event', () {
+      final json = Map<String, dynamic>.from(loadGroups()[0])
+        ..['type'] = 'annual_report'
+        ..['annual_report'] = {'year': '2026'}
+        ..remove('status_id');
+
+      final group = MastodonNotificationGroup.fromJson(json);
+
+      expect(group.type, MastodonNotificationType.annualReport);
+      expect(group.annualReport?.year, '2026');
+    });
+
+    test('deserializes collection data and fallback text', () {
+      final json = Map<String, dynamic>.from(loadGroups()[0])
+        ..['type'] = 'collection_update'
+        ..['collection'] = {'id': '42', 'name': 'Friends'}
+        ..['fallback'] = {
+          'title': 'Collection updated',
+          'summary': 'Sign in to view it',
+          'description': null,
+        }
+        ..remove('status_id');
+
+      final group = MastodonNotificationGroup.fromJson(json);
+
+      expect(group.type, MastodonNotificationType.collectionUpdate);
+      expect(group.collection?.name, 'Friends');
+      expect(group.fallback?.summary, 'Sign in to view it');
+    });
   });
 }

--- a/test/models/mastodon_notification_test.dart
+++ b/test/models/mastodon_notification_test.dart
@@ -56,5 +56,25 @@ void main() {
 
       expect(MastodonNotification.fromJson(json).groupKey, isNull);
     });
+
+    test('deserializes Mastodon 4.6 collection notification fallback', () {
+      final file = File('test/fixtures/notifications.json');
+      final list = jsonDecode(file.readAsStringSync()) as List<dynamic>;
+      final json = Map<String, dynamic>.from(list.first as Map<String, dynamic>)
+        ..['type'] = 'added_to_collection'
+        ..['collection'] = {'id': '42', 'name': 'Friends'}
+        ..['fallback'] = {
+          'title': '<span>Alice</span> added you to a collection',
+          'summary': '<a href="/">Sign in</a> to view it',
+          'description': null,
+        };
+
+      final notification = MastodonNotification.fromJson(json);
+
+      expect(notification.type, MastodonNotificationType.addedToCollection);
+      expect(notification.collection?.id, '42');
+      expect(notification.fallback?.title, contains('Alice'));
+      expect(notification.fallback?.description, isNull);
+    });
   });
 }

--- a/test/models/mastodon_preview_card_test.dart
+++ b/test/models/mastodon_preview_card_test.dart
@@ -19,6 +19,7 @@ void main() {
           ' open-source decentralized social media platform.',
         ),
       );
+      expect(card.language, 'en');
       expect(card.type, equals(MastodonPreviewCardType.link));
       expect(card.authorName, equals(''));
       expect(card.authorUrl, equals(''));
@@ -34,7 +35,10 @@ void main() {
         ),
       );
       expect(card.embedUrl, equals(''));
+      expect(card.imageDescription, equals(''));
       expect(card.blurhash, equals('U44UXbj_D~aus^fRayfRD#aw-rj{ajfQoffR'));
+      expect(card.publishedAt, isNull);
+      expect(card.missingAttribution, isNull);
       expect(card.authors, isEmpty);
     });
 


### PR DESCRIPTION
## 概要

PR #35を親とするStack PRです。Issue #17のEntity欠落と、Mastodon v4.6.6の既存ルート上で追加されたモデル属性・query parameterの対応漏れを補完します。

## 対応内容

- MediaAttachmentのpreview_remote_url、text_url、meta
- PreviewCardとtrends派生モデルのlanguage、image_description、published_at、missing_attribution
- Notificationのsupported_types[]、fallback、annual_report、collection関連通知
- Account statusesのexclude_direct
- Instance configuration.accountsのdisplay name、note、avatar/header description上限
- fixture key coverageのIssue #17除外を解消
- API query・モデルdeserializationの回帰テスト

## 検証

- dart analyze: 成功
- dart test: 303件成功、E2E 4件skip

## Stack

- Parent: #35
- このPRは#35のmerge後にbaseをdevelopへ切り替える想定です。

Closes #17