### PR TITLE
fix: v1通知のevent・report・filteredを正しく解析 (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   embedded status through `status.quote?.quotedStatus`; shallow nested quotes
   expose `quotedStatusId` instead. Edit history now exposes the same entity via
   `MastodonStatusEdit.quote` (issue #43)
+- `MastodonNotification` now reads relationship severance details from the
+  server's `event` key and exposes admin reports through `report` and the v1
+  notification filter flag through `filtered`. Its `toJson()` output now uses
+  `event` instead of the incorrect `relationship_severance_event` key (issue #44)
 
 ## [1.0.0-beta.3] - 2026-08-25
 

--- a/docs/docs/api/notifications.md
+++ b/docs/docs/api/notifications.md
@@ -38,6 +38,20 @@ final page = await client.notifications.fetch(
 final notification = await client.notifications.fetchById('12345');
 ```
 
+### Notification-specific details
+
+Some v1 notifications include additional details:
+
+```dart
+final event = notification.relationshipSeveranceEvent; // severed_relationships
+final report = notification.report;                    // admin.report
+final wasFiltered = notification.filtered;             // Mastodon 4.3+
+```
+
+`filtered` defaults to false because the server includes it only when true.
+Grouped v2 notifications expose severance details as `group.event` and reports
+as `group.report`; they do not have a per-notification `filtered` field.
+
 ### Unread count (Mastodon 4.3+)
 
 ```dart

--- a/docs/i18n/de/docusaurus-plugin-content-docs/current/api/notifications.md
+++ b/docs/i18n/de/docusaurus-plugin-content-docs/current/api/notifications.md
@@ -38,6 +38,21 @@ final page = await client.notifications.fetch(
 final notification = await client.notifications.fetchById('12345');
 ```
 
+### Benachrichtigungsspezifische Details
+
+Einige v1-Benachrichtigungen enthalten zusätzliche Details:
+
+```dart
+final event = notification.relationshipSeveranceEvent; // severed_relationships
+final report = notification.report;                    // admin.report
+final wasFiltered = notification.filtered;             // Mastodon 4.3+
+```
+
+`filtered` ist standardmäßig false, da der Server das Feld nur bei true sendet.
+Gruppierte v2-Benachrichtigungen stellen Trennungsdetails als `group.event` und
+Meldungen als `group.report` bereit; sie besitzen kein `filtered`-Feld pro
+Benachrichtigung.
+
 ### Anzahl ungelesener Benachrichtigungen (Mastodon 4.3+)
 
 ```dart

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/api/notifications.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/api/notifications.md
@@ -38,6 +38,21 @@ final page = await client.notifications.fetch(
 final notification = await client.notifications.fetchById('12345');
 ```
 
+### Détails propres à la notification
+
+Certaines notifications v1 contiennent des détails supplémentaires :
+
+```dart
+final event = notification.relationshipSeveranceEvent; // severed_relationships
+final report = notification.report;                    // admin.report
+final wasFiltered = notification.filtered;             // Mastodon 4.3+
+```
+
+`filtered` vaut false par défaut, car le serveur ne l'inclut que lorsqu'il vaut
+true. Les notifications groupées v2 exposent les ruptures via `group.event` et
+les signalements via `group.report` ; elles n'ont pas de champ `filtered` par
+notification.
+
 ### Nombre non lus (Mastodon 4.3+)
 
 ```dart

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/api/notifications.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/api/notifications.md
@@ -38,6 +38,20 @@ final page = await client.notifications.fetch(
 final notification = await client.notifications.fetchById('12345');
 ```
 
+### 通知種別ごとの詳細
+
+一部の v1 通知には追加の詳細情報が含まれます。
+
+```dart
+final event = notification.relationshipSeveranceEvent; // severed_relationships
+final report = notification.report;                    // admin.report
+final wasFiltered = notification.filtered;             // Mastodon 4.3+
+```
+
+サーバーは true の場合にのみキーを返すため、`filtered` の既定値は false です。
+グループ化された v2 通知では関係切断の詳細を `group.event`、通報を
+`group.report` から取得できますが、通知単位の `filtered` フィールドはありません。
+
 ### 未読数（Mastodon 4.3+）
 
 ```dart

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/notifications.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/notifications.md
@@ -38,6 +38,20 @@ final page = await client.notifications.fetch(
 final notification = await client.notifications.fetchById('12345');
 ```
 
+### 알림 유형별 세부 정보
+
+일부 v1 알림에는 추가 세부 정보가 포함됩니다.
+
+```dart
+final event = notification.relationshipSeveranceEvent; // severed_relationships
+final report = notification.report;                    // admin.report
+final wasFiltered = notification.filtered;             // Mastodon 4.3+
+```
+
+서버는 값이 true일 때만 키를 포함하므로 `filtered`의 기본값은 false입니다.
+그룹화된 v2 알림에서는 관계 단절 정보를 `group.event`, 신고를 `group.report`로
+제공하지만 알림별 `filtered` 필드는 없습니다.
+
 ### 읽지 않은 알림 수 (Mastodon 4.3+)
 
 ```dart

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/api/notifications.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/api/notifications.md
@@ -38,6 +38,20 @@ final page = await client.notifications.fetch(
 final notification = await client.notifications.fetchById('12345');
 ```
 
+### 通知类型特有的详细信息
+
+部分 v1 通知包含附加详细信息：
+
+```dart
+final event = notification.relationshipSeveranceEvent; // severed_relationships
+final report = notification.report;                    // admin.report
+final wasFiltered = notification.filtered;             // Mastodon 4.3+
+```
+
+服务器仅在值为 true 时返回该键，因此 `filtered` 默认为 false。分组的 v2 通知
+通过 `group.event` 提供关系断开详情，通过 `group.report` 提供举报；它们没有
+每条通知的 `filtered` 字段。
+
 ### 未读数量（Mastodon 4.3+）
 
 ```dart

--- a/lib/src/models/mastodon_notification.dart
+++ b/lib/src/models/mastodon_notification.dart
@@ -3,6 +3,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'json_converters.dart';
 import 'mastodon_account.dart';
 import 'mastodon_collection.dart';
+import 'mastodon_report.dart';
 import 'mastodon_status.dart';
 
 part 'mastodon_notification.freezed.dart';
@@ -233,10 +234,12 @@ class MastodonNotification with _$MastodonNotification {
     required this.account,
     this.groupKey,
     this.status,
+    this.report,
     this.relationshipSeveranceEvent,
     this.moderationWarning,
     this.collection,
     this.fallback,
+    this.filtered = false,
   });
 
   factory MastodonNotification.fromJson(Map<String, dynamic> json) =>
@@ -282,9 +285,16 @@ class MastodonNotification with _$MastodonNotification {
   @override
   final MastodonStatus? status;
 
+  /// Associated report.
+  ///
+  /// Non-null only for [MastodonNotificationType.adminReport].
+  @override
+  final MastodonReport? report;
+
   /// Details of the relationship severance event.
   ///
   /// Non-null only for [MastodonNotificationType.severedRelationships].
+  @JsonKey(name: 'event')
   @override
   final MastodonRelationshipSeveranceEvent? relationshipSeveranceEvent;
 
@@ -300,4 +310,11 @@ class MastodonNotification with _$MastodonNotification {
   /// Generic rendering for a notification type not supported by the client.
   @override
   final MastodonNotificationFallback? fallback;
+
+  /// Whether this notification was filtered by a notification policy.
+  ///
+  /// Added in Mastodon 4.3.0. The server omits this key when it is false.
+  @JsonKey(defaultValue: false)
+  @override
+  final bool filtered;
 }

--- a/lib/src/models/mastodon_notification.freezed.dart
+++ b/lib/src/models/mastodon_notification.freezed.dart
@@ -755,7 +755,7 @@ case _:
 /// @nodoc
 mixin _$MastodonNotification {
 
- String get id; MastodonNotificationType get type; DateTime get createdAt; MastodonAccount get account; String? get groupKey; MastodonStatus? get status; MastodonRelationshipSeveranceEvent? get relationshipSeveranceEvent; MastodonAccountWarning? get moderationWarning; MastodonCollection? get collection; MastodonNotificationFallback? get fallback;
+ String get id; MastodonNotificationType get type; DateTime get createdAt; MastodonAccount get account; String? get groupKey; MastodonStatus? get status; MastodonReport? get report; MastodonRelationshipSeveranceEvent? get relationshipSeveranceEvent; MastodonAccountWarning? get moderationWarning; MastodonCollection? get collection; MastodonNotificationFallback? get fallback; bool get filtered;
 /// Create a copy of MastodonNotification
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -766,12 +766,12 @@ $MastodonNotificationCopyWith<MastodonNotification> get copyWith => _$MastodonNo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonNotification&&(identical(other.id, id) || other.id == id)&&(identical(other.type, type) || other.type == type)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.account, account) || other.account == account)&&(identical(other.groupKey, groupKey) || other.groupKey == groupKey)&&(identical(other.status, status) || other.status == status)&&(identical(other.relationshipSeveranceEvent, relationshipSeveranceEvent) || other.relationshipSeveranceEvent == relationshipSeveranceEvent)&&(identical(other.moderationWarning, moderationWarning) || other.moderationWarning == moderationWarning)&&(identical(other.collection, collection) || other.collection == collection)&&(identical(other.fallback, fallback) || other.fallback == fallback));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonNotification&&(identical(other.id, id) || other.id == id)&&(identical(other.type, type) || other.type == type)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.account, account) || other.account == account)&&(identical(other.groupKey, groupKey) || other.groupKey == groupKey)&&(identical(other.status, status) || other.status == status)&&(identical(other.report, report) || other.report == report)&&(identical(other.relationshipSeveranceEvent, relationshipSeveranceEvent) || other.relationshipSeveranceEvent == relationshipSeveranceEvent)&&(identical(other.moderationWarning, moderationWarning) || other.moderationWarning == moderationWarning)&&(identical(other.collection, collection) || other.collection == collection)&&(identical(other.fallback, fallback) || other.fallback == fallback)&&(identical(other.filtered, filtered) || other.filtered == filtered));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,type,createdAt,account,groupKey,status,relationshipSeveranceEvent,moderationWarning,collection,fallback);
+int get hashCode => Object.hash(runtimeType,id,type,createdAt,account,groupKey,status,report,relationshipSeveranceEvent,moderationWarning,collection,fallback,filtered);
 
 
 
@@ -782,7 +782,7 @@ abstract mixin class $MastodonNotificationCopyWith<$Res>  {
   factory $MastodonNotificationCopyWith(MastodonNotification value, $Res Function(MastodonNotification) _then) = _$MastodonNotificationCopyWithImpl;
 @useResult
 $Res call({
- String id, MastodonNotificationType type, DateTime createdAt, MastodonAccount account, String? groupKey, MastodonStatus? status, MastodonRelationshipSeveranceEvent? relationshipSeveranceEvent, MastodonAccountWarning? moderationWarning, MastodonCollection? collection, MastodonNotificationFallback? fallback
+ String id, MastodonNotificationType type, DateTime createdAt, MastodonAccount account, String? groupKey, MastodonStatus? status, MastodonReport? report, MastodonRelationshipSeveranceEvent? relationshipSeveranceEvent, MastodonAccountWarning? moderationWarning, MastodonCollection? collection, MastodonNotificationFallback? fallback, bool filtered
 });
 
 
@@ -799,7 +799,7 @@ class _$MastodonNotificationCopyWithImpl<$Res>
 
 /// Create a copy of MastodonNotification
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? type = null,Object? createdAt = null,Object? account = null,Object? groupKey = freezed,Object? status = freezed,Object? relationshipSeveranceEvent = freezed,Object? moderationWarning = freezed,Object? collection = freezed,Object? fallback = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? type = null,Object? createdAt = null,Object? account = null,Object? groupKey = freezed,Object? status = freezed,Object? report = freezed,Object? relationshipSeveranceEvent = freezed,Object? moderationWarning = freezed,Object? collection = freezed,Object? fallback = freezed,Object? filtered = null,}) {
   return _then(MastodonNotification(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
@@ -807,11 +807,13 @@ as MastodonNotificationType,createdAt: null == createdAt ? _self.createdAt : cre
 as DateTime,account: null == account ? _self.account : account // ignore: cast_nullable_to_non_nullable
 as MastodonAccount,groupKey: freezed == groupKey ? _self.groupKey : groupKey // ignore: cast_nullable_to_non_nullable
 as String?,status: freezed == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
-as MastodonStatus?,relationshipSeveranceEvent: freezed == relationshipSeveranceEvent ? _self.relationshipSeveranceEvent : relationshipSeveranceEvent // ignore: cast_nullable_to_non_nullable
+as MastodonStatus?,report: freezed == report ? _self.report : report // ignore: cast_nullable_to_non_nullable
+as MastodonReport?,relationshipSeveranceEvent: freezed == relationshipSeveranceEvent ? _self.relationshipSeveranceEvent : relationshipSeveranceEvent // ignore: cast_nullable_to_non_nullable
 as MastodonRelationshipSeveranceEvent?,moderationWarning: freezed == moderationWarning ? _self.moderationWarning : moderationWarning // ignore: cast_nullable_to_non_nullable
 as MastodonAccountWarning?,collection: freezed == collection ? _self.collection : collection // ignore: cast_nullable_to_non_nullable
 as MastodonCollection?,fallback: freezed == fallback ? _self.fallback : fallback // ignore: cast_nullable_to_non_nullable
-as MastodonNotificationFallback?,
+as MastodonNotificationFallback?,filtered: null == filtered ? _self.filtered : filtered // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 

--- a/lib/src/models/mastodon_notification.g.dart
+++ b/lib/src/models/mastodon_notification.g.dart
@@ -95,10 +95,13 @@ MastodonNotification _$MastodonNotificationFromJson(
   status: json['status'] == null
       ? null
       : MastodonStatus.fromJson(json['status'] as Map<String, dynamic>),
-  relationshipSeveranceEvent: json['relationship_severance_event'] == null
+  report: json['report'] == null
+      ? null
+      : MastodonReport.fromJson(json['report'] as Map<String, dynamic>),
+  relationshipSeveranceEvent: json['event'] == null
       ? null
       : MastodonRelationshipSeveranceEvent.fromJson(
-          json['relationship_severance_event'] as Map<String, dynamic>,
+          json['event'] as Map<String, dynamic>,
         ),
   moderationWarning: json['moderation_warning'] == null
       ? null
@@ -113,6 +116,7 @@ MastodonNotification _$MastodonNotificationFromJson(
       : MastodonNotificationFallback.fromJson(
           json['fallback'] as Map<String, dynamic>,
         ),
+  filtered: json['filtered'] as bool? ?? false,
 );
 
 Map<String, dynamic> _$MastodonNotificationToJson(
@@ -124,10 +128,12 @@ Map<String, dynamic> _$MastodonNotificationToJson(
   'account': instance.account.toJson(),
   'group_key': instance.groupKey,
   'status': instance.status?.toJson(),
-  'relationship_severance_event': instance.relationshipSeveranceEvent?.toJson(),
+  'report': instance.report?.toJson(),
+  'event': instance.relationshipSeveranceEvent?.toJson(),
   'moderation_warning': instance.moderationWarning?.toJson(),
   'collection': instance.collection?.toJson(),
   'fallback': instance.fallback?.toJson(),
+  'filtered': instance.filtered,
 };
 
 const _$MastodonNotificationTypeEnumMap = {

--- a/test/fixtures/notifications_specialized.json
+++ b/test/fixtures/notifications_specialized.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "901",
+    "type": "severed_relationships",
+    "created_at": "2026-08-25T10:00:00.000Z",
+    "account": {
+      "id": "117100000000000010",
+      "username": "moderator",
+      "acct": "moderator"
+    },
+    "event": {
+      "id": "42",
+      "type": "domain_block",
+      "purged": false,
+      "target_name": "remote.example",
+      "followers_count": 3,
+      "following_count": 5,
+      "created_at": "2026-08-25T09:59:00.000Z"
+    }
+  },
+  {
+    "id": "902",
+    "type": "admin.report",
+    "created_at": "2026-08-25T11:00:00.000Z",
+    "account": {
+      "id": "117100000000000011",
+      "username": "reporter",
+      "acct": "reporter@remote.example"
+    },
+    "report": {
+      "id": "73",
+      "action_taken": false,
+      "action_taken_at": null,
+      "category": "spam",
+      "comment": "Repeated unsolicited messages",
+      "forwarded": true,
+      "created_at": "2026-08-25T10:58:00.000Z",
+      "status_ids": ["117100000000000012"],
+      "rule_ids": [],
+      "target_account": {
+        "id": "117100000000000013",
+        "username": "reported_user",
+        "acct": "reported_user@remote.example"
+      }
+    }
+  },
+  {
+    "id": "903",
+    "type": "mention",
+    "created_at": "2026-08-25T12:00:00.000Z",
+    "account": {
+      "id": "117100000000000014",
+      "username": "filtered_user",
+      "acct": "filtered_user"
+    },
+    "filtered": true
+  }
+]

--- a/test/models/fixture_key_coverage_test.dart
+++ b/test/models/fixture_key_coverage_test.dart
@@ -31,6 +31,8 @@ void main() {
     'instance_v2.json': (json) => MastodonInstance.fromJson(json).toJson(),
     'notifications.json': (json) =>
         MastodonNotification.fromJson(json).toJson(),
+    'notifications_specialized.json': (json) =>
+        MastodonNotification.fromJson(json).toJson(),
     'relationships.json': (json) =>
         MastodonRelationship.fromJson(json).toJson(),
     'suggestions.json': (json) => MastodonSuggestion.fromJson(json).toJson(),
@@ -52,22 +54,24 @@ void main() {
         final decoded = jsonDecode(
           File('test/fixtures/$fixture').readAsStringSync(),
         );
-        final json =
-            (decoded is List ? decoded.first : decoded) as Map<String, dynamic>;
+        final entries = decoded is List<dynamic> ? decoded : [decoded];
 
-        final missing = json.keys.toSet()
-          ..removeAll(roundTrip(json).keys)
-          ..removeAll(knownDivergences[fixture] ?? const <String>{});
+        for (var index = 0; index < entries.length; index++) {
+          final json = entries[index] as Map<String, dynamic>;
+          final missing = json.keys.toSet()
+            ..removeAll(roundTrip(json).keys)
+            ..removeAll(knownDivergences[fixture] ?? const <String>{});
 
-        expect(
-          missing,
-          isEmpty,
-          reason:
-              'サーバーが返しているが $fixture のモデルが読んでいないキー: '
-              '${missing.toList()..sort()}\n'
-              'モデルにフィールドを追加するか、意図的な差異なら '
-              'knownDivergences に登録すること',
-        );
+          expect(
+            missing,
+            isEmpty,
+            reason:
+                'サーバーが返しているが $fixture のモデルが読んでいないキー '
+                '(要素 $index): ${missing.toList()..sort()}\n'
+                'モデルにフィールドを追加するか、意図的な差異なら '
+                'knownDivergences に登録すること',
+          );
+        }
       });
     });
   });

--- a/test/models/mastodon_notification_test.dart
+++ b/test/models/mastodon_notification_test.dart
@@ -77,4 +77,71 @@ void main() {
       expect(notification.fallback?.description, isNull);
     });
   });
