### PR TITLE
fix: フィルターとIPブロックの期限解除に対応 (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** `FiltersApi.update()`, `FiltersApi.updateV1()`, and
+  `MastodonAdminIpBlockUpdateRequest.expiresIn` now accept `Optional<int>`
+  instead of `int`. Pass `Optional(seconds)` to set an expiration,
+  `Optional.null_()` to clear it, or omit the parameter to leave it unchanged
+  (issue #61)
+
 ## [1.0.0-beta.3] - 2026-08-25
 
 ### Added

--- a/docs/docs/api/admin.md
+++ b/docs/docs/api/admin.md
@@ -187,12 +187,19 @@ final block = await client.adminIpBlocks.create(
 // Update
 await client.adminIpBlocks.update(
   block.id,
-  MastodonAdminIpBlockUpdateRequest(severity: 'sign_up_block'),
+  const MastodonAdminIpBlockUpdateRequest(
+    severity: 'sign_up_block',
+    expiresIn: Optional.null_(), // Make the block permanent
+  ),
 );
 
 // Delete
 await client.adminIpBlocks.delete(block.id);
 ```
+
+For updates, omit `expiresIn` to keep the current expiration, pass
+`Optional(seconds)` to set one, or pass `Optional.null_()` to make the block
+permanent.
 
 ## Email blocks
 

--- a/docs/docs/api/filters.md
+++ b/docs/docs/api/filters.md
@@ -66,15 +66,25 @@ final filter = await client.filters.create(
 
 ## Updating a filter
 
-All parameters are optional; only the fields you provide are updated.
+All parameters are optional; only the fields you provide are updated. The
+`expiresIn` parameter has three states: omit it to keep the current expiration,
+pass `Optional(seconds)` to set one, or pass `Optional.null_()` to make the
+filter permanent.
 
 ```dart
 final updated = await client.filters.update(
   '1',
   title: 'Updated title',
   filterAction: 'hide',
+  expiresIn: const Optional(86400),
 );
+
+// Remove the expiration without changing the other fields.
+await client.filters.update('1', expiresIn: const Optional.null_());
 ```
+
+The deprecated `updateV1()` method uses the same three states. Mastodon rejects
+expiration changes on a v1 filter that contains multiple keywords.
 
 ## Deleting a filter
 

--- a/docs/i18n/de/docusaurus-plugin-content-docs/current/api/admin.md
+++ b/docs/i18n/de/docusaurus-plugin-content-docs/current/api/admin.md
@@ -187,12 +187,19 @@ final block = await client.adminIpBlocks.create(
 // Update
 await client.adminIpBlocks.update(
   block.id,
-  MastodonAdminIpBlockUpdateRequest(severity: 'sign_up_block'),
+  const MastodonAdminIpBlockUpdateRequest(
+    severity: 'sign_up_block',
+    expiresIn: Optional.null_(), // Sperre dauerhaft gültig machen
+  ),
 );
 
 // Delete
 await client.adminIpBlocks.delete(block.id);
 ```
+
+Bei Aktualisierungen `expiresIn` weglassen, um den aktuellen Ablauf
+beizubehalten, `Optional(seconds)` zum Setzen oder `Optional.null_()`, um die
+Sperre dauerhaft gültig zu machen.
 
 ## E-Mail-Sperren
 

--- a/docs/i18n/de/docusaurus-plugin-content-docs/current/api/filters.md
+++ b/docs/i18n/de/docusaurus-plugin-content-docs/current/api/filters.md
@@ -67,14 +67,24 @@ final filter = await client.filters.create(
 ## Filter aktualisieren
 
 Alle Parameter sind optional; nur angegebene Felder werden geändert.
+`expiresIn` hat drei Zustände: weglassen, um den aktuellen Ablauf beizubehalten,
+`Optional(seconds)` zum Setzen oder `Optional.null_()`, um den Filter dauerhaft
+gültig zu machen.
 
 ```dart
 final updated = await client.filters.update(
   '1',
   title: 'Updated title',
   filterAction: 'hide',
+  expiresIn: const Optional(86400),
 );
+
+// Ablauf entfernen, ohne andere Felder zu ändern.
+await client.filters.update('1', expiresIn: const Optional.null_());
 ```
+
+Die veraltete Methode `updateV1()` verwendet dieselben drei Zustände. Mastodon
+lehnt Ablaufänderungen bei einem v1-Filter mit mehreren Schlüsselwörtern ab.
 
 ## Filter löschen
 

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/api/admin.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/api/admin.md
@@ -187,12 +187,19 @@ final block = await client.adminIpBlocks.create(
 // Update
 await client.adminIpBlocks.update(
   block.id,
-  MastodonAdminIpBlockUpdateRequest(severity: 'sign_up_block'),
+  const MastodonAdminIpBlockUpdateRequest(
+    severity: 'sign_up_block',
+    expiresIn: Optional.null_(), // Rendre le blocage permanent
+  ),
 );
 
 // Delete
 await client.adminIpBlocks.delete(block.id);
 ```
+
+Lors d'une mise à jour, omettez `expiresIn` pour conserver l'expiration
+actuelle, passez `Optional(seconds)` pour en définir une, ou
+`Optional.null_()` pour rendre le blocage permanent.
 
 ## Blocages d'e-mails
 

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/api/filters.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/api/filters.md
@@ -67,14 +67,24 @@ final filter = await client.filters.create(
 ## Mettre à jour un filtre
 
 Tous les paramètres sont optionnels ; seuls les champs fournis sont mis à jour.
+`expiresIn` possède trois états : omettez-le pour conserver l'expiration
+actuelle, passez `Optional(seconds)` pour en définir une, ou
+`Optional.null_()` pour rendre le filtre permanent.
 
 ```dart
 final updated = await client.filters.update(
   '1',
   title: 'Updated title',
   filterAction: 'hide',
+  expiresIn: const Optional(86400),
 );
+
+// Supprimer l'expiration sans modifier les autres champs.
+await client.filters.update('1', expiresIn: const Optional.null_());
 ```
+
+La méthode obsolète `updateV1()` utilise les mêmes trois états. Mastodon refuse
+les modifications d'expiration d'un filtre v1 contenant plusieurs mots-clés.
 
 ## Supprimer un filtre
 

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/api/admin.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/api/admin.md
@@ -187,12 +187,18 @@ final block = await client.adminIpBlocks.create(
 // 更新
 await client.adminIpBlocks.update(
   block.id,
-  MastodonAdminIpBlockUpdateRequest(severity: 'sign_up_block'),
+  const MastodonAdminIpBlockUpdateRequest(
+    severity: 'sign_up_block',
+    expiresIn: Optional.null_(), // 無期限に変更
+  ),
 );
 
 // 削除
 await client.adminIpBlocks.delete(block.id);
 ```
+
+更新時の `expiresIn` は、省略すると現在の期限を維持し、`Optional(seconds)` で
+期限を設定し、`Optional.null_()` で無期限にできます。
 
 ## メールブロック
 

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/api/filters.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/api/filters.md
@@ -67,14 +67,23 @@ final filter = await client.filters.create(
 ## フィルターの更新
 
 すべてのパラメータは任意です。指定したフィールドのみ更新されます。
+`expiresIn` には3つの状態があります。省略すると現在の期限を維持し、
+`Optional(seconds)` で期限を設定し、`Optional.null_()` で無期限にできます。
 
 ```dart
 final updated = await client.filters.update(
   '1',
   title: '新しいタイトル',
   filterAction: 'hide',
+  expiresIn: const Optional(86400),
 );
+
+// 他のフィールドを変更せずに期限を解除
+await client.filters.update('1', expiresIn: const Optional.null_());
 ```
+
+非推奨の `updateV1()` も同じ3状態を使用します。複数キーワードを含む v1 フィルターでは、
+Mastodon が期限の変更を拒否します。
 
 ## フィルターの削除
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/admin.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/admin.md
@@ -187,12 +187,18 @@ final block = await client.adminIpBlocks.create(
 // 업데이트
 await client.adminIpBlocks.update(
   block.id,
-  MastodonAdminIpBlockUpdateRequest(severity: 'sign_up_block'),
+  const MastodonAdminIpBlockUpdateRequest(
+    severity: 'sign_up_block',
+    expiresIn: Optional.null_(), // 무기한으로 변경
+  ),
 );
 
 // 삭제
 await client.adminIpBlocks.delete(block.id);
 ```
+
+업데이트할 때 `expiresIn`을 생략하면 현재 만료 시간을 유지하고,
+`Optional(seconds)`로 설정하거나 `Optional.null_()`로 무기한으로 변경합니다.
 
 ## 이메일 차단
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/filters.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/filters.md
@@ -66,15 +66,24 @@ final filter = await client.filters.create(
 
 ## 필터 업데이트
 
-모든 파라미터는 선택 사항이며 제공한 필드만 업데이트됩니다.
+모든 파라미터는 선택 사항이며 제공한 필드만 업데이트됩니다. `expiresIn`에는
+세 가지 상태가 있습니다. 생략하면 현재 만료 시간을 유지하고,
+`Optional(seconds)`로 설정하거나 `Optional.null_()`로 무기한으로 변경합니다.
 
 ```dart
 final updated = await client.filters.update(
   '1',
   title: 'Updated title',
   filterAction: 'hide',
+  expiresIn: const Optional(86400),
 );
+
+// 다른 필드를 변경하지 않고 만료 시간을 제거합니다.
+await client.filters.update('1', expiresIn: const Optional.null_());
 ```
+
+지원 중단된 `updateV1()` 메서드도 같은 세 가지 상태를 사용합니다. 여러 키워드를
+포함하는 v1 필터에서는 Mastodon이 만료 시간 변경을 거부합니다.
 
 ## 필터 삭제
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/api/admin.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/api/admin.md
@@ -187,12 +187,18 @@ final block = await client.adminIpBlocks.create(
 // 更新
 await client.adminIpBlocks.update(
   block.id,
-  MastodonAdminIpBlockUpdateRequest(severity: 'sign_up_block'),
+  const MastodonAdminIpBlockUpdateRequest(
+    severity: 'sign_up_block',
+    expiresIn: Optional.null_(), // 改为永不过期
+  ),
 );
 
 // 删除
 await client.adminIpBlocks.delete(block.id);
 ```
+
+更新时省略 `expiresIn` 会保留当前过期时间，传入 `Optional(seconds)` 可设置
+过期时间，传入 `Optional.null_()` 可改为永不过期。
 
 ## 邮件屏蔽
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/api/filters.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/api/filters.md
@@ -66,15 +66,24 @@ final filter = await client.filters.create(
 
 ## 更新过滤器
 
-所有参数均为可选，只有提供的字段才会被更新。
+所有参数均为可选，只有提供的字段才会被更新。`expiresIn` 有三种状态：
+省略时保留当前过期时间，传入 `Optional(seconds)` 可设置过期时间，传入
+`Optional.null_()` 可改为永不过期。
 
 ```dart
 final updated = await client.filters.update(
   '1',
   title: 'Updated title',
   filterAction: 'hide',
+  expiresIn: const Optional(86400),
 );
+
+// 在不更改其他字段的情况下清除过期时间。
+await client.filters.update('1', expiresIn: const Optional.null_());
 ```
+
+已弃用的 `updateV1()` 方法也使用相同的三种状态。对于包含多个关键词的 v1
+过滤器，Mastodon 会拒绝修改过期时间。
 
 ## 删除过滤器
 

--- a/lib/mastodon_client.dart
+++ b/lib/mastodon_client.dart
@@ -5,6 +5,7 @@ export 'src/api/filters_api.dart'
     show MastodonFilterKeywordParam, MastodonFilterKeywordUpdateParam;
 export 'src/client/mastodon_client.dart';
 export 'src/exception/mastodon_exception.dart';
+export 'src/internal/optional.dart';
 export 'src/logging/function_logger.dart';
 export 'src/logging/logger.dart';
 export 'src/models/admin/mastodon_admin_account.dart';

--- a/lib/src/api/admin/admin_ip_blocks_api.dart
+++ b/lib/src/api/admin/admin_ip_blocks_api.dart
@@ -78,6 +78,10 @@ class AdminIpBlocksApi {
   ///
   /// `PUT /api/v1/admin/ip_blocks/{id}`
   ///
+  /// In [request], omit `expiresIn` to preserve the current expiration, pass
+  /// `Optional(seconds)` to set it, or pass `Optional.null_()` to make the
+  /// block permanent.
+  ///
   /// Throws a `MastodonException` on failure.
   Future<MastodonAdminIpBlock> update(
     String id,

--- a/lib/src/api/filters_api.dart
+++ b/lib/src/api/filters_api.dart
@@ -1,4 +1,6 @@
 import '../client/mastodon_http_client.dart';
+import '../internal/optional.dart';
+import '../internal/request_body.dart';
 import '../models/mastodon_filter.dart';
 
 /// API client for filters.
@@ -81,6 +83,9 @@ class FiltersApi {
   /// `PUT /api/v2/filters/{id}`
   ///
   /// All parameters are optional; only the fields provided are updated.
+  /// Omit [expiresIn] to preserve the current expiration, pass
+  /// `Optional(seconds)` to set it, or pass `Optional.null_()` to make the
+  /// filter permanent.
   /// [keywordsAttributes] may include new keywords to add, existing ones
   /// to update, or ones marked with `_destroy` to delete.
   ///
@@ -90,14 +95,14 @@ class FiltersApi {
     String? title,
     List<String>? context,
     String? filterAction,
-    int? expiresIn,
+    Optional<int>? expiresIn,
     List<MastodonFilterKeywordUpdateParam>? keywordsAttributes,
   }) async {
     final body = <String, dynamic>{
       'title': ?title,
       'filter_action': ?filterAction,
-      'expires_in': ?expiresIn,
     };
+    putOptional(body, 'expires_in', expiresIn);
     if (context != null) {
       body['context'] = context;
     }
@@ -339,7 +344,9 @@ class FiltersApi {
   /// or `context` on a filter with multiple keywords.
   ///
   /// [phrase] and [context] are required. [irreversible] and [wholeWord]
-  /// default to `false`. [expiresIn] is the expiration in seconds.
+  /// default to `false`. Omit [expiresIn] to preserve the current expiration,
+  /// pass `Optional(seconds)` to set it, or pass `Optional.null_()` to make the
+  /// filter permanent.
   ///
   /// Use [update] (v2) instead since Mastodon 4.0.
   ///
@@ -352,18 +359,19 @@ class FiltersApi {
     required List<String> context,
     bool? irreversible,
     bool? wholeWord,
-    int? expiresIn,
+    Optional<int>? expiresIn,
   }) async {
+    final body = <String, dynamic>{
+      'phrase': phrase,
+      'context': context,
+      'irreversible': ?irreversible,
+      'whole_word': ?wholeWord,
+    };
+    putOptional(body, 'expires_in', expiresIn);
     final data = await _http.send<Map<String, dynamic>>(
       '/api/v1/filters/$id',
       method: 'PUT',
-      data: <String, dynamic>{
-        'phrase': phrase,
-        'context': context,
-        'irreversible': ?irreversible,
-        'whole_word': ?wholeWord,
-        'expires_in': ?expiresIn,
-      },
+      data: body,
     );
     return MastodonFilterV1.fromJson(data!);
   }

--- a/lib/src/internal/optional.dart
+++ b/lib/src/internal/optional.dart
@@ -1,0 +1,38 @@
+/// A wrapper type that distinguishes between "not specified" and "explicitly
+/// send null" for API parameters.
+///
+/// Dart's optional parameters treat `null` as "not specified", making it
+/// impossible to express "send null to clear the value". This type represents
+/// three states:
+///
+/// When the parameter is omitted (default `null`), it is not included in the
+/// request body and the field remains unchanged. Passing `Optional(value)`
+/// sets the field to the given value. Passing `Optional.null_()` sends
+/// `null` explicitly to clear the field.
+///
+/// ```dart
+/// // Set an expiration, then remove it.
+/// await client.filters.update('1', expiresIn: Optional(3600));
+/// await client.filters.update('1', expiresIn: Optional.null_());
+/// ```
+sealed class Optional<T> {
+  /// Sets a value (use [Optional.null_] to explicitly send `null`).
+  const factory Optional(T value) = Some<T>;
+
+  const Optional._();
+
+  /// Explicitly sends `null` to clear the value.
+  const factory Optional.null_() = Some<T>.null_;
+}
+
+/// Represents a specified value (a `null` value means "send null").
+final class Some<T> extends Optional<T> {
+  /// Creates an instance with the given [value].
+  const Some(this.value) : super._();
+
+  /// Creates an instance that explicitly sends `null`.
+  const Some.null_() : value = null, super._();
+
+  /// The specified value, or `null` if the intent is to clear it.
+  final T? value;
+}

--- a/lib/src/internal/request_body.dart
+++ b/lib/src/internal/request_body.dart
@@ -1,0 +1,13 @@
+import 'optional.dart';
+
+/// Writes an [Optional] parameter into a request [body].
+///
+/// When [opt] is `null` (unspecified) the function does nothing, leaving the
+/// key out of the body so the server keeps the current value. When [opt] is a
+/// [Some] instance, `body[key]` is set to the wrapped value, which is `null`
+/// for `Optional.null_()` and therefore clears the field.
+void putOptional<T>(Map<String, dynamic> body, String key, Optional<T>? opt) {
+  if (opt case Some<T>(:final value)) {
+    body[key] = value;
+  }
+}

--- a/lib/src/models/admin/mastodon_admin_ip_block_request.dart
+++ b/lib/src/models/admin/mastodon_admin_ip_block_request.dart
@@ -1,3 +1,6 @@
+import '../../internal/optional.dart';
+import '../../internal/request_body.dart';
+
 /// Request for creating an admin IP block.
 ///
 /// Request body for `POST /api/v1/admin/ip_blocks`.
@@ -54,14 +57,20 @@ class MastodonAdminIpBlockUpdateRequest {
   /// Reason for the block.
   final String? comment;
 
-  /// Expiration time in seconds. Omit for permanent.
-  final int? expiresIn;
+  /// Expiration update.
+  ///
+  /// Omit to preserve the current expiration, pass `Optional(seconds)` to set
+  /// it, or pass `Optional.null_()` to make the block permanent.
+  final Optional<int>? expiresIn;
 
   /// Converts to a JSON map for the request body.
-  Map<String, dynamic> toJson() => {
-    'ip': ?ip,
-    'severity': ?severity,
-    'comment': ?comment,
-    'expires_in': ?expiresIn,
-  };
+  Map<String, dynamic> toJson() {
+    final body = <String, dynamic>{
+      'ip': ?ip,
+      'severity': ?severity,
+      'comment': ?comment,
+    };
+    putOptional(body, 'expires_in', expiresIn);
+    return body;
+  }
 }

--- a/test/api/expiration_update_test.dart
+++ b/test/api/expiration_update_test.dart
@@ -54,51 +54,60 @@ void main() {
     },
   );
 
-  test('FiltersApi.updateV1 distinguishes set, clear, and reset', () async {
-    final http = RecordingHttpClient(const [
-      filterV1Response,
-      filterV1Response,
-      filterV1Response,
-    ]);
-    final api = FiltersApi(http);
+  test(
+    'FiltersApi.updateV1 distinguishes set, clear, reset, and omission',
+    () async {
+      final http = RecordingHttpClient(const [
+        filterV1Response,
+        filterV1Response,
+        filterV1Response,
+        filterV1Response,
+      ]);
+      final api = FiltersApi(http);
 
-    await api.updateV1(
-      '1',
-      phrase: 'spoiler',
-      context: const ['home'],
-      expiresIn: const Optional(3600),
-    );
-    await api.updateV1(
-      '1',
-      phrase: 'spoiler',
-      context: const ['home'],
-      expiresIn: const Optional.null_(),
-    );
-    await api.updateV1(
-      '1',
-      phrase: 'spoiler',
-      context: const ['home'],
-      expiresIn: const Optional(7200),
-    );
+      await api.updateV1(
+        '1',
+        phrase: 'spoiler',
+        context: const ['home'],
+        expiresIn: const Optional(3600),
+      );
+      await api.updateV1(
+        '1',
+        phrase: 'spoiler',
+        context: const ['home'],
+        expiresIn: const Optional.null_(),
+      );
+      await api.updateV1(
+        '1',
+        phrase: 'spoiler',
+        context: const ['home'],
+        expiresIn: const Optional(7200),
+      );
+      await api.updateV1('1', phrase: 'spoiler', context: const ['home']);
 
-    expect(http.requests.map((request) => request.data), [
-      {
-        'phrase': 'spoiler',
-        'context': ['home'],
-        'expires_in': 3600,
-      },
-      {
-        'phrase': 'spoiler',
-        'context': ['home'],
-        'expires_in': null,
-      },
-      {
-        'phrase': 'spoiler',
-        'context': ['home'],
-        'expires_in': 7200,
-      },
-    ]);
-  });
+      expect(http.requests.map((request) => request.data), [
+        {
+          'phrase': 'spoiler',
+          'context': ['home'],
+          'expires_in': 3600,
+        },
+        {
+          'phrase': 'spoiler',
+          'context': ['home'],
+          'expires_in': null,
+        },
+        {
+          'phrase': 'spoiler',
+          'context': ['home'],
+          'expires_in': 7200,
+        },
+        {
+          'phrase': 'spoiler',
+          'context': ['home'],
+        },
+      ]);
+    },
+  );
 
   test('AdminIpBlocksApi.update distinguishes set, clear, and reset', () async {
     final http = RecordingHttpClient(const [

--- a/test/api/expiration_update_test.dart
+++ b/test/api/expiration_update_test.dart
@@ -1,0 +1,137 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
+import 'package:mastodon_client/mastodon_client.dart';
+import 'package:mastodon_client/src/api/admin/admin_ip_blocks_api.dart';
+import 'package:mastodon_client/src/api/filters_api.dart';
+import 'package:test/test.dart';
+
+import '../helpers/recording_http_client.dart';
+
+void main() {
+  const filterResponse = <String, dynamic>{
+    'id': '1',
+    'title': 'Test filter',
+    'context': <String>['home'],
+    'filter_action': 'warn',
+    'keywords': <dynamic>[],
+    'statuses': <dynamic>[],
+  };
+  const filterV1Response = <String, dynamic>{
+    'id': '1',
+    'phrase': 'spoiler',
+    'context': <String>['home'],
+    'irreversible': false,
+    'whole_word': false,
+  };
+  const ipBlockResponse = <String, dynamic>{
+    'id': '1',
+    'ip': '192.0.2.0/24',
+    'severity': 'no_access',
+  };
+
+  test(
+    'FiltersApi.update distinguishes set, clear, reset, and omission',
+    () async {
+      final http = RecordingHttpClient(const [
+        filterResponse,
+        filterResponse,
+        filterResponse,
+        filterResponse,
+      ]);
+      final api = FiltersApi(http);
+
+      await api.update('1', expiresIn: const Optional(3600));
+      await api.update('1', expiresIn: const Optional.null_());
+      await api.update('1', expiresIn: const Optional(7200));
+      await api.update('1');
+
+      expect(http.requests.map((request) => request.data), [
+        {'expires_in': 3600},
+        {'expires_in': null},
+        {'expires_in': 7200},
+        <String, dynamic>{},
+      ]);
+    },
+  );
+
+  test('FiltersApi.updateV1 distinguishes set, clear, and reset', () async {
+    final http = RecordingHttpClient(const [
+      filterV1Response,
+      filterV1Response,
+      filterV1Response,
+    ]);
+    final api = FiltersApi(http);
+
+    await api.updateV1(
+      '1',
+      phrase: 'spoiler',
+      context: const ['home'],
+      expiresIn: const Optional(3600),
+    );
+    await api.updateV1(
+      '1',
+      phrase: 'spoiler',
+      context: const ['home'],
+      expiresIn: const Optional.null_(),
+    );
+    await api.updateV1(
+      '1',
+      phrase: 'spoiler',
+      context: const ['home'],
+      expiresIn: const Optional(7200),
+    );
+
+    expect(http.requests.map((request) => request.data), [
+      {
+        'phrase': 'spoiler',
+        'context': ['home'],
+        'expires_in': 3600,
+      },
+      {
+        'phrase': 'spoiler',
+        'context': ['home'],
+        'expires_in': null,
+      },
+      {
+        'phrase': 'spoiler',
+        'context': ['home'],
+        'expires_in': 7200,
+      },
+    ]);
+  });
+
+  test('AdminIpBlocksApi.update distinguishes set, clear, and reset', () async {
+    final http = RecordingHttpClient(const [
+      ipBlockResponse,
+      ipBlockResponse,
+      ipBlockResponse,
+    ]);
+    final api = AdminIpBlocksApi(http);
+
+    await api.update(
+      '1',
+      const MastodonAdminIpBlockUpdateRequest(expiresIn: Optional(3600)),
+    );
+    await api.update(
+      '1',
+      const MastodonAdminIpBlockUpdateRequest(expiresIn: Optional.null_()),
+    );
+    await api.update(
+      '1',
+      const MastodonAdminIpBlockUpdateRequest(expiresIn: Optional(7200)),
+    );
+
+    expect(http.requests.map((request) => request.data), [
+      {'expires_in': 3600},
+      {'expires_in': null},
+      {'expires_in': 7200},
+    ]);
+  });
+
+  test('MastodonAdminIpBlockUpdateRequest omits an unspecified expiration', () {
+    expect(
+      const MastodonAdminIpBlockUpdateRequest().toJson(),
+      isNot(contains('expires_in')),
+    );
+  });
+}


### PR DESCRIPTION
## 概要

期限付きフィルターと管理者IPブロックを、更新APIから無期限へ戻せるようにします。

## 対応内容

- 姉妹ライブラリと共通設計の`Optional<T>`／`Optional.null_()`を追加・公開
- request body用の`putOptional()`を追加
- `FiltersApi.update()`／`updateV1()`の`expiresIn`へ適用
- `MastodonAdminIpBlockUpdateRequest.expiresIn`へ適用
- 値あり／明示null／省略の3状態を検証する回帰テストを追加
- Filters／Admin APIドキュメント6言語とCHANGELOGを更新

## 互換性

更新APIの`expiresIn`型は`int?`から`Optional<int>?`へ変わる破壊的変更です。

- 設定: `expiresIn: Optional(3600)`
- 解除: `expiresIn: Optional.null_()`
- 変更しない: `expiresIn`を省略

Create APIの`expiresIn`は従来どおり`int?`です。

## 検証

- `dart analyze`: 成功
- 対象テスト: 4件成功
- 全テスト: 309件成功、E2E 4件skip
- build_runner: 生成差分なし
- `git diff --check`: 成功
- `dart pub publish --dry-run`: 外部送信許可の都合で未実施

Closes #61
