### PR TITLE
fix: 引用投稿のQuoteエンティティを正しく解析 (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** `MastodonStatus.quote` is now a `MastodonQuote?` relationship
+  instead of a `MastodonStatus?`, matching Mastodon 4.5 responses. Access the
+  embedded status through `status.quote?.quotedStatus`; shallow nested quotes
+  expose `quotedStatusId` instead. Edit history now exposes the same entity via
+  `MastodonStatusEdit.quote` (issue #43)
+
 ## [1.0.0-beta.3] - 2026-08-25
 
 ### Added

--- a/docs/docs/api/statuses.md
+++ b/docs/docs/api/statuses.md
@@ -23,6 +23,21 @@ final statuses = await client.statuses.fetchMultiple(['1', '2', '3']);
 
 Non-existent or inaccessible IDs are silently excluded from the results.
 
+### Quoted statuses
+
+Mastodon 4.5 and later expose a quote relationship as `MastodonQuote`:
+
+```dart
+final quote = status.quote;
+final quotedStatus = quote?.quotedStatus;     // Embedded visible status
+final quotedStatusId = quote?.quotedStatusId; // ID in shallow nested contexts
+final state = quote?.state;
+```
+
+`quotedStatus` can be null when a quote is pending, unavailable, or represented
+by `quotedStatusId` in a shallow nested response. Edit history exposes the quote
+relationship through `MastodonStatusEdit.quote` as well.
+
 ### Thread context
 
 ```dart

--- a/docs/i18n/de/docusaurus-plugin-content-docs/current/api/statuses.md
+++ b/docs/i18n/de/docusaurus-plugin-content-docs/current/api/statuses.md
@@ -23,6 +23,22 @@ final statuses = await client.statuses.fetchMultiple(['1', '2', '3']);
 
 Nicht vorhandene oder nicht zugängliche IDs werden stillschweigend aus den Ergebnissen ausgeschlossen.
 
+### Zitierte Status
+
+Mastodon 4.5 und neuer stellt die Zitatbeziehung als `MastodonQuote` bereit:
+
+```dart
+final quote = status.quote;
+final quotedStatus = quote?.quotedStatus;     // Eingebetteter sichtbarer Status
+final quotedStatusId = quote?.quotedStatusId; // ID in flach verschachtelten Antworten
+final state = quote?.state;
+```
+
+`quotedStatus` kann null sein, wenn ein Zitat aussteht, nicht verfügbar ist oder
+in einer flach verschachtelten Antwort durch `quotedStatusId` dargestellt wird.
+Der Bearbeitungsverlauf stellt die Zitatbeziehung ebenfalls über
+`MastodonStatusEdit.quote` bereit.
+
 ### Thread-Kontext
 
 ```dart

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/api/statuses.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/api/statuses.md
@@ -23,6 +23,22 @@ final statuses = await client.statuses.fetchMultiple(['1', '2', '3']);
 
 Les IDs inexistants ou inaccessibles sont silencieusement exclus des résultats.
 
+### Statuts cités
+
+Mastodon 4.5 et versions ultérieures expose la relation de citation sous la
+forme `MastodonQuote` :
+
+```dart
+final quote = status.quote;
+final quotedStatus = quote?.quotedStatus;     // Statut visible intégré
+final quotedStatusId = quote?.quotedStatusId; // ID dans un contexte imbriqué allégé
+final state = quote?.state;
+```
+
+`quotedStatus` peut être null si une citation est en attente, indisponible ou
+représentée par `quotedStatusId` dans une réponse imbriquée allégée. L'historique
+des modifications expose également la relation via `MastodonStatusEdit.quote`.
+
 ### Contexte du fil
 
 ```dart

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/api/statuses.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/api/statuses.md
@@ -23,6 +23,21 @@ final statuses = await client.statuses.fetchMultiple(['1', '2', '3']);
 
 存在しない、またはアクセスできない ID は結果から除外されます。
 
+### 引用投稿
+
+Mastodon 4.5 以降の引用関係は `MastodonQuote` として取得できます。
+
+```dart
+final quote = status.quote;
+final quotedStatus = quote?.quotedStatus;     // 埋め込まれた閲覧可能な投稿
+final quotedStatusId = quote?.quotedStatusId; // 浅いネストで返される投稿 ID
+final state = quote?.state;
+```
+
+引用が承認待ち、閲覧不可、または浅いネストの応答で `quotedStatusId` として
+表現される場合、`quotedStatus` は null になります。編集履歴でも
+`MastodonStatusEdit.quote` から同じ引用関係を取得できます。
+
 ### スレッドコンテキスト
 
 ```dart

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/statuses.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/statuses.md
@@ -23,6 +23,21 @@ final statuses = await client.statuses.fetchMultiple(['1', '2', '3']);
 
 존재하지 않거나 접근할 수 없는 ID는 결과에서 자동으로 제외됩니다.
 
+### 인용 포스트
+
+Mastodon 4.5 이상에서는 인용 관계를 `MastodonQuote`로 제공합니다.
+
+```dart
+final quote = status.quote;
+final quotedStatus = quote?.quotedStatus;     // 포함된 표시 가능한 포스트
+final quotedStatusId = quote?.quotedStatusId; // 얕게 중첩된 응답의 ID
+final state = quote?.state;
+```
+
+인용이 승인 대기 중이거나 사용할 수 없거나 얕게 중첩된 응답에서
+`quotedStatusId`로 표현되면 `quotedStatus`는 null일 수 있습니다. 편집 기록에서도
+`MastodonStatusEdit.quote`를 통해 같은 인용 관계를 제공합니다.
+
 ### 스레드 컨텍스트
 
 ```dart

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/api/statuses.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/api/statuses.md
@@ -23,6 +23,21 @@ final statuses = await client.statuses.fetchMultiple(['1', '2', '3']);
 
 不存在或无法访问的 ID 会从结果中静默排除。
 
+### 引用帖子
+
+Mastodon 4.5 及更高版本将引用关系公开为 `MastodonQuote`：
+
+```dart
+final quote = status.quote;
+final quotedStatus = quote?.quotedStatus;     // 嵌入的可见帖子
+final quotedStatusId = quote?.quotedStatusId; // 浅层嵌套响应中的 ID
+final state = quote?.state;
+```
+
+当引用等待批准、不可用，或在浅层嵌套响应中由 `quotedStatusId` 表示时，
+`quotedStatus` 可能为 null。编辑历史也通过 `MastodonStatusEdit.quote`
+公开相同的引用关系。
+
 ### 线程上下文
 
 ```dart

--- a/lib/src/models/mastodon_status.dart
+++ b/lib/src/models/mastodon_status.dart
@@ -19,6 +19,21 @@ part 'mastodon_status.g.dart';
 @JsonEnum(fieldRename: FieldRename.snake)
 enum MastodonVisibility { public, unlisted, private, direct }
 
+/// State of a quote relationship.
+@JsonEnum(fieldRename: FieldRename.snake)
+enum MastodonQuoteState {
+  pending,
+  accepted,
+  rejected,
+  revoked,
+  deleted,
+  unauthorized,
+  blockedDomain,
+  blockedAccount,
+  mutedAccount,
+  unknown,
+}
+
 /// Mention (the `@username` portion within a status).
 @Freezed(toStringOverride: false)
 @JsonSerializable(fieldRename: FieldRename.snake)
@@ -230,9 +245,11 @@ class MastodonStatus with _$MastodonStatus {
   @override
   final MastodonPoll? poll;
 
-  /// Quoted status (Mastodon 4.5+ / FEP-044f). Null if not a quote.
+  /// Quote relationship attached to this status.
+  ///
+  /// Null if this status is not a quote. Added in Mastodon 4.5.0.
   @override
-  final MastodonStatus? quote;
+  final MastodonQuote? quote;
 
   /// Link preview card for the first link in the status.
   ///
@@ -269,6 +286,36 @@ class MastodonStatus with _$MastodonStatus {
   @JsonKey(defaultValue: <MastodonCollection>[])
   @override
   final List<MastodonCollection> taggedCollections;
+}
+
+/// Quote relationship attached to a status (Mastodon 4.5.0+).
+@Freezed(toStringOverride: false)
+@JsonSerializable(fieldRename: FieldRename.snake)
+class MastodonQuote with _$MastodonQuote {
+  const MastodonQuote({
+    required this.state,
+    this.quotedStatus,
+    this.quotedStatusId,
+  });
+
+  factory MastodonQuote.fromJson(Map<String, dynamic> json) =>
+      _$MastodonQuoteFromJson(json);
+
+  /// Serializes to JSON.
+  Map<String, dynamic> toJson() => _$MastodonQuoteToJson(this);
+
+  /// State of the quote relationship.
+  @JsonKey(unknownEnumValue: MastodonQuoteState.unknown)
+  @override
+  final MastodonQuoteState state;
+
+  /// Quoted status when the response embeds the visible status.
+  @override
+  final MastodonStatus? quotedStatus;
+
+  /// ID of the quoted status in shallow nested contexts.
+  @override
+  final String? quotedStatusId;
 }
 
 /// Application that published a status.

--- a/lib/src/models/mastodon_status.freezed.dart
+++ b/lib/src/models/mastodon_status.freezed.dart
@@ -200,7 +200,7 @@ case _:
 /// @nodoc
 mixin _$MastodonStatus {
 
- String get id; String? get uri; String? get url; DateTime get createdAt; String? get inReplyToId; String? get inReplyToAccountId; bool get sensitive; String get spoilerText; MastodonVisibility get visibility; String? get language; String get content; String? get text; DateTime? get editedAt; int get reblogsCount; int get favouritesCount; int get repliesCount; int get quotesCount; bool? get favourited; bool? get reblogged; bool? get bookmarked; bool? get muted; bool? get pinned; MastodonAccount get account; List<MastodonMediaAttachment> get mediaAttachments; List<MastodonMention> get mentions; List<MastodonTag> get tags; List<MastodonCustomEmoji> get emojis; MastodonStatus? get reblog; MastodonPoll? get poll; MastodonStatus? get quote; MastodonPreviewCard? get card; MastodonStatusApplication? get application; List<MastodonFilterResult> get filtered; MastodonQuoteApproval? get quoteApproval; List<MastodonCollection> get taggedCollections;
+ String get id; String? get uri; String? get url; DateTime get createdAt; String? get inReplyToId; String? get inReplyToAccountId; bool get sensitive; String get spoilerText; MastodonVisibility get visibility; String? get language; String get content; String? get text; DateTime? get editedAt; int get reblogsCount; int get favouritesCount; int get repliesCount; int get quotesCount; bool? get favourited; bool? get reblogged; bool? get bookmarked; bool? get muted; bool? get pinned; MastodonAccount get account; List<MastodonMediaAttachment> get mediaAttachments; List<MastodonMention> get mentions; List<MastodonTag> get tags; List<MastodonCustomEmoji> get emojis; MastodonStatus? get reblog; MastodonPoll? get poll; MastodonQuote? get quote; MastodonPreviewCard? get card; MastodonStatusApplication? get application; List<MastodonFilterResult> get filtered; MastodonQuoteApproval? get quoteApproval; List<MastodonCollection> get taggedCollections;
 /// Create a copy of MastodonStatus
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -227,7 +227,7 @@ abstract mixin class $MastodonStatusCopyWith<$Res>  {
   factory $MastodonStatusCopyWith(MastodonStatus value, $Res Function(MastodonStatus) _then) = _$MastodonStatusCopyWithImpl;
 @useResult
 $Res call({
- String id, DateTime createdAt, bool sensitive, String spoilerText, MastodonVisibility visibility, String content, int reblogsCount, int favouritesCount, int repliesCount, MastodonAccount account, List<MastodonMediaAttachment> mediaAttachments, List<MastodonMention> mentions, List<MastodonTag> tags, List<MastodonCustomEmoji> emojis, String? uri, String? url, String? inReplyToId, String? inReplyToAccountId, String? language, String? text, DateTime? editedAt, bool? favourited, bool? reblogged, bool? bookmarked, bool? muted, bool? pinned, MastodonStatus? reblog, MastodonPoll? poll, MastodonStatus? quote, MastodonPreviewCard? card, MastodonStatusApplication? application, MastodonQuoteApproval? quoteApproval, int quotesCount, List<MastodonFilterResult> filtered, List<MastodonCollection> taggedCollections
+ String id, DateTime createdAt, bool sensitive, String spoilerText, MastodonVisibility visibility, String content, int reblogsCount, int favouritesCount, int repliesCount, MastodonAccount account, List<MastodonMediaAttachment> mediaAttachments, List<MastodonMention> mentions, List<MastodonTag> tags, List<MastodonCustomEmoji> emojis, String? uri, String? url, String? inReplyToId, String? inReplyToAccountId, String? language, String? text, DateTime? editedAt, bool? favourited, bool? reblogged, bool? bookmarked, bool? muted, bool? pinned, MastodonStatus? reblog, MastodonPoll? poll, MastodonQuote? quote, MastodonPreviewCard? card, MastodonStatusApplication? application, MastodonQuoteApproval? quoteApproval, int quotesCount, List<MastodonFilterResult> filtered, List<MastodonCollection> taggedCollections
 });
 
 
@@ -275,7 +275,7 @@ as bool?,pinned: freezed == pinned ? _self.pinned : pinned // ignore: cast_nulla
 as bool?,reblog: freezed == reblog ? _self.reblog : reblog // ignore: cast_nullable_to_non_nullable
 as MastodonStatus?,poll: freezed == poll ? _self.poll : poll // ignore: cast_nullable_to_non_nullable
 as MastodonPoll?,quote: freezed == quote ? _self.quote : quote // ignore: cast_nullable_to_non_nullable
-as MastodonStatus?,card: freezed == card ? _self.card : card // ignore: cast_nullable_to_non_nullable
+as MastodonQuote?,card: freezed == card ? _self.card : card // ignore: cast_nullable_to_non_nullable
 as MastodonPreviewCard?,application: freezed == application ? _self.application : application // ignore: cast_nullable_to_non_nullable
 as MastodonStatusApplication?,quoteApproval: freezed == quoteApproval ? _self.quoteApproval : quoteApproval // ignore: cast_nullable_to_non_nullable
 as MastodonQuoteApproval?,quotesCount: null == quotesCount ? _self.quotesCount : quotesCount // ignore: cast_nullable_to_non_nullable
@@ -290,6 +290,190 @@ as List<MastodonCollection>,
 
 /// Adds pattern-matching-related methods to [MastodonStatus].
 extension MastodonStatusPatterns on MastodonStatus {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+
+/// @nodoc
+mixin _$MastodonQuote {
+
+ MastodonQuoteState get state; MastodonStatus? get quotedStatus; String? get quotedStatusId;
+/// Create a copy of MastodonQuote
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MastodonQuoteCopyWith<MastodonQuote> get copyWith => _$MastodonQuoteCopyWithImpl<MastodonQuote>(this as MastodonQuote, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonQuote&&(identical(other.state, state) || other.state == state)&&(identical(other.quotedStatus, quotedStatus) || other.quotedStatus == quotedStatus)&&(identical(other.quotedStatusId, quotedStatusId) || other.quotedStatusId == quotedStatusId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,state,quotedStatus,quotedStatusId);
+
+
+
+}
+
+/// @nodoc
+abstract mixin class $MastodonQuoteCopyWith<$Res>  {
+  factory $MastodonQuoteCopyWith(MastodonQuote value, $Res Function(MastodonQuote) _then) = _$MastodonQuoteCopyWithImpl;
+@useResult
+$Res call({
+ MastodonQuoteState state, MastodonStatus? quotedStatus, String? quotedStatusId
+});
+
+
+
+
+}
+/// @nodoc
+class _$MastodonQuoteCopyWithImpl<$Res>
+    implements $MastodonQuoteCopyWith<$Res> {
+  _$MastodonQuoteCopyWithImpl(this._self, this._then);
+
+  final MastodonQuote _self;
+  final $Res Function(MastodonQuote) _then;
+
+/// Create a copy of MastodonQuote
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? state = null,Object? quotedStatus = freezed,Object? quotedStatusId = freezed,}) {
+  return _then(MastodonQuote(
+state: null == state ? _self.state : state // ignore: cast_nullable_to_non_nullable
+as MastodonQuoteState,quotedStatus: freezed == quotedStatus ? _self.quotedStatus : quotedStatus // ignore: cast_nullable_to_non_nullable
+as MastodonStatus?,quotedStatusId: freezed == quotedStatusId ? _self.quotedStatusId : quotedStatusId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [MastodonQuote].
+extension MastodonQuotePatterns on MastodonQuote {
 /// A variant of `map` that fallback to returning `orElse`.
 ///
 /// It is equivalent to doing:

--- a/lib/src/models/mastodon_status.g.dart
+++ b/lib/src/models/mastodon_status.g.dart
@@ -75,7 +75,7 @@ MastodonStatus _$MastodonStatusFromJson(
       : MastodonPoll.fromJson(json['poll'] as Map<String, dynamic>),
   quote: json['quote'] == null
       ? null
-      : MastodonStatus.fromJson(json['quote'] as Map<String, dynamic>),
+      : MastodonQuote.fromJson(json['quote'] as Map<String, dynamic>),
   card: json['card'] == null
       ? null
       : MastodonPreviewCard.fromJson(json['card'] as Map<String, dynamic>),
@@ -150,6 +150,41 @@ const _$MastodonVisibilityEnumMap = {
   MastodonVisibility.unlisted: 'unlisted',
   MastodonVisibility.private: 'private',
   MastodonVisibility.direct: 'direct',
+};
+
+MastodonQuote _$MastodonQuoteFromJson(Map<String, dynamic> json) =>
+    MastodonQuote(
+      state: $enumDecode(
+        _$MastodonQuoteStateEnumMap,
+        json['state'],
+        unknownValue: MastodonQuoteState.unknown,
+      ),
+      quotedStatus: json['quoted_status'] == null
+          ? null
+          : MastodonStatus.fromJson(
+              json['quoted_status'] as Map<String, dynamic>,
+            ),
+      quotedStatusId: json['quoted_status_id'] as String?,
+    );
+
+Map<String, dynamic> _$MastodonQuoteToJson(MastodonQuote instance) =>
+    <String, dynamic>{
+      'state': _$MastodonQuoteStateEnumMap[instance.state]!,
+      'quoted_status': instance.quotedStatus?.toJson(),
+      'quoted_status_id': instance.quotedStatusId,
+    };
+
+const _$MastodonQuoteStateEnumMap = {
+  MastodonQuoteState.pending: 'pending',
+  MastodonQuoteState.accepted: 'accepted',
+  MastodonQuoteState.rejected: 'rejected',
+  MastodonQuoteState.revoked: 'revoked',
+  MastodonQuoteState.deleted: 'deleted',
+  MastodonQuoteState.unauthorized: 'unauthorized',
+  MastodonQuoteState.blockedDomain: 'blocked_domain',
+  MastodonQuoteState.blockedAccount: 'blocked_account',
+  MastodonQuoteState.mutedAccount: 'muted_account',
+  MastodonQuoteState.unknown: 'unknown',
 };
 
 MastodonStatusApplication _$MastodonStatusApplicationFromJson(

--- a/lib/src/models/mastodon_status_edit.dart
+++ b/lib/src/models/mastodon_status_edit.dart
@@ -3,6 +3,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'mastodon_account.dart';
 import 'mastodon_custom_emoji.dart';
 import 'mastodon_media_attachment.dart';
+import 'mastodon_status.dart';
 
 part 'mastodon_status_edit.freezed.dart';
 part 'mastodon_status_edit.g.dart';
@@ -23,6 +24,7 @@ class MastodonStatusEdit with _$MastodonStatusEdit {
     required this.mediaAttachments,
     required this.emojis,
     this.poll,
+    this.quote,
   });
 
   factory MastodonStatusEdit.fromJson(Map<String, dynamic> json) =>
@@ -67,6 +69,10 @@ class MastodonStatusEdit with _$MastodonStatusEdit {
   /// Poll at revision time. `null` if no poll.
   @override
   final MastodonStatusEditPoll? poll;
+
+  /// Quote relationship at revision time. `null` if not a quote.
+  @override
+  final MastodonQuote? quote;
 }
 
 /// Poll snapshot within the edit history.

--- a/lib/src/models/mastodon_status_edit.freezed.dart
+++ b/lib/src/models/mastodon_status_edit.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$MastodonStatusEdit {
 
- String get content; String get spoilerText; bool get sensitive; DateTime get createdAt; MastodonAccount get account; List<MastodonMediaAttachment> get mediaAttachments; List<MastodonCustomEmoji> get emojis; MastodonStatusEditPoll? get poll;
+ String get content; String get spoilerText; bool get sensitive; DateTime get createdAt; MastodonAccount get account; List<MastodonMediaAttachment> get mediaAttachments; List<MastodonCustomEmoji> get emojis; MastodonStatusEditPoll? get poll; MastodonQuote? get quote;
 /// Create a copy of MastodonStatusEdit
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,12 +26,12 @@ $MastodonStatusEditCopyWith<MastodonStatusEdit> get copyWith => _$MastodonStatus
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonStatusEdit&&(identical(other.content, content) || other.content == content)&&(identical(other.spoilerText, spoilerText) || other.spoilerText == spoilerText)&&(identical(other.sensitive, sensitive) || other.sensitive == sensitive)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.account, account) || other.account == account)&&const DeepCollectionEquality().equals(other.mediaAttachments, mediaAttachments)&&const DeepCollectionEquality().equals(other.emojis, emojis)&&(identical(other.poll, poll) || other.poll == poll));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonStatusEdit&&(identical(other.content, content) || other.content == content)&&(identical(other.spoilerText, spoilerText) || other.spoilerText == spoilerText)&&(identical(other.sensitive, sensitive) || other.sensitive == sensitive)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.account, account) || other.account == account)&&const DeepCollectionEquality().equals(other.mediaAttachments, mediaAttachments)&&const DeepCollectionEquality().equals(other.emojis, emojis)&&(identical(other.poll, poll) || other.poll == poll)&&(identical(other.quote, quote) || other.quote == quote));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,content,spoilerText,sensitive,createdAt,account,const DeepCollectionEquality().hash(mediaAttachments),const DeepCollectionEquality().hash(emojis),poll);
+int get hashCode => Object.hash(runtimeType,content,spoilerText,sensitive,createdAt,account,const DeepCollectionEquality().hash(mediaAttachments),const DeepCollectionEquality().hash(emojis),poll,quote);
 
 
 
@@ -42,7 +42,7 @@ abstract mixin class $MastodonStatusEditCopyWith<$Res>  {
   factory $MastodonStatusEditCopyWith(MastodonStatusEdit value, $Res Function(MastodonStatusEdit) _then) = _$MastodonStatusEditCopyWithImpl;
 @useResult
 $Res call({
- String content, String spoilerText, bool sensitive, DateTime createdAt, MastodonAccount account, List<MastodonMediaAttachment> mediaAttachments, List<MastodonCustomEmoji> emojis, MastodonStatusEditPoll? poll
+ String content, String spoilerText, bool sensitive, DateTime createdAt, MastodonAccount account, List<MastodonMediaAttachment> mediaAttachments, List<MastodonCustomEmoji> emojis, MastodonStatusEditPoll? poll, MastodonQuote? quote
 });
 
 
@@ -59,7 +59,7 @@ class _$MastodonStatusEditCopyWithImpl<$Res>
 
 /// Create a copy of MastodonStatusEdit
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? content = null,Object? spoilerText = null,Object? sensitive = null,Object? createdAt = null,Object? account = null,Object? mediaAttachments = null,Object? emojis = null,Object? poll = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? content = null,Object? spoilerText = null,Object? sensitive = null,Object? createdAt = null,Object? account = null,Object? mediaAttachments = null,Object? emojis = null,Object? poll = freezed,Object? quote = freezed,}) {
   return _then(MastodonStatusEdit(
 content: null == content ? _self.content : content // ignore: cast_nullable_to_non_nullable
 as String,spoilerText: null == spoilerText ? _self.spoilerText : spoilerText // ignore: cast_nullable_to_non_nullable
@@ -69,7 +69,8 @@ as DateTime,account: null == account ? _self.account : account // ignore: cast_n
 as MastodonAccount,mediaAttachments: null == mediaAttachments ? _self.mediaAttachments : mediaAttachments // ignore: cast_nullable_to_non_nullable
 as List<MastodonMediaAttachment>,emojis: null == emojis ? _self.emojis : emojis // ignore: cast_nullable_to_non_nullable
 as List<MastodonCustomEmoji>,poll: freezed == poll ? _self.poll : poll // ignore: cast_nullable_to_non_nullable
-as MastodonStatusEditPoll?,
+as MastodonStatusEditPoll?,quote: freezed == quote ? _self.quote : quote // ignore: cast_nullable_to_non_nullable
+as MastodonQuote?,
   ));
 }
 

--- a/lib/src/models/mastodon_status_edit.g.dart
+++ b/lib/src/models/mastodon_status_edit.g.dart
@@ -31,6 +31,9 @@ MastodonStatusEdit _$MastodonStatusEditFromJson(
   poll: json['poll'] == null
       ? null
       : MastodonStatusEditPoll.fromJson(json['poll'] as Map<String, dynamic>),
+  quote: json['quote'] == null
+      ? null
+      : MastodonQuote.fromJson(json['quote'] as Map<String, dynamic>),
 );
 
 Map<String, dynamic> _$MastodonStatusEditToJson(MastodonStatusEdit instance) =>
@@ -45,6 +48,7 @@ Map<String, dynamic> _$MastodonStatusEditToJson(MastodonStatusEdit instance) =>
           .toList(),
       'emojis': instance.emojis.map((e) => e.toJson()).toList(),
       'poll': instance.poll?.toJson(),
+      'quote': instance.quote?.toJson(),
     };
 
 MastodonStatusEditPoll _$MastodonStatusEditPollFromJson(

--- a/test/fixtures/quote_full.json
+++ b/test/fixtures/quote_full.json
@@ -1,0 +1,23 @@
+{
+  "state": "accepted",
+  "quoted_status": {
+    "id": "117100000000000001",
+    "created_at": "2026-08-25T12:00:00.000Z",
+    "sensitive": false,
+    "spoiler_text": "",
+    "visibility": "public",
+    "content": "<p>Quoted status</p>",
+    "reblogs_count": 0,
+    "favourites_count": 0,
+    "replies_count": 0,
+    "account": {
+      "id": "117100000000000002",
+      "username": "quote_author",
+      "acct": "quote_author"
+    },
+    "media_attachments": [],
+    "mentions": [],
+    "tags": [],
+    "emojis": []
+  }
+}

--- a/test/fixtures/quote_pending.json
+++ b/test/fixtures/quote_pending.json
@@ -1,0 +1,4 @@
+{
+  "state": "pending",
+  "quoted_status": null
+}

--- a/test/fixtures/quote_shallow.json
+++ b/test/fixtures/quote_shallow.json
@@ -1,0 +1,4 @@
+{
+  "state": "accepted",
+  "quoted_status_id": "117100000000000001"
+}

--- a/test/fixtures/quote_unknown.json
+++ b/test/fixtures/quote_unknown.json
@@ -1,0 +1,4 @@
+{
+  "state": "future_state",
+  "quoted_status": null
+}

--- a/test/models/freezed_model_test.dart
+++ b/test/models/freezed_model_test.dart
@@ -55,7 +55,7 @@ void main() {
         freezedCount += fileFreezedCount;
       }
 
-      expect(jsonSerializableCount, 133);
+      expect(jsonSerializableCount, 134);
       expect(freezedCount, jsonSerializableCount);
     });
 

--- a/test/models/mastodon_status_edit_test.dart
+++ b/test/models/mastodon_status_edit_test.dart
@@ -47,5 +47,22 @@ void main() {
 
       expect(edits.length, 1);
     });
+
+    test('deserializes the quote relationship from edit history', () {
+      final history =
+          jsonDecode(
+                File('test/fixtures/status_history.json').readAsStringSync(),
+              )
+              as List<dynamic>;
+      final quote =
+          jsonDecode(File('test/fixtures/quote_full.json').readAsStringSync())
+              as Map<String, dynamic>;
+      final json = {...(history.first as Map<String, dynamic>), 'quote': quote};
+
+      final edit = MastodonStatusEdit.fromJson(json);
+
+      expect(edit.quote?.state, MastodonQuoteState.accepted);
+      expect(edit.quote?.quotedStatus?.id, '117100000000000001');
+    });
   });
 }

