### PR TITLE
feat: 422検証エラーの詳細を型付きで公開

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `MastodonValidationException.details` now exposes Mastodon's field-level
+  validation errors as typed `MastodonValidationErrorDetail` values, including
+  the nested Collections response shape, while preserving unknown error codes
+  (issue #54)
+
 ### Changed
 
 - **Breaking:** HTTP requests no longer use library-defined 10-second connect,

--- a/docs/docs/error-handling.md
+++ b/docs/docs/error-handling.md
@@ -21,6 +21,7 @@ MastodonException (sealed)
 │   │   └── resetAt                   //   Time when the window resets
 │   ├── MastodonValidationException   // 422 - Validation error
 │   │   ├── serverMessage             //   Detailed server message
+│   │   ├── details                   //   Field errors by request field
 │   │   └── MastodonAlreadyVotedException // Already voted
 │   └── MastodonServerException       // 5xx - Server error
 ├── MastodonNetworkException          // Network connection error
@@ -64,11 +65,24 @@ try {
 
 ```dart
 try {
-  await client.statuses.create(request);
+  await client.accounts.create(request);
 } on MastodonValidationException catch (e) {
   print('Validation error: ${e.serverMessage}');
+  final details = e.details;
+  if (details != null) {
+    for (final entry in details.entries) {
+      for (final detail in entry.value) {
+        print('${entry.key}: ${detail.code} - ${detail.description ?? ''}');
+      }
+    }
+  }
 }
 ```
+
+`details` is keyed by request field. Each `MastodonValidationErrorDetail`
+contains the server's error code and optional description. Unknown codes are
+preserved as strings for forward compatibility. `details` is `null` when an
+endpoint does not return Mastodon's recognized validation-details shape.
 
 ## Special exceptions
 

--- a/docs/i18n/de/docusaurus-plugin-content-docs/current/error-handling.md
+++ b/docs/i18n/de/docusaurus-plugin-content-docs/current/error-handling.md
@@ -21,6 +21,7 @@ MastodonException (sealed)
 │   │   └── resetAt                   //   Time when the window resets
 │   ├── MastodonValidationException   // 422 - Validation error
 │   │   ├── serverMessage             //   Detailed server message
+│   │   ├── details                   //   Field errors by request field
 │   │   └── MastodonAlreadyVotedException // Already voted
 │   └── MastodonServerException       // 5xx - Server error
 ├── MastodonNetworkException          // Network connection error
@@ -64,11 +65,25 @@ try {
 
 ```dart
 try {
-  await client.statuses.create(request);
+  await client.accounts.create(request);
 } on MastodonValidationException catch (e) {
   print('Validation error: ${e.serverMessage}');
+  final details = e.details;
+  if (details != null) {
+    for (final entry in details.entries) {
+      for (final detail in entry.value) {
+        print('${entry.key}: ${detail.code} - ${detail.description ?? ''}');
+      }
+    }
+  }
 }
 ```
+
+`details` ist nach Request-Feldern gruppiert. Jeder
+`MastodonValidationErrorDetail` enthält den Fehlercode des Servers und eine
+optionale Beschreibung. Unbekannte Codes bleiben als Strings erhalten. Wenn
+ein Endpunkt nicht Mastodons erkanntes Format für Validierungsdetails liefert,
+ist `details` gleich `null`.
 
 ## Besondere Exceptions
 

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/error-handling.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/error-handling.md
@@ -21,6 +21,7 @@ MastodonException (sealed)
 │   │   └── resetAt                   //   Time when the window resets
 │   ├── MastodonValidationException   // 422 - Validation error
 │   │   ├── serverMessage             //   Detailed server message
+│   │   ├── details                   //   Field errors by request field
 │   │   └── MastodonAlreadyVotedException // Already voted
 │   └── MastodonServerException       // 5xx - Server error
 ├── MastodonNetworkException          // Network connection error
@@ -64,11 +65,25 @@ try {
 
 ```dart
 try {
-  await client.statuses.create(request);
+  await client.accounts.create(request);
 } on MastodonValidationException catch (e) {
   print('Validation error: ${e.serverMessage}');
+  final details = e.details;
+  if (details != null) {
+    for (final entry in details.entries) {
+      for (final detail in entry.value) {
+        print('${entry.key}: ${detail.code} - ${detail.description ?? ''}');
+      }
+    }
+  }
 }
 ```
+
+`details` est indexé par champ de requête. Chaque
+`MastodonValidationErrorDetail` contient le code d'erreur du serveur et une
+description facultative. Les codes inconnus sont conservés sous forme de
+chaînes. `details` vaut `null` lorsqu'un endpoint ne renvoie pas le format de
+détails de validation reconnu de Mastodon.
 
 ## Exceptions spéciales
 

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/error-handling.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/error-handling.md
@@ -21,6 +21,7 @@ MastodonException (sealed)
 │   │   └── resetAt                   //   制限がリセットされる時刻
 │   ├── MastodonValidationException   // 422 - バリデーションエラー
 │   │   ├── serverMessage             //   サーバーからの詳細メッセージ
+│   │   ├── details                   //   リクエスト項目ごとのエラー
 │   │   └── MastodonAlreadyVotedException // 投票済みエラー
 │   └── MastodonServerException       // 5xx - サーバーエラー
 ├── MastodonNetworkException          // ネットワーク接続エラー
@@ -64,11 +65,25 @@ try {
 
 ```dart
 try {
-  await client.statuses.create(request);
+  await client.accounts.create(request);
 } on MastodonValidationException catch (e) {
   print('バリデーションエラー: ${e.serverMessage}');
+  final details = e.details;
+  if (details != null) {
+    for (final entry in details.entries) {
+      for (final detail in entry.value) {
+        print('${entry.key}: ${detail.code} - ${detail.description ?? ''}');
+      }
+    }
+  }
 }
 ```
+
+`details` はリクエスト項目をキーとする Map です。各
+`MastodonValidationErrorDetail` からサーバーのエラーコードと任意の説明を
+取得できます。未知のコードも将来互換性のため文字列のまま保持されます。
+エンドポイントが Mastodon の既知のバリデーション詳細形式を返さない場合、
+`details` は `null` です。
 
 ## 特殊な例外
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/error-handling.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/error-handling.md
@@ -21,6 +21,7 @@ MastodonException (sealed)
 │   │   └── resetAt                   //   제한이 재설정되는 시각
 │   ├── MastodonValidationException   // 422 - 유효성 검사 에러
 │   │   ├── serverMessage             //   서버의 상세 메시지
+│   │   ├── details                   //   요청 필드별 에러
 │   │   └── MastodonAlreadyVotedException // 이미 투표함
 │   └── MastodonServerException       // 5xx - 서버 에러
 ├── MastodonNetworkException          // 네트워크 연결 에러
@@ -64,11 +65,25 @@ try {
 
 ```dart
 try {
-  await client.statuses.create(request);
+  await client.accounts.create(request);
 } on MastodonValidationException catch (e) {
   print('유효성 검사 에러: ${e.serverMessage}');
+  final details = e.details;
+  if (details != null) {
+    for (final entry in details.entries) {
+      for (final detail in entry.value) {
+        print('${entry.key}: ${detail.code} - ${detail.description ?? ''}');
+      }
+    }
+  }
 }
 ```
+
+`details`는 요청 필드를 키로 사용하는 Map입니다. 각
+`MastodonValidationErrorDetail`에는 서버의 에러 코드와 선택적 설명이
+포함됩니다. 알 수 없는 코드도 향후 호환성을 위해 문자열로 유지됩니다.
+엔드포인트가 Mastodon의 인식 가능한 유효성 검사 상세 형식을 반환하지 않으면
+`details`는 `null`입니다.
 
 ## 특수 예외
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/error-handling.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/error-handling.md
@@ -21,6 +21,7 @@ MastodonException (sealed)
 │   │   └── resetAt                   //   限制重置时间
 │   ├── MastodonValidationException   // 422 - 校验错误
 │   │   ├── serverMessage             //   服务器详细错误信息
+│   │   ├── details                   //   按请求字段分组的错误
 │   │   └── MastodonAlreadyVotedException // 已投过票
 │   └── MastodonServerException       // 5xx - 服务器错误
 ├── MastodonNetworkException          // 网络连接错误
@@ -64,11 +65,24 @@ try {
 
 ```dart
 try {
-  await client.statuses.create(request);
+  await client.accounts.create(request);
 } on MastodonValidationException catch (e) {
   print('校验错误: ${e.serverMessage}');
+  final details = e.details;
+  if (details != null) {
+    for (final entry in details.entries) {
+      for (final detail in entry.value) {
+        print('${entry.key}: ${detail.code} - ${detail.description ?? ''}');
+      }
+    }
+  }
 }
 ```
+
+`details` 是以请求字段为键的 Map。每个 `MastodonValidationErrorDetail`
+都包含服务器返回的错误代码和可选说明。未知代码也会以字符串形式保留，以便
+保持向前兼容。如果端点未返回 Mastodon 可识别的校验详情结构，`details` 为
+`null`。
 
 ## 特殊异常
 

--- a/lib/src/exception/mastodon_exception.dart
+++ b/lib/src/exception/mastodon_exception.dart
@@ -92,21 +92,43 @@ class MastodonRateLimitException extends MastodonApiException {
   final DateTime? resetAt;
 }
 
+/// Field-level detail returned in a Mastodon validation error.
+class MastodonValidationErrorDetail {
+  /// Creates a field-level validation error detail.
+  const MastodonValidationErrorDetail({required this.code, this.description});
+
+  /// Machine-readable identifier such as `ERR_TAKEN` or `ERR_BLANK`.
+  ///
+  /// Unknown values are preserved for forward compatibility.
+  final String code;
+
+  /// Human-readable description supplied by the server.
+  final String? description;
+}
+
 /// Validation error (HTTP 422).
 ///
 /// The request content is invalid.
 ///
-/// Holds the error details returned by the server in [serverMessage].
+/// Holds the message returned by the server in [serverMessage] and any
+/// field-level validation errors in [details].
 class MastodonValidationException extends MastodonApiException {
   const MastodonValidationException({
     super.message = 'Unprocessable entity',
     super.endpoint,
     super.raw,
     this.serverMessage,
+    this.details,
   }) : super(statusCode: 422);
 
-  /// Raw error message returned by the server.
+  /// Human-readable error message returned by the server.
   final String? serverMessage;
+
+  /// Field-level validation errors keyed by request field name.
+  ///
+  /// This is `null` when the response does not include a recognized
+  /// `details` object. Error codes not yet known to this client are preserved.
+  final Map<String, List<MastodonValidationErrorDetail>>? details;
 }
 
 /// Server error (HTTP 5xx).

--- a/lib/src/internal/dio_error_handler.dart
+++ b/lib/src/internal/dio_error_handler.dart
@@ -38,11 +38,7 @@ MastodonException convertDioExceptionAt(
         endpoint: endpoint,
         raw: e,
       ),
-      422 => MastodonValidationException(
-        serverMessage: serverMessage,
-        endpoint: endpoint,
-        raw: e,
-      ),
+      422 => _convertValidationException(e, endpoint),
       429 => MastodonRateLimitException(
         message: serverMessage ?? 'Rate limited',
         endpoint: endpoint,
@@ -81,6 +77,73 @@ String? _extractMessage(dynamic data) {
     if (error is String) return error;
   }
   return null;
+}
+
+MastodonValidationException _convertValidationException(
+  DioException error,
+  String? endpoint,
+) {
+  final parsed = _parseValidationError(error.response?.data);
+  return MastodonValidationException(
+    serverMessage: parsed.serverMessage,
+    details: parsed.details,
+    endpoint: endpoint,
+    raw: error,
+  );
+}
+
+({
+  String? serverMessage,
+  Map<String, List<MastodonValidationErrorDetail>>? details,
+})
+_parseValidationError(dynamic data) {
+  if (data is! Map<String, dynamic>) {
+    return (serverMessage: null, details: null);
+  }
+
+  final nestedError = data['error'];
+  final payload = nestedError is Map<String, dynamic> ? nestedError : data;
+  final message = payload['error'];
+
+  return (
+    serverMessage: message is String ? message : null,
+    details: _parseValidationDetails(payload['details']),
+  );
+}
+
+Map<String, List<MastodonValidationErrorDetail>>? _parseValidationDetails(
+  dynamic data,
+) {
+  if (data is! Map<String, dynamic>) return null;
+  if (data.isEmpty) {
+    return const <String, List<MastodonValidationErrorDetail>>{};
+  }
+
+  final parsed = <String, List<MastodonValidationErrorDetail>>{};
+  for (final entry in data.entries) {
+    final value = entry.value;
+    if (value is! List<dynamic>) continue;
+
+    final fieldErrors = <MastodonValidationErrorDetail>[];
+    for (final item in value) {
+      if (item is! Map<String, dynamic>) continue;
+      final code = item['error'];
+      if (code is! String || code.isEmpty) continue;
+      final description = item['description'];
+      fieldErrors.add(
+        MastodonValidationErrorDetail(
+          code: code,
+          description: description is String ? description : null,
+        ),
+      );
+    }
+
+    if (fieldErrors.isNotEmpty) {
+      parsed[entry.key] = List.unmodifiable(fieldErrors);
+    }
+  }
+
+  return parsed.isEmpty ? null : Map.unmodifiable(parsed);
 }
 
 ({Duration? retryAfter, int? limit, int? remaining, DateTime? resetAt})

--- a/test/internal/dio_error_handler_test.dart
+++ b/test/internal/dio_error_handler_test.dart
@@ -101,6 +101,163 @@ void main() {
               )
               as MastodonValidationException;
       expect(result.serverMessage, 'Validation failed: Text is too long');
+      expect(result.details, isNull);
+    });
+
+    test('422 parses field details from the standard response shape', () {
+      final result =
+          convertDioException(
+                _errorWithStatus(
+                  422,
+                  data: {
+                    'error': "Validation failed: Username can't be blank",
+                    'details': {
+                      'username': [
+                        {'error': 'ERR_BLANK', 'description': "can't be blank"},
+                      ],
+                    },
+                  },
+                ),
+              )
+              as MastodonValidationException;
+
+      expect(
+        result.serverMessage,
+        "Validation failed: Username can't be blank",
+      );
+      final usernameErrors = result.details?['username'];
+      expect(usernameErrors, hasLength(1));
+      expect(usernameErrors?.single.code, 'ERR_BLANK');
+      expect(usernameErrors?.single.description, "can't be blank");
+    });
+
+    test('422 parses the nested Collections validation response shape', () {
+      final result =
+          convertDioException(
+                _errorWithStatus(
+                  422,
+                  data: {
+                    'error': {
+                      'error': 'Validation failed: Name cannot be blank',
+                      'details': {
+                        'name': [
+                          {
+                            'error': 'ERR_BLANK',
+                            'description': "can't be blank",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                ),
+              )
+              as MastodonValidationException;
+
+      expect(result.serverMessage, 'Validation failed: Name cannot be blank');
+      expect(result.details?['name']?.single.code, 'ERR_BLANK');
+    });
+
+    test('422 preserves multiple fields, errors, and unknown values', () {
+      final result =
+          convertDioException(
+                _errorWithStatus(
+                  422,
+                  data: {
+                    'error': 'Validation failed',
+                    'details': {
+                      'username': [
+                        {
+                          'error': 'ERR_TAKEN',
+                          'description': 'has already been taken',
+                        },
+                        {
+                          'error': 'ERR_FUTURE_CODE',
+                          'description': 'future validation',
+                        },
+                        {'description': 'missing code'},
+                      ],
+                      'future_field': [
+                        {'error': 'ERR_INVALID', 'description': 42},
+                      ],
+                      'invalid': 'not a list',
+                    },
+                  },
+                ),
+              )
+              as MastodonValidationException;
+
+      expect(result.details, hasLength(2));
+      expect(result.details?['username']?.map((detail) => detail.code), [
+        'ERR_TAKEN',
+        'ERR_FUTURE_CODE',
+      ]);
+      expect(result.details?['future_field']?.single.code, 'ERR_INVALID');
+      expect(result.details?['future_field']?.single.description, isNull);
+      expect(result.details, isNot(contains('invalid')));
+    });
+
+    test('422 returns null details for an unrecognized details shape', () {
+      final result =
+          convertDioException(
+                _errorWithStatus(
+                  422,
+                  data: {
+                    'error': 'Validation failed',
+                    'details': {
+                      'username': [
+                        {'description': 'missing code'},
+                        'not an object',
+                      ],
+                    },
+                  },
+                ),
+              )
+              as MastodonValidationException;
+
+      expect(result.serverMessage, 'Validation failed');
+      expect(result.details, isNull);
+    });
+
+    test('422 preserves an explicitly empty details object', () {
+      final result =
+          convertDioException(
+                _errorWithStatus(
+                  422,
+                  data: {
+                    'error': 'Validation failed',
+                    'details': <String, dynamic>{},
+                  },
+                ),
+              )
+              as MastodonValidationException;
+
+      expect(result.details, isEmpty);
+    });
+
+    test('422 preserves the original DioException in raw', () {
+      final original = _errorWithStatus(
+        422,
+        data: {
+          'error': 'Validation failed',
+          'details': {
+            'username': [
+              {'error': 'ERR_BLANK'},
+            ],
+          },
+        },
+      );
+
+      final result =
+          convertDioException(original) as MastodonValidationException;
+
+      expect(result.raw, same(original));
+    });
+
+    test('MastodonAlreadyVotedException remains detail-free', () {
+      const result = MastodonAlreadyVotedException();
+
+      expect(result.serverMessage, 'already voted');
+      expect(result.details, isNull);
     });
 
     test('falls back to the default message when error is not a string', () {


### PR DESCRIPTION
## 概要

- `MastodonValidationErrorDetail` と `MastodonValidationException.details` を追加
- Mastodon標準の422レスポンスとCollectionsの入れ子レスポンスを同じ型へ正規化
- 未知のフィールド名・未知のエラーコードを保持し、不正な要素は安全に除外
- 元の `DioException` の保持と `MastodonAlreadyVotedException` の互換性を維持
- エラー処理ドキュメント全6ロケールとCHANGELOGを更新

## 確認内容

- `dart format --output=none --set-exit-if-changed .`
- `dart analyze --fatal-infos`
- `dart test --exclude-tags e2e`
- `docs/` で `npm run build`

一般的なHTTPエラー本文の扱いは #73 の範囲とし、このPRには含めていません。

Closes #54