### PR TITLE
docs: update unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added automatic streaming endpoint discovery from instance metadata, with normalization of scheme, port, and path (issue #21)
 - Added three streaming authentication modes with fallback, close-code-aware reconnection with exponential backoff and jitter, and `suspend()` / `resume()` (issue #21)
 - Added `MastodonClient.dispose()` and `HealthApi.checkStreaming()` (issue #21)
+- Added Mastodon 4.6 APIs for Collections, Profile, Annual Reports, instance languages, domain block previews, peer search, donation campaigns, unread conversations, notification clearing and policies, and OAuth token inspection (issue #14)
+- Added Mastodon 4.5 and 4.6 response fields for media attachments, preview cards, instances, notifications, notification groups, and trend links (issue #17)
+- Added automated release branch and pull request creation, version tagging, and `main`-to-`develop` merge-back on top of the existing pub.dev publishing and GitHub Release workflows (issue #38)
 
 ### Changed
 


### PR DESCRIPTION
## 概要

`v1.0.0-beta.2`以降の利用者影響がある変更のうち、未記載だった内容をCHANGELOGの`Unreleased`セクションへ整理します。

- Mastodon 4.6のCollections、Profile、Annual ReportsほかのAPI対応
- Mastodon 4.5／4.6レスポンスモデルの不足フィールド補完
- releaseブランチ・PR作成、タグ付け、マージバックの自動化

バージョン見出し・日付・`pubspec.yaml`の更新は行わず、Prepare Releaseによる自動生成に委ねます。

## 検証

- `git diff --check`
- `dart test test/tool/release_project_test.dart`（9件成功）

## マージ順序

`develop`から`main`への同期PR #40を先にマージし、その後に本PRを`develop`へマージします。これはLibraryLibrarian/misskey_mfm_parser#27、#28と同じ導入順序です。

Refs #14
Refs #17
Refs #38