--- a/test/models/mastodon_status_test.dart
+++ b/test/models/mastodon_status_test.dart
@@ -200,6 +200,63 @@ void main() {
       expect(status.quoteApproval, isNull);
       expect(status.quotesCount, 0);
     });
+
+    test('deserializes a full quote with an embedded status', () {
+      final statusJson =
+          jsonDecode(File('test/fixtures/status.json').readAsStringSync())
+              as Map<String, dynamic>;
+      final quoteJson =
+          jsonDecode(File('test/fixtures/quote_full.json').readAsStringSync())
+              as Map<String, dynamic>;
+
+      final status = MastodonStatus.fromJson({
+        ...statusJson,
+        'quote': quoteJson,
+      });
+
+      expect(status.quote?.state, MastodonQuoteState.accepted);
+      expect(status.quote?.quotedStatus?.id, '117100000000000001');
+      expect(status.quote?.quotedStatus?.content, '<p>Quoted status</p>');
+      expect(status.quote?.quotedStatusId, isNull);
+    });
+
+    test('deserializes a shallow quote with only the quoted status ID', () {
+      final json =
+          jsonDecode(
+                File('test/fixtures/quote_shallow.json').readAsStringSync(),
+              )
+              as Map<String, dynamic>;
+
+      final quote = MastodonQuote.fromJson(json);
+
+      expect(quote.state, MastodonQuoteState.accepted);
+      expect(quote.quotedStatus, isNull);
+      expect(quote.quotedStatusId, '117100000000000001');
+    });
+
+    test('deserializes a pending quote without a visible status', () {
+      final json =
+          jsonDecode(
+                File('test/fixtures/quote_pending.json').readAsStringSync(),
+              )
+              as Map<String, dynamic>;
+
+      final quote = MastodonQuote.fromJson(json);
+
+      expect(quote.state, MastodonQuoteState.pending);
+      expect(quote.quotedStatus, isNull);
+      expect(quote.quotedStatusId, isNull);
+    });
+
+    test('maps a future quote state to unknown', () {
+      final json =
+          jsonDecode(
+                File('test/fixtures/quote_unknown.json').readAsStringSync(),
+              )
+              as Map<String, dynamic>;
+
+      expect(MastodonQuote.fromJson(json).state, MastodonQuoteState.unknown);
+    });
   });
 
   group('MastodonStatus.fromJson - status_with_poll.json', () {


### PR DESCRIPTION
## 概要

Mastodon 4.5以降のStatusレスポンスが返すQuoteエンティティを正しい型で解析できるようにします。従来はQuoteをStatusとして解析していたため、引用投稿を含むレスポンスでTypeErrorが発生していました。

## 対応内容

- `MastodonQuote` と `MastodonQuoteState` を追加
- full `quoted_status` とshallow `quoted_status_id` の両形状に対応
- 既知9 stateと未知値fallbackに対応
- `MastodonStatus.quote` を `MastodonQuote?` へ変更
- `MastodonStatusEdit.quote` を追加
- 4形状のfixtureと回帰テストを追加
- APIドキュメント6言語とCHANGELOGを更新

## 互換性

`MastodonStatus.quote` の型変更は破壊的変更です。引用先Statusは `status.quote?.quotedStatus` から取得します。

## 検証

- `dart analyze --fatal-infos`: 成功
- 対象テスト: 32件成功
- 全テスト: 310件成功、E2E 4件skip
- build_runner再実行: 差分なし
- `dart pub publish --dry-run`: 0 warnings

Closes #43
