### PR TITLE
ミュート一覧で期限情報を取得できるようにする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** `MutesApi.fetch()` now returns
+  `MastodonPage<MastodonMutedAccount>` instead of
+  `MastodonPage<MastodonAccount>`. Access the account through `item.account`;
+  `item.muteExpiresAt` exposes the expiration of a timed mute (issue #49)
 - **Breaking:** `MastodonProfile.hideCollections` and `discoverable` are now
   nullable, preserving Mastodon's distinction between an unset value and
   explicit `false` instead of coercing both to `false` (issue #50)

--- a/docs/docs/api/moderation.md
+++ b/docs/docs/api/moderation.md
@@ -45,8 +45,12 @@ To block or unblock an account, use `client.accounts.block()` and `client.accoun
 
 ```dart
 final page = await client.mutes.fetch(limit: 40);
-for (final account in page.items) {
-  print(account.acct);
+for (final mutedAccount in page.items) {
+  print(mutedAccount.account.acct);
+  final expiresAt = mutedAccount.muteExpiresAt;
+  if (expiresAt != null) {
+    print('Mute expires at $expiresAt');
+  }
 }
 
 // Next page
@@ -54,6 +58,10 @@ if (page.nextMaxId != null) {
   final next = await client.mutes.fetch(maxId: page.nextMaxId);
 }
 ```
+
+Each item is a `MastodonMutedAccount`. Its `account` contains the muted
+account, and `muteExpiresAt` contains the expiration of a timed mute. The
+expiration is `null` for an indefinite mute.
 
 Parameters:
 

--- a/docs/i18n/de/docusaurus-plugin-content-docs/current/api/moderation.md
+++ b/docs/i18n/de/docusaurus-plugin-content-docs/current/api/moderation.md
@@ -45,8 +45,12 @@ Zum Blockieren oder Entsperren eines Accounts `client.accounts.block()` und `cli
 
 ```dart
 final page = await client.mutes.fetch(limit: 40);
-for (final account in page.items) {
-  print(account.acct);
+for (final mutedAccount in page.items) {
+  print(mutedAccount.account.acct);
+  final expiresAt = mutedAccount.muteExpiresAt;
+  if (expiresAt != null) {
+    print('Stummschaltung endet um $expiresAt');
+  }
 }
 
 // Next page
@@ -54,6 +58,11 @@ if (page.nextMaxId != null) {
   final next = await client.mutes.fetch(maxId: page.nextMaxId);
 }
 ```
+
+Jeder Eintrag ist ein `MastodonMutedAccount`. `account` enthält den
+stummgeschalteten Account und `muteExpiresAt` den Ablaufzeitpunkt einer
+zeitlich begrenzten Stummschaltung. Bei einer unbegrenzten Stummschaltung ist
+der Ablaufzeitpunkt `null`.
 
 Parameter:
 

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/api/moderation.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/api/moderation.md
@@ -45,8 +45,12 @@ Pour bloquer ou débloquer un compte, utilisez `client.accounts.block()` et `cli
 
 ```dart
 final page = await client.mutes.fetch(limit: 40);
-for (final account in page.items) {
-  print(account.acct);
+for (final mutedAccount in page.items) {
+  print(mutedAccount.account.acct);
+  final expiresAt = mutedAccount.muteExpiresAt;
+  if (expiresAt != null) {
+    print('Le masquage expire à $expiresAt');
+  }
 }
 
 // Next page
@@ -54,6 +58,10 @@ if (page.nextMaxId != null) {
   final next = await client.mutes.fetch(maxId: page.nextMaxId);
 }
 ```
+
+Chaque élément est un `MastodonMutedAccount`. Son champ `account` contient le
+compte masqué et `muteExpiresAt` la date d'expiration d'un masquage temporaire.
+La date d'expiration vaut `null` pour un masquage permanent.
 
 Paramètres :
 

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/api/moderation.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/api/moderation.md
@@ -45,8 +45,12 @@ if (page.nextMaxId != null) {
 
 ```dart
 final page = await client.mutes.fetch(limit: 40);
-for (final account in page.items) {
-  print(account.acct);
+for (final mutedAccount in page.items) {
+  print(mutedAccount.account.acct);
+  final expiresAt = mutedAccount.muteExpiresAt;
+  if (expiresAt != null) {
+    print('ミュート解除予定: $expiresAt');
+  }
 }
 
 // 次のページ
@@ -54,6 +58,10 @@ if (page.nextMaxId != null) {
   final next = await client.mutes.fetch(maxId: page.nextMaxId);
 }
 ```
+
+各要素は `MastodonMutedAccount` です。`account` にミュート中のアカウント、
+`muteExpiresAt` に時限ミュートの有効期限が入ります。無期限のミュートでは
+有効期限は `null` です。
 
 パラメーター:
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/moderation.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/moderation.md
@@ -45,8 +45,12 @@ if (page.nextMaxId != null) {
 
 ```dart
 final page = await client.mutes.fetch(limit: 40);
-for (final account in page.items) {
-  print(account.acct);
+for (final mutedAccount in page.items) {
+  print(mutedAccount.account.acct);
+  final expiresAt = mutedAccount.muteExpiresAt;
+  if (expiresAt != null) {
+    print('뮤트 만료 시각: $expiresAt');
+  }
 }
 
 // 다음 페이지
@@ -54,6 +58,10 @@ if (page.nextMaxId != null) {
   final next = await client.mutes.fetch(maxId: page.nextMaxId);
 }
 ```
+
+각 항목은 `MastodonMutedAccount`입니다. `account`에는 뮤트된 계정이,
+`muteExpiresAt`에는 기간이 지정된 뮤트의 만료 시각이 들어 있습니다. 무기한
+뮤트인 경우 만료 시각은 `null`입니다.
 
 파라미터:
 

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/api/moderation.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/api/moderation.md
@@ -45,8 +45,12 @@ if (page.nextMaxId != null) {
 
 ```dart
 final page = await client.mutes.fetch(limit: 40);
-for (final account in page.items) {
-  print(account.acct);
+for (final mutedAccount in page.items) {
+  print(mutedAccount.account.acct);
+  final expiresAt = mutedAccount.muteExpiresAt;
+  if (expiresAt != null) {
+    print('静音到期时间：$expiresAt');
+  }
 }
 
 // 下一页
@@ -54,6 +58,9 @@ if (page.nextMaxId != null) {
   final next = await client.mutes.fetch(maxId: page.nextMaxId);
 }
 ```
+
+每个条目都是 `MastodonMutedAccount`。`account` 包含已静音账号，
+`muteExpiresAt` 包含限时静音的到期时间。永久静音时，到期时间为 `null`。
 
 参数：
 

--- a/lib/mastodon_client.dart
+++ b/lib/mastodon_client.dart
@@ -53,6 +53,7 @@ export 'src/models/mastodon_instance_v1.dart';
 export 'src/models/mastodon_list.dart';
 export 'src/models/mastodon_marker.dart';
 export 'src/models/mastodon_media_attachment.dart';
+export 'src/models/mastodon_muted_account.dart';
 export 'src/models/mastodon_notification.dart';
 export 'src/models/mastodon_notification_group.dart';
 export 'src/models/mastodon_notification_policy.dart';

--- a/lib/src/api/mutes_api.dart
+++ b/lib/src/api/mutes_api.dart
@@ -1,6 +1,6 @@
 import '../client/mastodon_http_client.dart';
 import '../internal/link_header_parser.dart';
-import '../models/mastodon_account.dart';
+import '../models/mastodon_muted_account.dart';
 import '../models/mastodon_page.dart';
 import 'accounts_api.dart' show AccountsApi;
 
@@ -21,9 +21,10 @@ class MutesApi {
   /// header and stored in [MastodonPage].
   ///
   /// Use [AccountsApi]'s `mute` / `unmute` to mute or unmute accounts.
+  /// Each item contains the muted account and the expiration of a timed mute.
   ///
   /// Throws a `MastodonException` on failure.
-  Future<MastodonPage<MastodonAccount>> fetch({
+  Future<MastodonPage<MastodonMutedAccount>> fetch({
     int? limit,
     String? maxId,
     String? sinceId,
@@ -39,7 +40,7 @@ class MutesApi {
     final linkHeader = response.headers.map['link']?.join(',');
     final items = (response.data ?? const <dynamic>[])
         .cast<Map<String, dynamic>>()
-        .map(MastodonAccount.fromJson)
+        .map(MastodonMutedAccount.fromJson)
         .toList();
     return MastodonPage(
       items: items,

--- a/lib/src/models/mastodon_muted_account.dart
+++ b/lib/src/models/mastodon_muted_account.dart
@@ -1,0 +1,40 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'json_converters.dart';
+import 'mastodon_account.dart';
+
+part 'mastodon_muted_account.freezed.dart';
+
+/// An account returned by `GET /api/v1/mutes` and its mute expiration.
+@Freezed(toStringOverride: false)
+@JsonSerializable(createFactory: false, createToJson: false)
+class MastodonMutedAccount with _$MastodonMutedAccount {
+  const MastodonMutedAccount({required this.account, this.muteExpiresAt});
+
+  /// Creates a [MastodonMutedAccount] from Mastodon's flat response object.
+  factory MastodonMutedAccount.fromJson(Map<String, dynamic> json) =>
+      MastodonMutedAccount(
+        account: MastodonAccount.fromJson(json),
+        muteExpiresAt: const SafeDateTimeConverter().fromJson(
+          json['mute_expires_at'] as String?,
+        ),
+      );
+
+  /// Serializes to Mastodon's flat muted-account response shape.
+  Map<String, dynamic> toJson() => <String, dynamic>{
+    ...account.toJson(),
+    'mute_expires_at': const SafeDateTimeConverter().toJson(muteExpiresAt),
+  };
+
+  /// The muted account.
+  @override
+  final MastodonAccount account;
+
+  /// When the timed mute expires.
+  ///
+  /// Mastodon only returns `mute_expires_at` from `GET /api/v1/mutes`. This is
+  /// `null` for an indefinite mute and when an older compatible server omits
+  /// the field.
+  @override
+  final DateTime? muteExpiresAt;
+}

--- a/lib/src/models/mastodon_muted_account.freezed.dart
+++ b/lib/src/models/mastodon_muted_account.freezed.dart
@@ -1,0 +1,197 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'mastodon_muted_account.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$MastodonMutedAccount {
+
+ MastodonAccount get account; DateTime? get muteExpiresAt;
+/// Create a copy of MastodonMutedAccount
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MastodonMutedAccountCopyWith<MastodonMutedAccount> get copyWith => _$MastodonMutedAccountCopyWithImpl<MastodonMutedAccount>(this as MastodonMutedAccount, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MastodonMutedAccount&&(identical(other.account, account) || other.account == account)&&(identical(other.muteExpiresAt, muteExpiresAt) || other.muteExpiresAt == muteExpiresAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,account,muteExpiresAt);
+
+
+
+}
+
+/// @nodoc
+abstract mixin class $MastodonMutedAccountCopyWith<$Res>  {
+  factory $MastodonMutedAccountCopyWith(MastodonMutedAccount value, $Res Function(MastodonMutedAccount) _then) = _$MastodonMutedAccountCopyWithImpl;
+@useResult
+$Res call({
+ MastodonAccount account, DateTime? muteExpiresAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$MastodonMutedAccountCopyWithImpl<$Res>
+    implements $MastodonMutedAccountCopyWith<$Res> {
+  _$MastodonMutedAccountCopyWithImpl(this._self, this._then);
+
+  final MastodonMutedAccount _self;
+  final $Res Function(MastodonMutedAccount) _then;
+
+/// Create a copy of MastodonMutedAccount
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? account = null,Object? muteExpiresAt = freezed,}) {
+  return _then(MastodonMutedAccount(
+account: null == account ? _self.account : account // ignore: cast_nullable_to_non_nullable
+as MastodonAccount,muteExpiresAt: freezed == muteExpiresAt ? _self.muteExpiresAt : muteExpiresAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [MastodonMutedAccount].
+extension MastodonMutedAccountPatterns on MastodonMutedAccount {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(){
+final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>() {final _that = this;
+switch (_that) {
+case _:
+  return null;
+
+}
+}
+
+}
+
+// dart format on

--- a/test/api/mutes_api_test.dart
+++ b/test/api/mutes_api_test.dart
@@ -1,0 +1,33 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:mastodon_client/src/api/mutes_api.dart';
+import 'package:test/test.dart';
+
+import '../helpers/recording_http_client.dart';
+
+void main() {
+  test('fetch returns muted accounts with their expiration', () async {
+    final fixture =
+        jsonDecode(File('test/fixtures/mutes.json').readAsStringSync())
+            as List<dynamic>;
+    final http = RecordingHttpClient([fixture]);
+
+    final page = await MutesApi(
+      http,
+    ).fetch(limit: 40, maxId: '100', sinceId: '10');
+
+    expect(page.items, hasLength(1));
+    expect(page.items.single.account.username, 'e2e_admin');
+    expect(
+      page.items.single.muteExpiresAt,
+      DateTime.utc(2026, 9, 7, 15, 47, 31, 818),
+    );
+    expect(http.requests.single.path, '/api/v1/mutes');
+    expect(http.requests.single.queryParameters, {
+      'limit': 40,
+      'max_id': '100',
+      'since_id': '10',
+    });
+  });
+}

--- a/test/fixtures/mutes.json
+++ b/test/fixtures/mutes.json
@@ -1,31 +1,47 @@
 [
     {
-        "id": "116266806698837085",
-        "username": "mutetest",
-        "acct": "mutetest",
+        "id": "117020186420336661",
+        "username": "e2e_admin",
+        "acct": "e2e_admin",
         "display_name": "",
         "locked": false,
         "bot": false,
         "discoverable": null,
         "indexable": false,
         "group": false,
-        "created_at": "2026-03-21T00:00:00.000Z",
+        "created_at": "2026-08-01T00:00:00.000Z",
         "note": "",
-        "url": "https://localhost:3001/@mutetest",
-        "uri": "https://localhost:3001/ap/users/116266806698837085",
-        "avatar": "https://localhost:3001/avatars/original/missing.png",
-        "avatar_static": "https://localhost:3001/avatars/original/missing.png",
-        "header": "https://localhost:3001/headers/original/missing.png",
-        "header_static": "https://localhost:3001/headers/original/missing.png",
+        "url": "https://mastodon.test/@e2e_admin",
+        "uri": "https://mastodon.test/ap/users/117020186420336661",
+        "avatar": "https://mastodon.test/avatars/original/missing.png",
+        "avatar_static": "https://mastodon.test/avatars/original/missing.png",
+        "avatar_description": "",
+        "header": "https://mastodon.test/headers/original/missing.png",
+        "header_static": "https://mastodon.test/headers/original/missing.png",
+        "header_description": "",
         "followers_count": 0,
         "following_count": 0,
-        "statuses_count": 0,
-        "last_status_at": null,
+        "statuses_count": 1,
+        "last_status_at": "2026-08-02",
         "hide_collections": null,
+        "show_media": true,
+        "show_media_replies": true,
+        "show_featured": true,
         "noindex": false,
-        "mute_expires_at": null,
+        "feature_approval": {
+            "automatic": [],
+            "manual": [],
+            "current_user": "denied"
+        },
+        "mute_expires_at": "2026-09-07T15:47:31.818Z",
         "emojis": [],
-        "roles": [],
+        "roles": [
+            {
+                "id": "3",
+                "name": "Owner",
+                "color": ""
+            }
+        ],
         "fields": []
     }
 ]

--- a/test/models/fixture_key_coverage_test.dart
+++ b/test/models/fixture_key_coverage_test.dart
@@ -41,6 +41,7 @@ void main() {
     'poll.json': (json) => MastodonPoll.fromJson(json).toJson(),
     'media_attachment.json': (json) =>
         MastodonMediaAttachment.fromJson(json).toJson(),
+    'mutes.json': (json) => MastodonMutedAccount.fromJson(json).toJson(),
     'collection.json': (json) => MastodonCollection.fromJson(json).toJson(),
     'collection_tagged.json': (json) =>
         MastodonCollection.fromJson(json).toJson(),

--- a/test/models/freezed_model_test.dart
+++ b/test/models/freezed_model_test.dart
@@ -55,7 +55,7 @@ void main() {
         freezedCount += fileFreezedCount;
       }
 
-      expect(jsonSerializableCount, 134);
+      expect(jsonSerializableCount, 135);
       expect(freezedCount, jsonSerializableCount);
     });
 

--- a/test/models/mastodon_muted_account_test.dart
+++ b/test/models/mastodon_muted_account_test.dart
@@ -1,0 +1,49 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:mastodon_client/mastodon_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MastodonMutedAccount.fromJson', () {
+    Map<String, dynamic> loadMutedAccount() {
+      final list =
+          jsonDecode(File('test/fixtures/mutes.json').readAsStringSync())
+              as List<dynamic>;
+      return Map<String, dynamic>.from(list.single as Map<String, dynamic>);
+    }
+
+    test('deserializes a timed mute from the fixture', () {
+      final mutedAccount = MastodonMutedAccount.fromJson(loadMutedAccount());
+
+      expect(mutedAccount.account.username, 'e2e_admin');
+      expect(
+        mutedAccount.muteExpiresAt,
+        DateTime.utc(2026, 9, 7, 15, 47, 31, 818),
+      );
+    });
+
+    test('deserializes an indefinite mute', () {
+      final json = loadMutedAccount()..['mute_expires_at'] = null;
+
+      final mutedAccount = MastodonMutedAccount.fromJson(json);
+
+      expect(mutedAccount.muteExpiresAt, isNull);
+    });
+
+    test('accepts servers that omit mute_expires_at', () {
+      final json = loadMutedAccount()..remove('mute_expires_at');
+
+      expect(MastodonMutedAccount.fromJson(json).muteExpiresAt, isNull);
+    });
+
+    test('serializes to Mastodon\'s flat muted-account shape', () {
+      final mutedAccount = MastodonMutedAccount.fromJson(loadMutedAccount());
+      final json = mutedAccount.toJson();
+
+      expect(json['username'], 'e2e_admin');
+      expect(json, isNot(contains('account')));
+      expect(json, containsPair('mute_expires_at', '2026-09-07T15:47:31.818Z'));
+    });
+  });
+}


### PR DESCRIPTION
## 概要

- `MastodonAccount` とミュート期限を保持する `MastodonMutedAccount` を追加
- `MutesApi.fetch()` の戻り値を `MastodonPage<MastodonMutedAccount>` へ変更
- フラットなMutedAccountレスポンスの変換、値入りfixture、テスト、ドキュメント、CHANGELOGを更新

## 確認

- `dart run build_runner build`
- `dart analyze`
- `dart test`
- `npm run build`（docs）

Closes #49
