### PR TITLE
fix: Mastodonのrate-limit resetヘッダを解析 (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `MastodonRateLimitException` now derives `retryAfter` from Mastodon's
+  `X-RateLimit-Reset` header when `Retry-After` is unavailable, supports
+  HTTP-date values, and exposes `limit`, `remaining`, and `resetAt` (issue #47)
+
 ## [1.0.0-beta.3] - 2026-08-25
 
 ### Added

--- a/docs/docs/error-handling.md
+++ b/docs/docs/error-handling.md
@@ -15,7 +15,10 @@ MastodonException (sealed)
 │   ├── MastodonForbiddenException    // 403 - Permission error
 │   ├── MastodonNotFoundException     // 404 - Resource not found
 │   ├── MastodonRateLimitException    // 429 - Rate limited
-│   │   └── retryAfter                //   Recommended wait duration
+│   │   ├── retryAfter                //   Recommended wait duration
+│   │   ├── limit                     //   Request limit for the window
+│   │   ├── remaining                 //   Remaining requests
+│   │   └── resetAt                   //   Time when the window resets
 │   ├── MastodonValidationException   // 422 - Validation error
 │   │   ├── serverMessage             //   Detailed server message
 │   │   └── MastodonAlreadyVotedException // Already voted
@@ -97,11 +100,16 @@ try {
 
 ## Handling rate limits
 
+`MastodonRateLimitException` exposes Mastodon's `X-RateLimit-*` headers. The
+recommended wait uses `Retry-After` when a server or proxy provides it, then
+falls back to the `X-RateLimit-Reset` timestamp.
+
 ```dart
 Future<T> withRetry<T>(Future<T> Function() action) async {
   try {
     return await action();
   } on MastodonRateLimitException catch (e) {
+    print('${e.remaining}/${e.limit} requests remain; reset at ${e.resetAt}');
     final wait = e.retryAfter ?? const Duration(seconds: 60);
     await Future<void>.delayed(wait);
     return action();

--- a/docs/i18n/de/docusaurus-plugin-content-docs/current/error-handling.md
+++ b/docs/i18n/de/docusaurus-plugin-content-docs/current/error-handling.md
@@ -15,7 +15,10 @@ MastodonException (sealed)
 │   ├── MastodonForbiddenException    // 403 - Permission error
 │   ├── MastodonNotFoundException     // 404 - Resource not found
 │   ├── MastodonRateLimitException    // 429 - Rate limited
-│   │   └── retryAfter                //   Recommended wait duration
+│   │   ├── retryAfter                //   Recommended wait duration
+│   │   ├── limit                     //   Request limit for the window
+│   │   ├── remaining                 //   Remaining requests
+│   │   └── resetAt                   //   Time when the window resets
 │   ├── MastodonValidationException   // 422 - Validation error
 │   │   ├── serverMessage             //   Detailed server message
 │   │   └── MastodonAlreadyVotedException // Already voted
@@ -97,11 +100,16 @@ try {
 
 ## Rate-Limits behandeln
 
+`MastodonRateLimitException` stellt die `X-RateLimit-*`-Header von Mastodon
+bereit. Die empfohlene Wartezeit verwendet `Retry-After`, wenn der Server oder
+Proxy diesen Header liefert, andernfalls den Zeitstempel `X-RateLimit-Reset`.
+
 ```dart
 Future<T> withRetry<T>(Future<T> Function() action) async {
   try {
     return await action();
   } on MastodonRateLimitException catch (e) {
+    print('${e.remaining}/${e.limit} Anfragen verbleiben; Reset um ${e.resetAt}');
     final wait = e.retryAfter ?? const Duration(seconds: 60);
     await Future<void>.delayed(wait);
     return action();

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/error-handling.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/error-handling.md
@@ -15,7 +15,10 @@ MastodonException (sealed)
 │   ├── MastodonForbiddenException    // 403 - Permission error
 │   ├── MastodonNotFoundException     // 404 - Resource not found
 │   ├── MastodonRateLimitException    // 429 - Rate limited
-│   │   └── retryAfter                //   Recommended wait duration
+│   │   ├── retryAfter                //   Recommended wait duration
+│   │   ├── limit                     //   Request limit for the window
+│   │   ├── remaining                 //   Remaining requests
+│   │   └── resetAt                   //   Time when the window resets
 │   ├── MastodonValidationException   // 422 - Validation error
 │   │   ├── serverMessage             //   Detailed server message
 │   │   └── MastodonAlreadyVotedException // Already voted
@@ -97,11 +100,16 @@ try {
 
 ## Gérer les limites de débit
 
+`MastodonRateLimitException` expose les en-têtes `X-RateLimit-*` de Mastodon.
+L'attente recommandée utilise `Retry-After` lorsqu'il est fourni par le serveur
+ou le proxy, puis se rabat sur l'horodatage `X-RateLimit-Reset`.
+
 ```dart
 Future<T> withRetry<T>(Future<T> Function() action) async {
   try {
     return await action();
   } on MastodonRateLimitException catch (e) {
+    print('${e.remaining}/${e.limit} requêtes restantes ; réinitialisation à ${e.resetAt}');
     final wait = e.retryAfter ?? const Duration(seconds: 60);
     await Future<void>.delayed(wait);
     return action();

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/error-handling.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/error-handling.md
@@ -15,7 +15,10 @@ MastodonException (sealed)
 │   ├── MastodonForbiddenException    // 403 - 権限エラー
 │   ├── MastodonNotFoundException     // 404 - リソース不在
 │   ├── MastodonRateLimitException    // 429 - レート制限
-│   │   └── retryAfter                //   リトライ推奨待機時間
+│   │   ├── retryAfter                //   リトライ推奨待機時間
+│   │   ├── limit                     //   制限期間内のリクエスト上限
+│   │   ├── remaining                 //   残りリクエスト数
+│   │   └── resetAt                   //   制限がリセットされる時刻
 │   ├── MastodonValidationException   // 422 - バリデーションエラー
 │   │   ├── serverMessage             //   サーバーからの詳細メッセージ
 │   │   └── MastodonAlreadyVotedException // 投票済みエラー
@@ -97,11 +100,16 @@ try {
 
 ## レート制限への対応
 
+`MastodonRateLimitException` は Mastodon の `X-RateLimit-*` ヘッダーを公開します。
+推奨待機時間には、サーバーまたはプロキシが `Retry-After` を返した場合はその値を使い、
+返さない場合は `X-RateLimit-Reset` のタイムスタンプを使います。
+
 ```dart
 Future<T> withRetry<T>(Future<T> Function() action) async {
   try {
     return await action();
   } on MastodonRateLimitException catch (e) {
+    print('残り ${e.remaining}/${e.limit} 件。${e.resetAt} にリセット');
     final wait = e.retryAfter ?? const Duration(seconds: 60);
     await Future<void>.delayed(wait);
     return action();

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/error-handling.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/error-handling.md
@@ -15,7 +15,10 @@ MastodonException (sealed)
 │   ├── MastodonForbiddenException    // 403 - 권한 에러
 │   ├── MastodonNotFoundException     // 404 - 리소스 없음
 │   ├── MastodonRateLimitException    // 429 - 요청 제한 초과
-│   │   └── retryAfter                //   재시도 권장 대기 시간
+│   │   ├── retryAfter                //   재시도 권장 대기 시간
+│   │   ├── limit                     //   제한 기간의 요청 한도
+│   │   ├── remaining                 //   남은 요청 수
+│   │   └── resetAt                   //   제한이 재설정되는 시각
 │   ├── MastodonValidationException   // 422 - 유효성 검사 에러
 │   │   ├── serverMessage             //   서버의 상세 메시지
 │   │   └── MastodonAlreadyVotedException // 이미 투표함
@@ -97,11 +100,16 @@ try {
 
 ## 요청 제한 처리
 
+`MastodonRateLimitException`은 Mastodon의 `X-RateLimit-*` 헤더를 제공합니다.
+권장 대기 시간은 서버나 프록시가 `Retry-After`를 제공하면 그 값을 사용하고,
+그렇지 않으면 `X-RateLimit-Reset` 타임스탬프를 사용합니다.
+
 ```dart
 Future<T> withRetry<T>(Future<T> Function() action) async {
   try {
     return await action();
   } on MastodonRateLimitException catch (e) {
+    print('${e.remaining}/${e.limit}개 요청 남음; ${e.resetAt}에 재설정');
     final wait = e.retryAfter ?? const Duration(seconds: 60);
     await Future<void>.delayed(wait);
     return action();

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/error-handling.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/error-handling.md
@@ -15,7 +15,10 @@ MastodonException (sealed)
 │   ├── MastodonForbiddenException    // 403 - 权限错误
 │   ├── MastodonNotFoundException     // 404 - 资源不存在
 │   ├── MastodonRateLimitException    // 429 - 触发频率限制
-│   │   └── retryAfter                //   建议等待时长
+│   │   ├── retryAfter                //   建议等待时长
+│   │   ├── limit                     //   限制周期内的请求上限
+│   │   ├── remaining                 //   剩余请求数
+│   │   └── resetAt                   //   限制重置时间
 │   ├── MastodonValidationException   // 422 - 校验错误
 │   │   ├── serverMessage             //   服务器详细错误信息
 │   │   └── MastodonAlreadyVotedException // 已投过票
@@ -97,11 +100,16 @@ try {
 
 ## 处理频率限制
 
+`MastodonRateLimitException` 会公开 Mastodon 的 `X-RateLimit-*` 响应头。
+建议等待时长会优先使用服务器或代理提供的 `Retry-After`，否则使用
+`X-RateLimit-Reset` 时间戳。
+
 ```dart
 Future<T> withRetry<T>(Future<T> Function() action) async {
   try {
     return await action();
   } on MastodonRateLimitException catch (e) {
+    print('剩余 ${e.remaining}/${e.limit} 次请求；${e.resetAt} 重置');
     final wait = e.retryAfter ?? const Duration(seconds: 60);
     await Future<void>.delayed(wait);
     return action();

--- a/lib/src/exception/mastodon_exception.dart
+++ b/lib/src/exception/mastodon_exception.dart
@@ -74,10 +74,22 @@ class MastodonRateLimitException extends MastodonApiException {
     super.endpoint,
     super.raw,
     this.retryAfter,
+    this.limit,
+    this.remaining,
+    this.resetAt,
   }) : super(statusCode: 429);
 
   /// Recommended wait duration indicated by the server.
   final Duration? retryAfter;
+
+  /// Maximum number of requests allowed in the current rate-limit window.
+  final int? limit;
+
+  /// Number of requests remaining in the current rate-limit window.
+  final int? remaining;
+
+  /// Time when the current rate-limit window resets.
+  final DateTime? resetAt;
 }
 
 /// Validation error (HTTP 422).

--- a/lib/src/internal/dio_error_handler.dart
+++ b/lib/src/internal/dio_error_handler.dart
@@ -6,11 +6,22 @@ import '../exception/mastodon_exception.dart';
 ///
 /// Internal utility used by all API classes.
 MastodonException convertDioException(DioException e, [String? endpoint]) {
+  return convertDioExceptionAt(e, DateTime.now().toUtc(), endpoint);
+}
+
+/// Converts a [DioException] using [now] as the current time.
+///
+/// This variant keeps date-based rate-limit parsing deterministic in tests.
+MastodonException convertDioExceptionAt(
+  DioException e,
+  DateTime now, [
+  String? endpoint,
+]) {
   final statusCode = e.response?.statusCode;
 
   if (statusCode != null) {
     final serverMessage = _extractMessage(e.response?.data);
-    final retryAfter = _parseRetryAfter(e.response);
+    final rateLimit = _parseRateLimit(e.response, now.toUtc());
     return switch (statusCode) {
       401 => MastodonUnauthorizedException(
         message: serverMessage ?? 'Unauthorized',
@@ -36,7 +47,10 @@ MastodonException convertDioException(DioException e, [String? endpoint]) {
         message: serverMessage ?? 'Rate limited',
         endpoint: endpoint,
         raw: e,
-        retryAfter: retryAfter,
+        retryAfter: rateLimit.retryAfter,
+        limit: rateLimit.limit,
+        remaining: rateLimit.remaining,
+        resetAt: rateLimit.resetAt,
       ),
       >= 500 => MastodonServerException(
         statusCode: statusCode,
@@ -69,13 +83,121 @@ String? _extractMessage(dynamic data) {
   return null;
 }
 
-Duration? _parseRetryAfter(Response<dynamic>? response) {
-  final ra = response?.headers.value('retry-after');
-  if (ra != null) {
-    final seconds = int.tryParse(ra.trim());
-    if (seconds != null) {
-      return Duration(seconds: seconds);
-    }
+({Duration? retryAfter, int? limit, int? remaining, DateTime? resetAt})
+_parseRateLimit(Response<dynamic>? response, DateTime now) {
+  final headers = response?.headers;
+  final resetAt = DateTime.tryParse(
+    headers?.value('x-ratelimit-reset')?.trim() ?? '',
+  )?.toUtc();
+  final retryAfter = _parseRetryAfter(headers?.value('retry-after'), now);
+
+  return (
+    retryAfter: retryAfter ?? _durationUntil(resetAt, now),
+    limit: _parseNonNegativeInt(headers?.value('x-ratelimit-limit')),
+    remaining: _parseNonNegativeInt(headers?.value('x-ratelimit-remaining')),
+    resetAt: resetAt,
+  );
+}
+
+Duration? _parseRetryAfter(String? value, DateTime now) {
+  if (value == null) return null;
+
+  final seconds = _parseNonNegativeInt(value);
+  if (seconds != null) return Duration(seconds: seconds);
+
+  return _durationUntil(_tryParseHttpDate(value, now), now);
+}
+
+int? _parseNonNegativeInt(String? value) {
+  final parsed = int.tryParse(value?.trim() ?? '');
+  return parsed != null && parsed >= 0 ? parsed : null;
+}
+
+Duration? _durationUntil(DateTime? target, DateTime now) {
+  if (target == null) return null;
+  final difference = target.toUtc().difference(now.toUtc());
+  return difference.isNegative ? Duration.zero : difference;
+}
+
+DateTime? _tryParseHttpDate(String value, DateTime now) {
+  final trimmed = value.trim();
+  final imfFixdate = RegExp(
+    r'^[A-Za-z]{3}, (\d{2}) ([A-Za-z]{3}) (\d{4}) '
+    r'(\d{2}):(\d{2}):(\d{2}) GMT$',
+  ).firstMatch(trimmed);
+  if (imfFixdate != null) {
+    return _buildHttpDate(
+      year: int.parse(imfFixdate[3]!),
+      month: imfFixdate[2]!,
+      day: int.parse(imfFixdate[1]!),
+      hour: int.parse(imfFixdate[4]!),
+      minute: int.parse(imfFixdate[5]!),
+      second: int.parse(imfFixdate[6]!),
+    );
   }
-  return null;
+
+  final rfc850Date = RegExp(
+    r'^[A-Za-z]+, (\d{2})-([A-Za-z]{3})-(\d{2}) '
+    r'(\d{2}):(\d{2}):(\d{2}) GMT$',
+  ).firstMatch(trimmed);
+  if (rfc850Date != null) {
+    var year = 2000 + int.parse(rfc850Date[3]!);
+    if (year - now.year > 50) year -= 100;
+    return _buildHttpDate(
+      year: year,
+      month: rfc850Date[2]!,
+      day: int.parse(rfc850Date[1]!),
+      hour: int.parse(rfc850Date[4]!),
+      minute: int.parse(rfc850Date[5]!),
+      second: int.parse(rfc850Date[6]!),
+    );
+  }
+
+  final asctimeDate = RegExp(
+    r'^[A-Za-z]{3} ([A-Za-z]{3}) +([0-9]{1,2}) '
+    r'(\d{2}):(\d{2}):(\d{2}) (\d{4})$',
+  ).firstMatch(trimmed);
+  if (asctimeDate == null) return null;
+  return _buildHttpDate(
+    year: int.parse(asctimeDate[6]!),
+    month: asctimeDate[1]!,
+    day: int.parse(asctimeDate[2]!),
+    hour: int.parse(asctimeDate[3]!),
+    minute: int.parse(asctimeDate[4]!),
+    second: int.parse(asctimeDate[5]!),
+  );
+}
+
+DateTime? _buildHttpDate({
+  required int year,
+  required String month,
+  required int day,
+  required int hour,
+  required int minute,
+  required int second,
+}) {
+  const months = {
+    'Jan': 1,
+    'Feb': 2,
+    'Mar': 3,
+    'Apr': 4,
+    'May': 5,
+    'Jun': 6,
+    'Jul': 7,
+    'Aug': 8,
+    'Sep': 9,
+    'Oct': 10,
+    'Nov': 11,
+    'Dec': 12,
+  };
+  final monthNumber = months[month];
+  if (monthNumber == null || hour > 23 || minute > 59 || second > 59) {
+    return null;
+  }
+
+  final result = DateTime.utc(year, monthNumber, day, hour, minute, second);
+  if (result.year != year || result.month != monthNumber || result.day != day) {
+    return null;
+  }
+  return result;
 }

--- a/lib/src/internal/dio_error_handler.dart
+++ b/lib/src/internal/dio_error_handler.dart
@@ -86,9 +86,7 @@ String? _extractMessage(dynamic data) {
 ({Duration? retryAfter, int? limit, int? remaining, DateTime? resetAt})
 _parseRateLimit(Response<dynamic>? response, DateTime now) {
   final headers = response?.headers;
-  final resetAt = DateTime.tryParse(
-    headers?.value('x-ratelimit-reset')?.trim() ?? '',
-  )?.toUtc();
+  final resetAt = _tryParseIsoTimestamp(headers?.value('x-ratelimit-reset'));
   final retryAfter = _parseRetryAfter(headers?.value('retry-after'), now);
 
   return (
@@ -119,56 +117,108 @@ Duration? _durationUntil(DateTime? target, DateTime now) {
   return difference.isNegative ? Duration.zero : difference;
 }
 
+DateTime? _tryParseIsoTimestamp(String? value) {
+  if (value == null) return null;
+  final trimmed = value.trim();
+  final match = RegExp(
+    r'^(\d{4})-(\d{2})-(\d{2})T'
+    r'(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?'
+    r'(Z|[+-](\d{2}):(\d{2}))$',
+  ).firstMatch(trimmed);
+  if (match == null) return null;
+
+  final year = int.parse(match[1]!);
+  final month = int.parse(match[2]!);
+  final day = int.parse(match[3]!);
+  final hour = int.parse(match[4]!);
+  final minute = int.parse(match[5]!);
+  final second = int.parse(match[6]!);
+  final offsetHour = int.tryParse(match[8] ?? '') ?? 0;
+  final offsetMinute = int.tryParse(match[9] ?? '') ?? 0;
+  if (!_isValidDateTime(
+        year: year,
+        month: month,
+        day: day,
+        hour: hour,
+        minute: minute,
+        second: second,
+      ) ||
+      offsetHour > 23 ||
+      offsetMinute > 59) {
+    return null;
+  }
+
+  return DateTime.tryParse(trimmed)?.toUtc();
+}
+
 DateTime? _tryParseHttpDate(String value, DateTime now) {
   final trimmed = value.trim();
   final imfFixdate = RegExp(
-    r'^[A-Za-z]{3}, (\d{2}) ([A-Za-z]{3}) (\d{4}) '
+    r'^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), '
+    r'(\d{2}) ([A-Za-z]{3}) (\d{4}) '
     r'(\d{2}):(\d{2}):(\d{2}) GMT$',
   ).firstMatch(trimmed);
   if (imfFixdate != null) {
     return _buildHttpDate(
-      year: int.parse(imfFixdate[3]!),
-      month: imfFixdate[2]!,
-      day: int.parse(imfFixdate[1]!),
-      hour: int.parse(imfFixdate[4]!),
-      minute: int.parse(imfFixdate[5]!),
-      second: int.parse(imfFixdate[6]!),
+      weekday: imfFixdate[1]!,
+      year: int.parse(imfFixdate[4]!),
+      month: imfFixdate[3]!,
+      day: int.parse(imfFixdate[2]!),
+      hour: int.parse(imfFixdate[5]!),
+      minute: int.parse(imfFixdate[6]!),
+      second: int.parse(imfFixdate[7]!),
     );
   }
 
   final rfc850Date = RegExp(
-    r'^[A-Za-z]+, (\d{2})-([A-Za-z]{3})-(\d{2}) '
+    r'^(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), '
+    r'(\d{2})-([A-Za-z]{3})-(\d{2}) '
     r'(\d{2}):(\d{2}):(\d{2}) GMT$',
   ).firstMatch(trimmed);
   if (rfc850Date != null) {
-    var year = 2000 + int.parse(rfc850Date[3]!);
-    if (year - now.year > 50) year -= 100;
-    return _buildHttpDate(
+    final currentCentury = now.year - (now.year % 100);
+    var year = currentCentury + int.parse(rfc850Date[4]!);
+    var result = _buildHttpDate(
       year: year,
-      month: rfc850Date[2]!,
-      day: int.parse(rfc850Date[1]!),
-      hour: int.parse(rfc850Date[4]!),
-      minute: int.parse(rfc850Date[5]!),
-      second: int.parse(rfc850Date[6]!),
+      month: rfc850Date[3]!,
+      day: int.parse(rfc850Date[2]!),
+      hour: int.parse(rfc850Date[5]!),
+      minute: int.parse(rfc850Date[6]!),
+      second: int.parse(rfc850Date[7]!),
     );
+    if (result == null) return null;
+    if (result.isAfter(_addYears(now, 50))) {
+      year -= 100;
+      result = _buildHttpDate(
+        year: year,
+        month: rfc850Date[3]!,
+        day: int.parse(rfc850Date[2]!),
+        hour: int.parse(rfc850Date[5]!),
+        minute: int.parse(rfc850Date[6]!),
+        second: int.parse(rfc850Date[7]!),
+      );
+    }
+    return _hasMatchingWeekday(result, rfc850Date[1]!) ? result : null;
   }
 
   final asctimeDate = RegExp(
-    r'^[A-Za-z]{3} ([A-Za-z]{3}) +([0-9]{1,2}) '
+    r'^(Mon|Tue|Wed|Thu|Fri|Sat|Sun) ([A-Za-z]{3}) +([0-9]{1,2}) '
     r'(\d{2}):(\d{2}):(\d{2}) (\d{4})$',
   ).firstMatch(trimmed);
   if (asctimeDate == null) return null;
   return _buildHttpDate(
-    year: int.parse(asctimeDate[6]!),
-    month: asctimeDate[1]!,
-    day: int.parse(asctimeDate[2]!),
-    hour: int.parse(asctimeDate[3]!),
-    minute: int.parse(asctimeDate[4]!),
-    second: int.parse(asctimeDate[5]!),
+    weekday: asctimeDate[1]!,
+    year: int.parse(asctimeDate[7]!),
+    month: asctimeDate[2]!,
+    day: int.parse(asctimeDate[3]!),
+    hour: int.parse(asctimeDate[4]!),
+    minute: int.parse(asctimeDate[5]!),
+    second: int.parse(asctimeDate[6]!),
   );
 }
 
 DateTime? _buildHttpDate({
+  String? weekday,
   required int year,
   required String month,
   required int day,
@@ -191,13 +241,77 @@ DateTime? _buildHttpDate({
     'Dec': 12,
   };
   final monthNumber = months[month];
-  if (monthNumber == null || hour > 23 || minute > 59 || second > 59) {
+  if (monthNumber == null ||
+      !_isValidDateTime(
+        year: year,
+        month: monthNumber,
+        day: day,
+        hour: hour,
+        minute: minute,
+        second: second,
+      )) {
     return null;
   }
 
   final result = DateTime.utc(year, monthNumber, day, hour, minute, second);
-  if (result.year != year || result.month != monthNumber || result.day != day) {
-    return null;
+  return weekday == null || _hasMatchingWeekday(result, weekday)
+      ? result
+      : null;
+}
+
+bool _isValidDateTime({
+  required int year,
+  required int month,
+  required int day,
+  required int hour,
+  required int minute,
+  required int second,
+}) {
+  if (month < 1 ||
+      month > 12 ||
+      day < 1 ||
+      hour > 23 ||
+      minute > 59 ||
+      second > 59) {
+    return false;
   }
-  return result;
+  final result = DateTime.utc(year, month, day, hour, minute, second);
+  return result.year == year && result.month == month && result.day == day;
+}
+
+bool _hasMatchingWeekday(DateTime? date, String weekday) {
+  if (date == null) return false;
+  const weekdays = {
+    'Mon': DateTime.monday,
+    'Monday': DateTime.monday,
+    'Tue': DateTime.tuesday,
+    'Tuesday': DateTime.tuesday,
+    'Wed': DateTime.wednesday,
+    'Wednesday': DateTime.wednesday,
+    'Thu': DateTime.thursday,
+    'Thursday': DateTime.thursday,
+    'Fri': DateTime.friday,
+    'Friday': DateTime.friday,
+    'Sat': DateTime.saturday,
+    'Saturday': DateTime.saturday,
+    'Sun': DateTime.sunday,
+    'Sunday': DateTime.sunday,
+  };
+  return weekdays[weekday] == date.weekday;
+}
+
+DateTime _addYears(DateTime date, int years) {
+  final targetYear = date.year + years;
+  final lastDayOfMonth = DateTime.utc(targetYear, date.month + 1, 0).day;
+  final targetDay = date.day > lastDayOfMonth ? lastDayOfMonth : date.day;
+  return DateTime.utc(
+    targetYear,
+    date.month,
+    targetDay,
+    date.hour,
+    date.minute,
+    date.second,
+    date.millisecond,
+    date.microsecond,
+  );
 }

--- a/test/internal/dio_error_handler_test.dart
+++ b/test/internal/dio_error_handler_test.dart
@@ -136,35 +136,150 @@ void main() {
     });
   });
 
-  group('convertDioException - retry-after header (429)', () {
+  group('convertDioException - rate-limit headers (429)', () {
+    final now = DateTime.utc(2026, 8, 26, 12);
+
     test('parses a numeric retry-after header into a Duration', () {
-      final result = convertDioException(
+      final result = convertDioExceptionAt(
         _errorWithStatus(
           429,
           headers: {
             'retry-after': ['60'],
           },
         ),
+        now,
       );
       final rateLimit = result as MastodonRateLimitException;
       expect(rateLimit.retryAfter, const Duration(seconds: 60));
     });
 
-    test('retryAfter is null when the header is absent', () {
-      final result = convertDioException(_errorWithStatus(429));
+    test('retryAfter is null when rate-limit headers are absent', () {
+      final result = convertDioExceptionAt(_errorWithStatus(429), now);
       expect((result as MastodonRateLimitException).retryAfter, isNull);
     });
 
-    test('retryAfter is null when the header is not a valid integer', () {
-      final result = convertDioException(
+    test('parses an IMF-fixdate retry-after header', () {
+      final result = convertDioExceptionAt(
         _errorWithStatus(
           429,
           headers: {
-            'retry-after': ['Wed, 21 Oct 2026 07:28:00 GMT'],
+            'retry-after': ['Wed, 26 Aug 2026 12:01:30 GMT'],
           },
         ),
+        now,
       );
-      expect((result as MastodonRateLimitException).retryAfter, isNull);
+      expect(
+        (result as MastodonRateLimitException).retryAfter,
+        const Duration(seconds: 90),
+      );
+    });
+
+    for (final retryAfter in [
+      'Wednesday, 26-Aug-26 12:01:30 GMT',
+      'Wed Aug 26 12:01:30 2026',
+    ]) {
+      test('parses the obsolete HTTP-date form: $retryAfter', () {
+        final result = convertDioExceptionAt(
+          _errorWithStatus(
+            429,
+            headers: {
+              'retry-after': [retryAfter],
+            },
+          ),
+          now,
+        );
+        expect(
+          (result as MastodonRateLimitException).retryAfter,
+          const Duration(seconds: 90),
+        );
+      });
+    }
+
+    test('falls back to x-ratelimit-reset when retry-after is invalid', () {
+      final result = convertDioExceptionAt(
+        _errorWithStatus(
+          429,
+          headers: {
+            'retry-after': ['invalid'],
+            'x-ratelimit-reset': ['2026-08-26T12:02:00.000000Z'],
+          },
+        ),
+        now,
+      );
+      expect(
+        (result as MastodonRateLimitException).retryAfter,
+        const Duration(minutes: 2),
+      );
+    });
+
+    test('parses Mastodon rate-limit metadata', () {
+      final result = convertDioExceptionAt(
+        _errorWithStatus(
+          429,
+          headers: {
+            'x-ratelimit-limit': ['300'],
+            'x-ratelimit-remaining': ['0'],
+            'x-ratelimit-reset': ['2026-08-26T12:02:00.123456Z'],
+          },
+        ),
+        now,
+      );
+      final rateLimit = result as MastodonRateLimitException;
+      expect(
+        rateLimit.retryAfter,
+        const Duration(minutes: 2, microseconds: 123456),
+      );
+      expect(rateLimit.limit, 300);
+      expect(rateLimit.remaining, 0);
+      expect(rateLimit.resetAt, DateTime.utc(2026, 8, 26, 12, 2, 0, 123, 456));
+    });
+
+    test('clamps a past x-ratelimit-reset to zero', () {
+      final result = convertDioExceptionAt(
+        _errorWithStatus(
+          429,
+          headers: {
+            'x-ratelimit-reset': ['2026-08-26T11:59:59.999999Z'],
+          },
+        ),
+        now,
+      );
+      expect((result as MastodonRateLimitException).retryAfter, Duration.zero);
+    });
+
+    test('prefers a valid retry-after over x-ratelimit-reset', () {
+      final result = convertDioExceptionAt(
+        _errorWithStatus(
+          429,
+          headers: {
+            'retry-after': ['60'],
+            'x-ratelimit-reset': ['2026-08-26T12:02:00Z'],
+          },
+        ),
+        now,
+      );
+      final rateLimit = result as MastodonRateLimitException;
+      expect(rateLimit.retryAfter, const Duration(minutes: 1));
+      expect(rateLimit.resetAt, DateTime.utc(2026, 8, 26, 12, 2));
+    });
+
+    test('ignores malformed rate-limit metadata', () {
+      final result = convertDioExceptionAt(
+        _errorWithStatus(
+          429,
+          headers: {
+            'x-ratelimit-limit': ['many'],
+            'x-ratelimit-remaining': ['-1'],
+            'x-ratelimit-reset': ['later'],
+          },
+        ),
+        now,
+      );
+      final rateLimit = result as MastodonRateLimitException;
+      expect(rateLimit.retryAfter, isNull);
+      expect(rateLimit.limit, isNull);
+      expect(rateLimit.remaining, isNull);
+      expect(rateLimit.resetAt, isNull);
     });
   });
 

--- a/test/internal/dio_error_handler_test.dart
+++ b/test/internal/dio_error_handler_test.dart
@@ -195,6 +195,79 @@ void main() {
       });
     }
 
+    test('keeps an RFC850 date exactly 50 years in the future', () {
+      final result = convertDioExceptionAt(
+        _errorWithStatus(
+          429,
+          headers: {
+            'retry-after': ['Wednesday, 26-Aug-76 12:00:00 GMT'],
+          },
+        ),
+        now,
+      );
+      expect(
+        (result as MastodonRateLimitException).retryAfter,
+        DateTime.utc(2076, 8, 26, 12).difference(now),
+      );
+    });
+
+    test(
+      'moves an RFC850 instant over the 50-year boundary back a century',
+      () {
+        final result = convertDioExceptionAt(
+          _errorWithStatus(
+            429,
+            headers: {
+              'retry-after': ['Thursday, 26-Aug-76 12:00:01 GMT'],
+            },
+          ),
+          now,
+        );
+        expect(
+          (result as MastodonRateLimitException).retryAfter,
+          Duration.zero,
+        );
+      },
+    );
+
+    test('moves an RFC850 date over the 50-year boundary back a century', () {
+      final result = convertDioExceptionAt(
+        _errorWithStatus(
+          429,
+          headers: {
+            'retry-after': ['Friday, 27-Aug-76 12:00:00 GMT'],
+          },
+        ),
+        now,
+      );
+      expect((result as MastodonRateLimitException).retryAfter, Duration.zero);
+    });
+
+    for (final retryAfter in [
+      'Foo, 26 Aug 2026 12:01:00 GMT',
+      'Thu, 26 Aug 2026 12:01:00 GMT',
+    ]) {
+      test(
+        'falls back when retry-after has an invalid weekday: $retryAfter',
+        () {
+          final result = convertDioExceptionAt(
+            _errorWithStatus(
+              429,
+              headers: {
+                'retry-after': [retryAfter],
+                'x-ratelimit-reset': ['2026-08-26T12:02:00Z'],
+              },
+            ),
+            now,
+          );
+          expect(
+            (result as MastodonRateLimitException).retryAfter,
+            const Duration(minutes: 2),
+          );
+        },
+      );
+    }
+
     test('falls back to x-ratelimit-reset when retry-after is invalid', () {
       final result = convertDioExceptionAt(
         _errorWithStatus(
@@ -232,6 +305,54 @@ void main() {
       expect(rateLimit.limit, 300);
       expect(rateLimit.remaining, 0);
       expect(rateLimit.resetAt, DateTime.utc(2026, 8, 26, 12, 2, 0, 123, 456));
+    });
+
+    test('accepts an explicit offset in x-ratelimit-reset', () {
+      final result = convertDioExceptionAt(
+        _errorWithStatus(
+          429,
+          headers: {
+            'x-ratelimit-reset': ['2026-08-26T21:02:00+09:00'],
+          },
+        ),
+        now,
+      );
+      final rateLimit = result as MastodonRateLimitException;
+      expect(rateLimit.retryAfter, const Duration(minutes: 2));
+      expect(rateLimit.resetAt, DateTime.utc(2026, 8, 26, 12, 2));
+    });
+
+    for (final reset in ['2026-08-26T12:02:00', '2026-02-30T12:02:00Z']) {
+      test('rejects a non-strict x-ratelimit-reset value: $reset', () {
+        final result = convertDioExceptionAt(
+          _errorWithStatus(
+            429,
+            headers: {
+              'x-ratelimit-reset': [reset],
+            },
+          ),
+          now,
+        );
+        final rateLimit = result as MastodonRateLimitException;
+        expect(rateLimit.retryAfter, isNull);
+        expect(rateLimit.resetAt, isNull);
+      });
+    }
+
+    test('uses retry-after when x-ratelimit-reset is not strict ISO', () {
+      final result = convertDioExceptionAt(
+        _errorWithStatus(
+          429,
+          headers: {
+            'retry-after': ['30'],
+            'x-ratelimit-reset': ['2026-08-26T12:02:00'],
+          },
+        ),
+        now,
+      );
+      final rateLimit = result as MastodonRateLimitException;
+      expect(rateLimit.retryAfter, const Duration(seconds: 30));
+      expect(rateLimit.resetAt, isNull);
     });
 
     test('clamps a past x-ratelimit-reset to zero', () {


### PR DESCRIPTION
## 概要

Mastodon本体が返すrate-limitヘッダから、429後の再試行時刻と生の制限情報を取得できるようにします。

## 対応内容

- 数値形式の`Retry-After`を維持
- RFC 9110のHTTP-date 3形式に対応
- `Retry-After`が欠落／不正な場合に`X-RateLimit-Reset`へフォールバック
- reset日時をタイムゾーン付きISO形式として厳密に検証
- 過去のreset日時を`Duration.zero`へ丸める
- `MastodonRateLimitException`へ`limit`／`remaining`／`resetAt`を追加
- deterministicな境界・不正値・優先順位テストを追加
- error handlingドキュメント6言語とCHANGELOGを更新

成功応答からrate-limit情報を公開する設計は、レスポンスAPI全体への影響があるため本PRの対象外です。

## 検証

- `dart analyze --fatal-infos`: 成功
- 対象テスト: 39件成功
- 全テスト: 321件成功、E2E 4件skip
- `git diff --check`: 成功
- `dart pub publish --dry-run`: 外部送信許可の都合で未実施

Closes #47
