### PR TITLE
アカウント一覧取得時の403エラーを伝播する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** Account follower, following, and endorsement listings now
+  propagate HTTP 403 as `MastodonForbiddenException` instead of silently
+  returning an empty page, allowing authorization and scope failures to be
+  detected (issue #60)
 - **Breaking:** `MastodonStatus.quote` is now a `MastodonQuote?` relationship
   instead of a `MastodonStatus?`, matching Mastodon 4.5 responses. Access the
   embedded status through `status.quote?.quotedStatus`; shallow nested quotes

--- a/lib/src/api/accounts_api.dart
+++ b/lib/src/api/accounts_api.dart
@@ -132,8 +132,9 @@ class AccountsApi {
   /// pass the `nextMaxId` from the previous response as [maxId] to page
   /// backward, or use [minId] for forward pagination.
   ///
-  /// Returns an empty [MastodonPage] for private accounts (HTTP 403).
-  /// Throws a subclass of [MastodonException] on other failures.
+  /// Throws [MastodonForbiddenException] on HTTP 403, including when the
+  /// access token does not have the required `read` or `read:accounts` scope.
+  /// Throws another subclass of [MastodonException] on other failures.
   Future<MastodonPage<MastodonAccount>> fetchFollowers(
     String accountId, {
     int? limit,
@@ -157,8 +158,9 @@ class AccountsApi {
   /// pass the `nextMaxId` from the previous response as [maxId] to page
   /// backward, or use [minId] for forward pagination.
   ///
-  /// Returns an empty [MastodonPage] for private accounts (HTTP 403).
-  /// Throws a subclass of [MastodonException] on other failures.
+  /// Throws [MastodonForbiddenException] on HTTP 403, including when the
+  /// access token does not have the required `read` or `read:accounts` scope.
+  /// Throws another subclass of [MastodonException] on other failures.
   Future<MastodonPage<MastodonAccount>> fetchFollowing(
     String accountId, {
     int? limit,
@@ -470,7 +472,9 @@ class AccountsApi {
   /// backward; use [sinceId] to receive only newer results, or [minId]
   /// for forward pagination.
   ///
-  /// Throws a subclass of [MastodonException] on failure.
+  /// Throws [MastodonForbiddenException] on HTTP 403, including when the
+  /// access token does not have the required `read` or `read:accounts` scope.
+  /// Throws another subclass of [MastodonException] on other failures.
   Future<MastodonPage<MastodonAccount>> fetchEndorsements(
     String id, {
     int? limit,
@@ -609,28 +613,24 @@ class AccountsApi {
     String? sinceId,
     String? minId,
   }) async {
-    try {
-      final response = await _http.sendRaw<List<dynamic>>(
-        path,
-        queryParameters: <String, dynamic>{
-          'limit': ?limit,
-          'max_id': ?maxId,
-          'since_id': ?sinceId,
-          'min_id': ?minId,
-        },
-      );
-      final linkHeader = response.headers.map['link']?.join(',');
-      final items = (response.data ?? const <dynamic>[])
-          .cast<Map<String, dynamic>>()
-          .map(MastodonAccount.fromJson)
-          .toList();
-      return MastodonPage(
-        items: items,
-        nextMaxId: parseNextMaxId(linkHeader),
-        prevMinId: parsePrevMinId(linkHeader),
-      );
-    } on MastodonForbiddenException {
-      return const MastodonPage(items: []);
-    }
+    final response = await _http.sendRaw<List<dynamic>>(
+      path,
+      queryParameters: <String, dynamic>{
+        'limit': ?limit,
+        'max_id': ?maxId,
+        'since_id': ?sinceId,
+        'min_id': ?minId,
+      },
+    );
+    final linkHeader = response.headers.map['link']?.join(',');
+    final items = (response.data ?? const <dynamic>[])
+        .cast<Map<String, dynamic>>()
+        .map(MastodonAccount.fromJson)
+        .toList();
+    return MastodonPage(
+      items: items,
+      nextMaxId: parseNextMaxId(linkHeader),
+      prevMinId: parsePrevMinId(linkHeader),
+    );
   }
 }

--- a/test/api/accounts_api_test.dart
+++ b/test/api/accounts_api_test.dart
@@ -1,0 +1,70 @@
+import 'package:dio/dio.dart';
+import 'package:mastodon_client/src/api/accounts_api.dart';
+import 'package:mastodon_client/src/client/mastodon_http_client.dart';
+import 'package:mastodon_client/src/exception/mastodon_exception.dart';
+import 'package:test/test.dart';
+
+import '../helpers/recording_http_client.dart';
+
+void main() {
+  group('AccountsApi account collections', () {
+    test('returns an empty page for a successful empty response', () async {
+      final api = AccountsApi(RecordingHttpClient([<dynamic>[]]));
+
+      final page = await api.fetchFollowers('42');
+
+      expect(page.items, isEmpty);
+    });
+
+    for (final testCase
+        in <({String name, String path, _AccountPageCall call})>[
+          (
+            name: 'fetchFollowers',
+            path: '/api/v1/accounts/42/followers',
+            call: (api) => api.fetchFollowers('42'),
+          ),
+          (
+            name: 'fetchFollowing',
+            path: '/api/v1/accounts/42/following',
+            call: (api) => api.fetchFollowing('42'),
+          ),
+          (
+            name: 'fetchEndorsements',
+            path: '/api/v1/accounts/42/endorsements',
+            call: (api) => api.fetchEndorsements('42'),
+          ),
+        ]) {
+      test('${testCase.name} propagates HTTP 403', () async {
+        final api = AccountsApi(_ForbiddenHttpClient());
+
+        await expectLater(
+          testCase.call(api),
+          throwsA(
+            isA<MastodonForbiddenException>()
+                .having((error) => error.message, 'message', 'Scope denied')
+                .having((error) => error.endpoint, 'endpoint', testCase.path),
+          ),
+        );
+      });
+    }
+  });
+}
+
+typedef _AccountPageCall = Future<Object?> Function(AccountsApi api);
+
+class _ForbiddenHttpClient extends MastodonHttpClient {
+  _ForbiddenHttpClient()
+    : super(baseUrl: 'https://mastodon.example', enableLog: false);
+
+  @override
+  Future<Response<T>> sendRaw<T>(
+    String path, {
+    String method = 'GET',
+    Object? data,
+    Map<String, dynamic>? queryParameters,
+    Map<String, String>? headers,
+    String? contentType,
+  }) {
+    throw MastodonForbiddenException(message: 'Scope denied', endpoint: path);
+  }
+}


### PR DESCRIPTION
## 概要

- フォロワー、フォロー中、推薦アカウント一覧の取得時に、HTTP 403を空ページへ変換せずそのまま送出するよう修正
- 認証およびスコープ不足時の挙動に合わせて公開メソッドのドキュメントを修正
- 3つの一覧取得経路における403の伝播と、正常な空レスポンスに対する回帰テストを追加

## 検証

- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test`（344件成功、E2E 4件は環境未構成のためスキップ）

Closes #60