+
+  group('MastodonNotification specialized fields (Mastodon 4.3.0+)', () {
+    late List<MastodonNotification> notifications;
+
+    setUpAll(() {
+      final list =
+          jsonDecode(
+                File(
+                  'test/fixtures/notifications_specialized.json',
+                ).readAsStringSync(),
+              )
+              as List<dynamic>;
+      notifications = list
+          .map(
+            (json) =>
+                MastodonNotification.fromJson(json as Map<String, dynamic>),
+          )
+          .toList();
+    });
+
+    test('reads a relationship severance event from the event key', () {
+      final notification = notifications[0];
+
+      expect(notification.type, MastodonNotificationType.severedRelationships);
+      expect(notification.relationshipSeveranceEvent?.id, '42');
+      expect(
+        notification.relationshipSeveranceEvent?.targetName,
+        'remote.example',
+      );
+      expect(notification.relationshipSeveranceEvent?.followersCount, 3);
+      expect(notification.relationshipSeveranceEvent?.followingCount, 5);
+      expect(notification.toJson(), contains('event'));
+      expect(
+        notification.toJson(),
+        isNot(contains('relationship_severance_event')),
+      );
+    });
+
+    test('deserializes the report on an admin report notification', () {
+      final notification = notifications[1];
+
+      expect(notification.type, MastodonNotificationType.adminReport);
+      expect(notification.report?.id, '73');
+      expect(notification.report?.category, 'spam');
+      expect(notification.report?.statusIds, ['117100000000000012']);
+      expect(notification.report?.targetAccount?.username, 'reported_user');
+    });
+
+    test('deserializes an explicitly filtered v1 notification', () {
+      expect(notifications[2].filtered, isTrue);
+    });
+
+    test('defaults filtered to false when the server omits the key', () {
+      final list =
+          jsonDecode(
+                File('test/fixtures/notifications.json').readAsStringSync(),
+              )
+              as List<dynamic>;
+
+      expect(
+        MastodonNotification.fromJson(
+          list.first as Map<String, dynamic>,
+        ).filtered,
+        isFalse,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## 概要

PR #62を親とするStack PRです。v1通知モデルがMastodon本体のJSONキーと属性を正しく読み取れるようにします。

## 対応内容

- `relationshipSeveranceEvent` の公開名を維持しつつ `event` キーへ対応
- `MastodonNotification.report` を追加
- `MastodonNotification.filtered` を既定値 `false` で追加
- specialized notification 3形状のfixtureと回帰テストを追加
- fixture key coverageをリストの全要素へ拡張
- APIドキュメント6言語とCHANGELOGを更新
- v2 notification groupには通知単位の`filtered`がない点を明記

## 検証

- `dart analyze --fatal-infos`: 成功
- 対象テスト: 36件成功
- 全テスト: 315件成功、E2E 4件skip
- build_runner再実行: 差分なし
- `dart pub publish --dry-run`: 0 warnings

## Stack

- Parent: #62
- このPRは#62のmerge後にbaseをdevelopへ切り替える想定です。

Closes #44
