### PR TITLE
fix: Push subscription更新のpolicyとalertsを保持 (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Web Push subscription updates so `policy` is nested inside `data`,
+  documented the server's whole-data replacement behavior, and rejected empty
+  updates before they can silently clear existing settings (issue #45)
+
 ## [1.0.0-beta.3] - 2026-08-25
 
 ### Added

--- a/docs/docs/api/push.md
+++ b/docs/docs/api/push.md
@@ -34,7 +34,7 @@ print(subscription.serverKey); // use to verify incoming pushes
 
 ### Alert types
 
-`MastodonPushAlertSettings` accepts any combination of the following fields. Fields set to `null` are omitted from the request and left unchanged.
+`MastodonPushAlertSettings` accepts any combination of the following fields. Fields set to `null` are omitted from the request. On creation, omitted fields use the server defaults. Updates replace the whole settings object as described below.
 
 | Field | Description |
 |-------|-------------|
@@ -71,7 +71,7 @@ print(subscription.policy);
 
 ## Updating alert settings
 
-Use `update` to change alert settings or the policy without recreating the subscription. Only the `data` portion (alerts and policy) can be changed.
+Use `update` to replace the subscription's `data` portion (alerts and policy) without recreating the subscription. This is not a partial update: every omitted alert type becomes disabled, and omitting `policy` resets it to `all`. Send every alert type that should remain enabled. A request with neither `alerts` nor `policy` throws `ArgumentError` before sending an HTTP request.
 
 ```dart
 final updated = await client.push.update(
@@ -79,8 +79,21 @@ final updated = await client.push.update(
     alerts: MastodonPushAlertSettings(
       mention: true,
       follow: false,
+      reblog: true,
+      favourite: true,
+      poll: true,
     ),
     policy: 'all',
+  ),
+);
+```
+
+To explicitly disable every alert and reset the policy to `all`, send an empty alert settings object:
+
+```dart
+await client.push.update(
+  const MastodonPushSubscriptionUpdateRequest(
+    alerts: MastodonPushAlertSettings(),
   ),
 );
 ```

--- a/docs/i18n/de/docusaurus-plugin-content-docs/current/api/push.md
+++ b/docs/i18n/de/docusaurus-plugin-content-docs/current/api/push.md
@@ -34,7 +34,7 @@ print(subscription.serverKey); // use to verify incoming pushes
 
 ### Alert-Typen
 
-`MastodonPushAlertSettings` akzeptiert jede Kombination der folgenden Felder. Auf `null` gesetzte Felder werden aus der Anfrage weggelassen und bleiben unverändert.
+`MastodonPushAlertSettings` akzeptiert jede Kombination der folgenden Felder. Auf `null` gesetzte Felder werden aus der Anfrage weggelassen. Beim Erstellen gelten für ausgelassene Felder die Server-Standardwerte. Beim Aktualisieren wird das gesamte Einstellungsobjekt wie unten beschrieben ersetzt.
 
 | Feld | Beschreibung |
 |------|-------------|
@@ -71,7 +71,7 @@ print(subscription.policy);
 
 ## Alert-Einstellungen aktualisieren
 
-Mit `update` können Alert-Einstellungen oder die Richtlinie geändert werden, ohne das Abonnement neu zu erstellen. Nur der `data`-Teil (Alerts und Richtlinie) kann geändert werden.
+Mit `update` wird der `data`-Teil (Alerts und Richtlinie) ersetzt, ohne das Abonnement neu zu erstellen. Dies ist keine Teilaktualisierung: Jeder ausgelassene Alert-Typ wird deaktiviert, und eine ausgelassene `policy` wird auf `all` zurückgesetzt. Geben Sie jeden Alert-Typ an, der aktiviert bleiben soll. Werden sowohl `alerts` als auch `policy` ausgelassen, wird vor dem Senden einer HTTP-Anfrage ein `ArgumentError` ausgelöst.
 
 ```dart
 final updated = await client.push.update(
@@ -79,8 +79,21 @@ final updated = await client.push.update(
     alerts: MastodonPushAlertSettings(
       mention: true,
       follow: false,
+      reblog: true,
+      favourite: true,
+      poll: true,
     ),
     policy: 'all',
+  ),
+);
+```
+
+Um alle Alerts ausdrücklich zu deaktivieren und die Richtlinie auf `all` zurückzusetzen, senden Sie ein leeres Alert-Einstellungsobjekt:
+
+```dart
+await client.push.update(
+  const MastodonPushSubscriptionUpdateRequest(
+    alerts: MastodonPushAlertSettings(),
   ),
 );
 ```

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/api/push.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/api/push.md
@@ -34,7 +34,7 @@ print(subscription.serverKey); // use to verify incoming pushes
 
 ### Types d'alertes
 
-`MastodonPushAlertSettings` accepte toute combinaison des champs suivants. Les champs définis à `null` sont omis de la requête et restent inchangés.
+`MastodonPushAlertSettings` accepte toute combinaison des champs suivants. Les champs définis à `null` sont omis de la requête. Lors de la création, les champs omis utilisent les valeurs par défaut du serveur. Lors d'une mise à jour, l'ensemble des paramètres est remplacé comme décrit ci-dessous.
 
 | Champ | Description |
 |-------|-------------|
@@ -71,7 +71,7 @@ print(subscription.policy);
 
 ## Mettre à jour les paramètres d'alerte
 
-Utilisez `update` pour modifier les paramètres d'alerte ou la politique sans recréer l'abonnement. Seule la partie `data` (alertes et politique) peut être modifiée.
+Utilisez `update` pour remplacer la partie `data` (alertes et politique) sans recréer l'abonnement. Il ne s'agit pas d'une mise à jour partielle : chaque type d'alerte omis est désactivé et l'omission de `policy` la réinitialise à `all`. Indiquez chaque type d'alerte qui doit rester activé. Si `alerts` et `policy` sont tous deux omis, une `ArgumentError` est levée avant l'envoi d'une requête HTTP.
 
 ```dart
 final updated = await client.push.update(
@@ -79,8 +79,21 @@ final updated = await client.push.update(
     alerts: MastodonPushAlertSettings(
       mention: true,
       follow: false,
+      reblog: true,
+      favourite: true,
+      poll: true,
     ),
     policy: 'all',
+  ),
+);
+```
+
+Pour désactiver explicitement toutes les alertes et réinitialiser la politique à `all`, envoyez un objet de paramètres d'alerte vide :
+
+```dart
+await client.push.update(
+  const MastodonPushSubscriptionUpdateRequest(
+    alerts: MastodonPushAlertSettings(),
   ),
 );
 ```

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/api/push.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/api/push.md
@@ -34,7 +34,7 @@ print(subscription.serverKey); // プッシュメッセージの検証に使用
 
 ### 通知タイプ
 
-`MastodonPushAlertSettings` には以下のフィールドを任意の組み合わせで指定できます。`null` のフィールドはリクエストから除外され、変更されません。
+`MastodonPushAlertSettings` には以下のフィールドを任意の組み合わせで指定できます。`null` のフィールドはリクエストから除外されます。作成時は除外したフィールドにサーバーの既定値が使われます。更新時は後述のとおり設定全体が置き換えられます。
 
 | フィールド | 説明 |
 |-----------|------|
@@ -71,7 +71,7 @@ print(subscription.policy);
 
 ## 通知設定の更新
 
-サブスクリプションを再作成せずに通知設定やポリシーを変更するには `update` を使います。変更できるのは `data` 部分（alerts と policy）のみです。
+サブスクリプションを再作成せずに `data` 部分（alerts と policy）を置き換えるには `update` を使います。これは部分更新ではありません。指定しなかった通知タイプはすべて無効になり、`policy` を省略すると `all` に戻ります。有効なままにする通知タイプはすべて指定してください。`alerts` と `policy` の両方を省略すると、HTTP リクエストを送る前に `ArgumentError` がスローされます。
 
 ```dart
 final updated = await client.push.update(
@@ -79,8 +79,21 @@ final updated = await client.push.update(
     alerts: MastodonPushAlertSettings(
       mention: true,
       follow: false,
+      reblog: true,
+      favourite: true,
+      poll: true,
     ),
     policy: 'all',
+  ),
+);
+```
+
+すべての通知を明示的に無効化し、ポリシーを `all` に戻すには、空の通知設定を送信します。
+
+```dart
+await client.push.update(
+  const MastodonPushSubscriptionUpdateRequest(
+    alerts: MastodonPushAlertSettings(),
   ),
 );
 ```

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/push.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/push.md
@@ -34,7 +34,7 @@ print(subscription.serverKey); // 수신된 푸시 검증에 사용
 
 ### 알림 타입
 
-`MastodonPushAlertSettings`는 다음 필드의 임의 조합을 허용합니다. `null`로 설정된 필드는 요청에서 생략되어 변경되지 않습니다.
+`MastodonPushAlertSettings`는 다음 필드의 임의 조합을 허용합니다. `null`로 설정된 필드는 요청에서 생략됩니다. 구독을 생성할 때 생략된 필드에는 서버 기본값이 사용됩니다. 업데이트할 때는 아래 설명과 같이 전체 설정 객체가 교체됩니다.
 
 | 필드 | 설명 |
 |------|------|
@@ -71,7 +71,7 @@ print(subscription.policy);
 
 ## 알림 설정 업데이트
 
-`update`를 사용하면 구독을 재생성하지 않고 알림 설정이나 정책을 변경할 수 있습니다. `data` 부분(알림과 정책)만 변경할 수 있습니다.
+`update`를 사용하면 구독을 재생성하지 않고 `data` 부분(알림과 정책)을 교체할 수 있습니다. 부분 업데이트가 아니므로 생략한 모든 알림 타입은 비활성화되고, `policy`를 생략하면 `all`로 재설정됩니다. 계속 활성화할 모든 알림 타입을 지정해야 합니다. `alerts`와 `policy`를 모두 생략하면 HTTP 요청을 보내기 전에 `ArgumentError`가 발생합니다.
 
 ```dart
 final updated = await client.push.update(
@@ -79,8 +79,21 @@ final updated = await client.push.update(
     alerts: MastodonPushAlertSettings(
       mention: true,
       follow: false,
+      reblog: true,
+      favourite: true,
+      poll: true,
     ),
     policy: 'all',
+  ),
+);
+```
+
+모든 알림을 명시적으로 비활성화하고 정책을 `all`로 재설정하려면 빈 알림 설정 객체를 전송합니다.
+
+```dart
+await client.push.update(
+  const MastodonPushSubscriptionUpdateRequest(
+    alerts: MastodonPushAlertSettings(),
   ),
 );
 ```

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/api/push.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/api/push.md
@@ -34,7 +34,7 @@ print(subscription.serverKey); // 用于验证收到的推送消息
 
 ### 通知类型
 
-`MastodonPushAlertSettings` 接受以下字段的任意组合。值为 `null` 的字段会从请求中省略，保持原有设置不变。
+`MastodonPushAlertSettings` 接受以下字段的任意组合。值为 `null` 的字段会从请求中省略。创建订阅时，省略的字段使用服务器默认值；更新订阅时，整个设置对象会按下文所述被替换。
 
 | 字段 | 说明 |
 |------|------|
@@ -71,7 +71,7 @@ print(subscription.policy);
 
 ## 更新通知设置
 
-使用 `update` 更改通知设置或策略，无需重新创建订阅。只能更改 `data` 部分（通知类型和策略）。
+使用 `update` 替换订阅的 `data` 部分（通知类型和策略），无需重新创建订阅。这不是局部更新：省略的每种通知类型都会被禁用，省略 `policy` 会将其重置为 `all`。请指定所有需要保持启用的通知类型。如果同时省略 `alerts` 和 `policy`，则会在发送 HTTP 请求前抛出 `ArgumentError`。
 
 ```dart
 final updated = await client.push.update(
@@ -79,8 +79,21 @@ final updated = await client.push.update(
     alerts: MastodonPushAlertSettings(
       mention: true,
       follow: false,
+      reblog: true,
+      favourite: true,
+      poll: true,
     ),
     policy: 'all',
+  ),
+);
+```
+
+如需明确禁用所有通知并将策略重置为 `all`，请发送一个空的通知设置对象：
+
+```dart
+await client.push.update(
+  const MastodonPushSubscriptionUpdateRequest(
+    alerts: MastodonPushAlertSettings(),
   ),
 );
 ```

--- a/lib/src/api/push_api.dart
+++ b/lib/src/api/push_api.dart
@@ -36,8 +36,12 @@ class PushApi {
   ///
   /// `PUT /api/v1/push/subscription`
   ///
-  /// Updates only the `data` portion of the subscription (alert settings
-  /// and policy).
+  /// Replaces the `data` portion of the subscription (alert settings and
+  /// policy). Omitted alert types become disabled, and an omitted policy resets
+  /// to `all`.
+  ///
+  /// Throws an [ArgumentError] if neither alert settings nor a policy is
+  /// provided.
   Future<MastodonWebPushSubscription> update(
     MastodonPushSubscriptionUpdateRequest request,
   ) async {

--- a/lib/src/models/mastodon_push_subscription_request.dart
+++ b/lib/src/models/mastodon_push_subscription_request.dart
@@ -1,6 +1,9 @@
 /// Alert settings per Web Push notification type (for requests).
 ///
-/// Fields set to `null` are not included in the request.
+/// Fields set to `null` are not included in the request. When creating a
+/// subscription, omitted fields use the server defaults. When updating a
+/// subscription, the server replaces the whole `data` object, so omitted alert
+/// types become disabled.
 class MastodonPushAlertSettings {
   const MastodonPushAlertSettings({
     this.mention,
@@ -129,8 +132,10 @@ class MastodonPushSubscriptionRequest {
 /// Web Push subscription update request.
 ///
 /// Used with `PUT /api/v1/push/subscription`.
-/// Updates only the `data` portion (alert settings and policy) of the
-/// subscription.
+///
+/// The server replaces the whole `data` portion (alert settings and policy) of
+/// the subscription. Omitted alert types become disabled, and omitting [policy]
+/// resets it to `all`.
 class MastodonPushSubscriptionUpdateRequest {
   const MastodonPushSubscriptionUpdateRequest({this.alerts, this.policy});
 
@@ -142,17 +147,23 @@ class MastodonPushSubscriptionUpdateRequest {
 
   /// Converts to a JSON map for the request.
   ///
-  /// For PUT requests, `policy` is placed at the top level (unlike
-  /// `data[policy]` in POST).
+  /// Throws an [ArgumentError] when both [alerts] and [policy] are `null`,
+  /// because an empty update would clear the subscription's existing data.
+  ///
+  /// To explicitly disable every alert and reset the policy to `all`, pass an
+  /// empty [MastodonPushAlertSettings] as [alerts].
   Map<String, dynamic> toJson() {
-    final data = <String, dynamic>{};
-    if (alerts != null) {
-      data['alerts'] = alerts!.toJson();
+    if (alerts == null && policy == null) {
+      throw ArgumentError(
+        'At least one of alerts or policy must be provided for an update.',
+      );
     }
-    final json = <String, dynamic>{'data': data};
-    if (policy != null) {
-      json['policy'] = policy;
-    }
-    return json;
+
+    return <String, dynamic>{
+      'data': <String, dynamic>{
+        if (alerts != null) 'alerts': alerts!.toJson(),
+        if (policy != null) 'policy': policy,
+      },
+    };
   }
 }

--- a/test/api/push_api_test.dart
+++ b/test/api/push_api_test.dart
@@ -1,0 +1,107 @@
+import 'package:mastodon_client/mastodon_client.dart';
+import 'package:mastodon_client/src/api/push_api.dart';
+import 'package:test/test.dart';
+
+import '../helpers/recording_http_client.dart';
+
+void main() {
+  group('PushApi.create', () {
+    test('nests alerts and policy in data', () async {
+      final http = RecordingHttpClient([_subscriptionResponse]);
+      final api = PushApi(http);
+
+      await api.create(
+        const MastodonPushSubscriptionRequest(
+          endpoint: 'https://push.example/subscription',
+          p256dh: 'public-key',
+          auth: 'auth-secret',
+          standard: true,
+          alerts: MastodonPushAlertSettings(
+            mention: true,
+            followRequest: false,
+          ),
+          policy: 'followed',
+        ),
+      );
+
+      expect(http.requests.single.method, 'POST');
+      expect(http.requests.single.path, '/api/v1/push/subscription');
+      expect(http.requests.single.data, {
+        'subscription': {
+          'endpoint': 'https://push.example/subscription',
+          'keys': {'p256dh': 'public-key', 'auth': 'auth-secret'},
+          'standard': true,
+        },
+        'data': {
+          'alerts': {'mention': true, 'follow_request': false},
+          'policy': 'followed',
+        },
+      });
+    });
+  });
+
+  group('PushApi.update', () {
+    test('nests a policy-only update in data', () async {
+      final http = RecordingHttpClient([_subscriptionResponse]);
+      final api = PushApi(http);
+
+      await api.update(
+        const MastodonPushSubscriptionUpdateRequest(policy: 'followed'),
+      );
+
+      expect(http.requests.single.data, {
+        'data': {'policy': 'followed'},
+      });
+    });
+
+    test('nests policy in data alongside alerts', () async {
+      final http = RecordingHttpClient([_subscriptionResponse]);
+      final api = PushApi(http);
+
+      await api.update(
+        const MastodonPushSubscriptionUpdateRequest(
+          alerts: MastodonPushAlertSettings(mention: true, reblog: false),
+          policy: 'follower',
+        ),
+      );
+
+      expect(http.requests.single.method, 'PUT');
+      expect(http.requests.single.path, '/api/v1/push/subscription');
+      expect(http.requests.single.data, {
+        'data': {
+          'alerts': {'mention': true, 'reblog': false},
+          'policy': 'follower',
+        },
+      });
+    });
+
+    test('rejects an update without alerts or policy', () async {
+      final http = RecordingHttpClient();
+      final api = PushApi(http);
+
+      await expectLater(
+        api.update(const MastodonPushSubscriptionUpdateRequest()),
+        throwsArgumentError,
+      );
+      expect(http.requests, isEmpty);
+    });
+
+    test('allows explicitly disabling all alerts and resetting policy', () {
+      const request = MastodonPushSubscriptionUpdateRequest(
+        alerts: MastodonPushAlertSettings(),
+      );
+
+      expect(request.toJson(), {
+        'data': {'alerts': <String, dynamic>{}},
+      });
+    });
+  });
+}
+
+const _subscriptionResponse = <String, dynamic>{
+  'id': '1',
+  'endpoint': 'https://push.example/subscription',
+  'server_key': 'server-key',
+  'alerts': <String, dynamic>{},
+  'policy': 'all',
+};


### PR DESCRIPTION
## 概要

Web Push subscription更新時のリクエスト構造をMastodon本体に合わせ、policyが無視されたうえに既存alertsが消える問題を修正します。

## 対応内容

- PUTでも`policy`を`data`配下へ配置
- alerts／policyとも未指定の空更新をHTTP送信前に拒否
- サーバーが`data`全体を置換する挙動をDartdocへ明記
- 空のalertsを使った全通知無効化／policyリセット経路を明記
- POST／PUTのserializationと送信前検証テストを追加
- APIドキュメント6言語とCHANGELOGを更新

## 検証

- `dart analyze --fatal-infos`: 成功
- 対象テスト: 5件成功
- 全テスト: 310件成功、E2E 4件skip
- `dart pub publish --dry-run`: 0 warnings

Closes #45
